### PR TITLE
refactor: Refactor functions for modifying stop and target orders

### DIFF
--- a/alpaca-broker/src/lib.rs
+++ b/alpaca-broker/src/lib.rs
@@ -1,5 +1,6 @@
 use model::{Account, Broker, BrokerLog, Environment, Order, OrderIds, Status, Trade};
 use std::error::Error;
+use uuid::Uuid;
 
 mod cancel_trade;
 mod close_trade;
@@ -50,7 +51,7 @@ impl Broker for AlpacaBroker {
         trade: &Trade,
         account: &Account,
         new_stop_price: rust_decimal::Decimal,
-    ) -> Result<BrokerLog, Box<dyn Error>> {
+    ) -> Result<Uuid, Box<dyn Error>> {
         modify_stop::modify(trade, account, new_stop_price)
     }
 
@@ -59,7 +60,7 @@ impl Broker for AlpacaBroker {
         trade: &Trade,
         account: &Account,
         new_target_price: rust_decimal::Decimal,
-    ) -> Result<BrokerLog, Box<dyn Error>> {
+    ) -> Result<Uuid, Box<dyn Error>> {
         modify_target::modify(trade, account, new_target_price)
     }
 }

--- a/alpaca-broker/src/modify_stop.rs
+++ b/alpaca-broker/src/modify_stop.rs
@@ -1,7 +1,6 @@
 use crate::keys;
 use apca::api::v2::order::{ChangeReqInit, Id, Order, Patch};
 use apca::Client;
-use model::BrokerLog;
 use model::{Account, Trade};
 use num_decimal::Num;
 use rust_decimal::Decimal;
@@ -9,11 +8,7 @@ use std::{error::Error, str::FromStr};
 use tokio::runtime::Runtime;
 use uuid::Uuid;
 
-pub fn modify(
-    trade: &Trade,
-    account: &Account,
-    price: Decimal,
-) -> Result<BrokerLog, Box<dyn Error>> {
+pub fn modify(trade: &Trade, account: &Account, price: Decimal) -> Result<Uuid, Box<dyn Error>> {
     assert!(trade.account_id == account.id); // Verify that the trade is for the account
 
     let api_info = keys::read_api_key(&account.environment, account)?;
@@ -26,14 +21,9 @@ pub fn modify(
         price,
     ))?;
 
-    // 3. Log the Alpaca order.
-    let log = BrokerLog {
-        trade_id: trade.id,
-        log: serde_json::to_string(&alpaca_order)?,
-        ..Default::default()
-    };
+    // TODO LOG
 
-    Ok(log)
+    Ok(alpaca_order.id.0)
 }
 
 async fn submit(client: &Client, order_id: Uuid, price: Decimal) -> Result<Order, Box<dyn Error>> {

--- a/alpaca-broker/src/modify_target.rs
+++ b/alpaca-broker/src/modify_target.rs
@@ -1,7 +1,6 @@
 use crate::keys;
 use apca::api::v2::order::{ChangeReqInit, Id, Order, Patch};
 use apca::Client;
-use model::BrokerLog;
 use model::{Account, Trade};
 use num_decimal::Num;
 use rust_decimal::Decimal;
@@ -9,11 +8,7 @@ use std::{error::Error, str::FromStr};
 use tokio::runtime::Runtime;
 use uuid::Uuid;
 
-pub fn modify(
-    trade: &Trade,
-    account: &Account,
-    price: Decimal,
-) -> Result<BrokerLog, Box<dyn Error>> {
+pub fn modify(trade: &Trade, account: &Account, price: Decimal) -> Result<Uuid, Box<dyn Error>> {
     assert!(trade.account_id == account.id); // Verify that the trade is for the account
 
     let api_info = keys::read_api_key(&account.environment, account)?;
@@ -26,14 +21,9 @@ pub fn modify(
         price,
     ))?;
 
-    // 3. Log the Alpaca order.
-    let log = BrokerLog {
-        trade_id: trade.id,
-        log: serde_json::to_string(&alpaca_order)?,
-        ..Default::default()
-    };
+    // TODO LOG
 
-    Ok(log)
+    Ok(alpaca_order.id.0)
 }
 
 async fn submit(client: &Client, order_id: Uuid, price: Decimal) -> Result<Order, Box<dyn Error>> {

--- a/cli/src/dialogs/modify_dialog.rs
+++ b/cli/src/dialogs/modify_dialog.rs
@@ -1,12 +1,12 @@
 use crate::dialogs::AccountSearchDialog;
-use crate::views::{LogView, OrderView, TradeBalanceView, TradeView};
+use crate::views::{OrderView, TradeBalanceView, TradeView};
 use core::TrustFacade;
 use dialoguer::{theme::ColorfulTheme, FuzzySelect, Input};
-use model::{Account, BrokerLog, Status, Trade};
+use model::{Account, Status, Trade};
 use rust_decimal::Decimal;
 use std::error::Error;
 
-type ModifyDialogBuilderResult = Option<Result<(Trade, BrokerLog), Box<dyn Error>>>;
+type ModifyDialogBuilderResult = Option<Result<Trade, Box<dyn Error>>>;
 
 pub struct ModifyDialogBuilder {
     account: Option<Account>,
@@ -40,7 +40,7 @@ impl ModifyDialogBuilder {
             .expect("No stop price found, did you forget to call stop_price?");
 
         match trust.modify_stop(&trade, &account, stop_price) {
-            Ok((trade, log)) => self.result = Some(Ok((trade, log))),
+            Ok(trade) => self.result = Some(Ok(trade)),
             Err(error) => self.result = Some(Err(error)),
         }
         self
@@ -61,7 +61,7 @@ impl ModifyDialogBuilder {
             .expect("No target price found, did you forget to call stop_price?");
 
         match trust.modify_target(&trade, &account, target_price) {
-            Ok((trade, log)) => self.result = Some(Ok((trade, log))),
+            Ok(trade) => self.result = Some(Ok(trade)),
             Err(error) => self.result = Some(Err(error)),
         }
         self
@@ -72,7 +72,7 @@ impl ModifyDialogBuilder {
             .result
             .expect("No result found, did you forget to call search?")
         {
-            Ok((trade, log)) => {
+            Ok(trade) => {
                 println!("Trade updated:");
                 TradeView::display(&trade, &self.account.unwrap().name);
 
@@ -83,8 +83,6 @@ impl ModifyDialogBuilder {
 
                 println!("Target:");
                 OrderView::display(trade.target);
-
-                LogView::display(&log);
             }
             Err(error) => println!("Error submitting trade: {:?}", error),
         }

--- a/cli/tests/integration_test_account.rs
+++ b/cli/tests/integration_test_account.rs
@@ -8,6 +8,7 @@ use model::{
 use rust_decimal::Decimal;
 use rust_decimal_macros::dec;
 use std::error::Error;
+use uuid::Uuid;
 
 fn create_trust() -> TrustFacade {
     let db = SqliteDatabase::new_in_memory();
@@ -229,7 +230,7 @@ impl Broker for MockBroker {
         trade: &Trade,
         account: &Account,
         new_stop_price: Decimal,
-    ) -> Result<BrokerLog, Box<dyn Error>> {
+    ) -> Result<Uuid, Box<dyn Error>> {
         unimplemented!(
             "Modify stop: {:?} {:?} {:?}",
             trade,
@@ -243,7 +244,7 @@ impl Broker for MockBroker {
         trade: &Trade,
         account: &Account,
         new_target_price: rust_decimal::Decimal,
-    ) -> Result<BrokerLog, Box<dyn Error>> {
+    ) -> Result<Uuid, Box<dyn Error>> {
         unimplemented!(
             "Modify target: {:?} {:?} {:?}",
             trade,

--- a/cli/tests/integration_test_cancel_trade.rs
+++ b/cli/tests/integration_test_cancel_trade.rs
@@ -8,6 +8,7 @@ use model::{
 use rust_decimal::Decimal;
 use rust_decimal_macros::dec;
 use std::error::Error;
+use uuid::Uuid;
 
 fn create_trust() -> TrustFacade {
     let db = SqliteDatabase::new_in_memory();
@@ -134,7 +135,7 @@ impl Broker for MockBroker {
         trade: &Trade,
         account: &Account,
         new_stop_price: Decimal,
-    ) -> Result<BrokerLog, Box<dyn Error>> {
+    ) -> Result<Uuid, Box<dyn Error>> {
         unimplemented!(
             "Modify stop: {:?} {:?} {:?}",
             trade,
@@ -148,7 +149,7 @@ impl Broker for MockBroker {
         trade: &Trade,
         account: &Account,
         new_target_price: rust_decimal::Decimal,
-    ) -> Result<BrokerLog, Box<dyn Error>> {
+    ) -> Result<Uuid, Box<dyn Error>> {
         unimplemented!(
             "Modify target: {:?} {:?} {:?}",
             trade,

--- a/cli/tests/integration_test_trade.rs
+++ b/cli/tests/integration_test_trade.rs
@@ -510,7 +510,7 @@ fn test_trade_modify_stop_long() {
         .clone();
 
     // 7. Modify stop
-    let (_, log) = trust
+    trust
         .modify_stop(&trade, &account, dec!(39))
         .expect("Failed to modify stop");
 
@@ -524,7 +524,10 @@ fn test_trade_modify_stop_long() {
     // Assert Trade Overview
     assert_eq!(trade.status, Status::Filled); // The trade is still filled, but the stop was changed
     assert_eq!(trade.safety_stop.unit_price, dec!(39));
-    assert_eq!(log.trade_id, trade.id);
+    assert_eq!(
+        trade.safety_stop.broker_order_id.unwrap(),
+        Uuid::parse_str("7654f70e-3b42-4014-a9ac-5a7101989aad").unwrap()
+    );
 }
 
 #[test]
@@ -548,7 +551,7 @@ fn test_trade_modify_target() {
         .clone();
 
     // 7. Modify stop
-    let (_, log) = trust
+    trust
         .modify_target(&trade, &account, dec!(100.1))
         .expect("Failed to modify stop");
 
@@ -562,7 +565,10 @@ fn test_trade_modify_target() {
     // Assert Trade Overview
     assert_eq!(trade.status, Status::Filled); // The trade is still filled, but the stop was changed
     assert_eq!(trade.target.unit_price, dec!(100.1));
-    assert_eq!(log.trade_id, trade.id);
+    assert_eq!(
+        trade.target.broker_order_id.unwrap(),
+        Uuid::parse_str("5654f70e-3b42-4014-a9ac-5a7101989aad").unwrap()
+    );
 }
 
 struct BrokerResponse;
@@ -831,16 +837,12 @@ impl Broker for MockBroker {
         trade: &Trade,
         account: &Account,
         new_stop_price: Decimal,
-    ) -> Result<BrokerLog, Box<dyn Error>> {
+    ) -> Result<Uuid, Box<dyn Error>> {
         assert_eq!(trade.account_id, account.id);
         assert_eq!(trade.safety_stop.unit_price, dec!(38));
         assert_eq!(new_stop_price, dec!(39));
 
-        Ok(BrokerLog {
-            trade_id: trade.id,
-            log: "".to_string(),
-            ..Default::default()
-        })
+        Ok(Uuid::parse_str("7654f70e-3b42-4014-a9ac-5a7101989aad").unwrap())
     }
 
     fn modify_target(
@@ -848,15 +850,11 @@ impl Broker for MockBroker {
         trade: &Trade,
         account: &Account,
         new_target_price: rust_decimal::Decimal,
-    ) -> Result<BrokerLog, Box<dyn Error>> {
+    ) -> Result<Uuid, Box<dyn Error>> {
         assert_eq!(trade.account_id, account.id);
         assert_eq!(trade.target.unit_price, dec!(50));
         assert_eq!(new_target_price, dec!(100.1));
 
-        Ok(BrokerLog {
-            trade_id: trade.id,
-            log: "".to_string(),
-            ..Default::default()
-        })
+        Ok(Uuid::parse_str("5654f70e-3b42-4014-a9ac-5a7101989aad").unwrap())
     }
 }

--- a/core/src/commands/order.rs
+++ b/core/src/commands/order.rs
@@ -108,9 +108,10 @@ pub fn record_timestamp_target(
 pub fn modify(
     order: &Order,
     new_price: Decimal,
+    broker_id: Uuid,
     write_database: &mut dyn OrderWrite,
 ) -> Result<Order, Box<dyn std::error::Error>> {
-    let stop = write_database.update_price(order, new_price)?;
+    let stop = write_database.update_price(order, new_price, broker_id)?;
     Ok(stop)
 }
 

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -241,7 +241,7 @@ impl TrustFacade {
         trade: &Trade,
         account: &Account,
         new_stop_price: Decimal,
-    ) -> Result<(Trade, BrokerLog), Box<dyn std::error::Error>> {
+    ) -> Result<Trade, Box<dyn std::error::Error>> {
         commands::trade::modify_stop(
             trade,
             account,
@@ -256,7 +256,7 @@ impl TrustFacade {
         trade: &Trade,
         account: &Account,
         new_target_price: Decimal,
-    ) -> Result<(Trade, BrokerLog), Box<dyn std::error::Error>> {
+    ) -> Result<Trade, Box<dyn std::error::Error>> {
         commands::trade::modify_target(
             trade,
             account,

--- a/db-sqlite/src/database.rs
+++ b/db-sqlite/src/database.rs
@@ -178,8 +178,18 @@ impl OrderWrite for SqliteDatabase {
     fn closing_of(&mut self, order: &Order) -> Result<Order, Box<dyn Error>> {
         WorkerOrder::update_closed_at(&mut self.connection.lock().unwrap(), order)
     }
-    fn update_price(&mut self, order: &Order, price: Decimal) -> Result<Order, Box<dyn Error>> {
-        WorkerOrder::update_price(&mut self.connection.lock().unwrap(), order, price)
+    fn update_price(
+        &mut self,
+        order: &Order,
+        price: Decimal,
+        new_broker_id: Uuid,
+    ) -> Result<Order, Box<dyn Error>> {
+        WorkerOrder::update_price(
+            &mut self.connection.lock().unwrap(),
+            order,
+            price,
+            new_broker_id,
+        )
     }
 }
 

--- a/db-sqlite/src/workers/worker_order.rs
+++ b/db-sqlite/src/workers/worker_order.rs
@@ -85,6 +85,7 @@ impl WorkerOrder {
         connection: &mut SqliteConnection,
         order: &Order,
         new_price: Decimal,
+        new_broker_id: Uuid,
     ) -> Result<Order, Box<dyn Error>> {
         let now: NaiveDateTime = Utc::now().naive_utc();
         diesel::update(orders::table)
@@ -92,6 +93,7 @@ impl WorkerOrder {
             .set((
                 orders::updated_at.eq(now),
                 orders::unit_price.eq(new_price.to_string()),
+                orders::broker_order_id.eq(new_broker_id.to_string()),
             ))
             .execute(connection)?;
 

--- a/model/src/broker.rs
+++ b/model/src/broker.rs
@@ -69,12 +69,12 @@ pub trait Broker {
         trade: &Trade,
         account: &Account,
         new_stop_price: Decimal,
-    ) -> Result<BrokerLog, Box<dyn Error>>;
+    ) -> Result<Uuid, Box<dyn Error>>;
 
     fn modify_target(
         &self,
         trade: &Trade,
         account: &Account,
         new_price: Decimal,
-    ) -> Result<BrokerLog, Box<dyn Error>>;
+    ) -> Result<Uuid, Box<dyn Error>>;
 }

--- a/model/src/database.rs
+++ b/model/src/database.rs
@@ -102,7 +102,12 @@ pub trait OrderWrite {
     fn filling_of(&mut self, order: &Order) -> Result<Order, Box<dyn Error>>;
     fn closing_of(&mut self, order: &Order) -> Result<Order, Box<dyn Error>>;
     fn update(&mut self, order: &Order) -> Result<Order, Box<dyn Error>>;
-    fn update_price(&mut self, order: &Order, price: Decimal) -> Result<Order, Box<dyn Error>>;
+    fn update_price(
+        &mut self,
+        order: &Order,
+        price: Decimal,
+        broker_id: Uuid,
+    ) -> Result<Order, Box<dyn Error>>;
 }
 
 pub trait ReadTransactionDB {


### PR DESCRIPTION
- Change return types of `modify_stop` and `modify_target` functions in multiple files from `BrokerLog` to `Uuid`
- Update implementations of `modify_stop` and `modify_target` functions to use the new return types and assign new broker IDs
- Modify `modify_stop` and `modify_target` functions to pass new broker ID when modifying orders
- Modify `update_price` function in database.rs and WorkerOrder struct to include a `broker_id` parameter
- Modify `modify` function in modify_stop.rs to return UUID of modified order instead of BrokerLog
- Refactor `build_stop` and `build_target` methods in modify_dialog.rs to only return modified trade and remove log
- Remove unused imports and variables in modify_target.rs and lib.rs
- Modify various tests to update broker_order_id assertion and change return types of `modify_stop` and `modify_target` to return UUIDs
