### PR TITLE
refactor: Refactor database URL handling in CLI and makefile targets

### DIFF
--- a/makefile
+++ b/makefile
@@ -10,8 +10,7 @@ MIGRATIONS_DIRECTORY = ./trust-db-sqlite/migrations
 DIESEL_CONFIG_FILE = ./trust-db-sqlite/diesel.toml
 
 # Set the path to your Diesel DB URL
-DIESEL_DATABASE_URL = ./trust-db-sqlite/production.db
-CLI_DATABASE_URL = ~/.trust
+CLI_DATABASE_URL = ~/.trust/debug.db
 
 # Set the path to your Diesel CLI executable
 DIESEL_CLI = diesel
@@ -27,7 +26,7 @@ CARGO = cargo
 
 .PHONY: setup
 setup:
-	$(DIESEL_CLI) setup --config-file $(DIESEL_CONFIG_FILE) --database-url $(DIESEL_DATABASE_URL)
+	$(DIESEL_CLI) setup --config-file $(DIESEL_CONFIG_FILE) --database-url $(CLI_DATABASE_URL)
 
 .PHONY: build
 build: setup
@@ -43,13 +42,12 @@ test: setup
 
 .PHONY: clean-db
 clean-db:
-	$(DIESEL_CLI) migration redo --config-file $(DIESEL_CONFIG_FILE) --database-url $(DIESEL_DATABASE_URL)
+	$(DIESEL_CLI) migration redo --config-file $(DIESEL_CONFIG_FILE) --database-url $(CLI_DATABASE_URL)
 
 .PHONY: delete-db
 delete-db:
-	rm -f $(DIESEL_DATABASE_URL)
 	rm -fr $(CLI_DATABASE_URL)
 
 .PHONY: migration
 migration:
-	$(DIESEL_CLI) migration run --config-file $(DIESEL_CONFIG_FILE) --database-url $(DIESEL_DATABASE_URL)
+	$(DIESEL_CLI) migration run --config-file $(DIESEL_CONFIG_FILE) --database-url $(CLI_DATABASE_URL)

--- a/trust-cli/src/dispatcher.rs
+++ b/trust-cli/src/dispatcher.rs
@@ -21,12 +21,21 @@ pub struct ArgDispatcher {
 impl ArgDispatcher {
     pub fn new_sqlite() -> Self {
         create_dir_if_necessary();
-        let db_url = tilde("~/.trust/production.db").to_string();
-        let database = SqliteDatabase::new(&db_url);
+        let database = SqliteDatabase::new(ArgDispatcher::database_url().as_str());
 
         ArgDispatcher {
             trust: TrustFacade::new(Box::new(database), Box::<AlpacaBroker>::default()),
         }
+    }
+
+    #[cfg(debug_assertions)]
+    fn database_url() -> String {
+        tilde("~/.trust/debug.db").to_string()
+    }
+
+    #[cfg(not(debug_assertions))]
+    fn database_url() -> String {
+        tilde("~/.trust/production.db").to_string()
     }
 
     pub fn dispatch(mut self, matches: ArgMatches) {


### PR DESCRIPTION
Refactor conditional URL creation for database and update database URL for CLI usage.

- Use `ArgDispatcher::database_url()` instead of tilde expansion in `SqliteDatabase::new`
- Update CLI database URL to `~/.trust/debug.db` in `makefile`
- Use CLI database URL in `setup` and `clean-db` targets
- Remove command to remove Diesel database URL in `delete-db` target
