### PR TITLE
Add broker-neutral routing and IBKR support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -20,6 +20,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "aho-corasick"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "alpaca-broker"
 version = "0.3.5"
 dependencies = [
@@ -111,10 +120,10 @@ dependencies = [
  "async-trait",
  "chrono",
  "futures",
- "http",
+ "http 1.4.0",
  "http-body-util",
  "http-endpoint",
- "hyper",
+ "hyper 1.8.1",
  "hyper-tls",
  "hyper-util",
  "num-decimal",
@@ -151,6 +160,58 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
 
 [[package]]
+name = "ascii-canvas"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8824ecca2e851cec16968d54a01dd372ef8f95b244fb84b84e70128be347c3c6"
+dependencies = [
+ "term",
+]
+
+[[package]]
+name = "assert-json-diff"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47e4f2b81832e72834d7518d8487a0396a28cc408186a2e8854c0f98011faf12"
+dependencies = [
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "async-attributes"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a3203e79f4dd9bdda415ed03cf14dae5a2bf775c683a00f94e9cd1faf0f596e5"
+dependencies = [
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "async-channel"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81953c529336010edd6d8e358f886d9581267795c61b19475b71314bffa46d35"
+dependencies = [
+ "concurrent-queue",
+ "event-listener 2.5.3",
+ "futures-core",
+]
+
+[[package]]
+name = "async-channel"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "924ed96dd52d1b75e9c1a3e6275715fd320f5f9439fb5a4a11fa51f4221158d2"
+dependencies = [
+ "concurrent-queue",
+ "event-listener-strategy",
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
 name = "async-compression"
 version = "0.4.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -161,6 +222,143 @@ dependencies = [
  "futures-io",
  "pin-project-lite",
 ]
+
+[[package]]
+name = "async-executor"
+version = "1.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c96bf972d85afc50bf5ab8fe2d54d1586b4e0b46c97c50a0c9e71e2f7bcd812a"
+dependencies = [
+ "async-task",
+ "concurrent-queue",
+ "fastrand",
+ "futures-lite",
+ "pin-project-lite",
+ "slab",
+]
+
+[[package]]
+name = "async-global-executor"
+version = "2.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05b1b633a2115cd122d73b955eadd9916c18c8f510ec9cd1686404c60ad1c29c"
+dependencies = [
+ "async-channel 2.5.0",
+ "async-executor",
+ "async-io",
+ "async-lock",
+ "blocking",
+ "futures-lite",
+ "once_cell",
+]
+
+[[package]]
+name = "async-io"
+version = "2.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "456b8a8feb6f42d237746d4b3e9a178494627745c3c56c6ea55d92ba50d026fc"
+dependencies = [
+ "autocfg",
+ "cfg-if",
+ "concurrent-queue",
+ "futures-io",
+ "futures-lite",
+ "parking",
+ "polling",
+ "rustix",
+ "slab",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "async-lock"
+version = "3.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "290f7f2596bd5b78a9fec8088ccd89180d7f9f55b94b0576823bbbdc72ee8311"
+dependencies = [
+ "event-listener 5.4.1",
+ "event-listener-strategy",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-object-pool"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "333c456b97c3f2d50604e8b2624253b7f787208cb72eb75e64b0ad11b221652c"
+dependencies = [
+ "async-std",
+]
+
+[[package]]
+name = "async-process"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc50921ec0055cdd8a16de48773bfeec5c972598674347252c0399676be7da75"
+dependencies = [
+ "async-channel 2.5.0",
+ "async-io",
+ "async-lock",
+ "async-signal",
+ "async-task",
+ "blocking",
+ "cfg-if",
+ "event-listener 5.4.1",
+ "futures-lite",
+ "rustix",
+]
+
+[[package]]
+name = "async-signal"
+version = "0.2.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43c070bbf59cd3570b6b2dd54cd772527c7c3620fce8be898406dd3ed6adc64c"
+dependencies = [
+ "async-io",
+ "async-lock",
+ "atomic-waker",
+ "cfg-if",
+ "futures-core",
+ "futures-io",
+ "rustix",
+ "signal-hook-registry",
+ "slab",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "async-std"
+version = "1.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c8e079a4ab67ae52b7403632e4618815d6db36d2a010cfe41b02c1b1578f93b"
+dependencies = [
+ "async-attributes",
+ "async-channel 1.9.0",
+ "async-global-executor",
+ "async-io",
+ "async-lock",
+ "async-process",
+ "crossbeam-utils",
+ "futures-channel",
+ "futures-core",
+ "futures-io",
+ "futures-lite",
+ "gloo-timers",
+ "kv-log-macro",
+ "log",
+ "memchr",
+ "once_cell",
+ "pin-project-lite",
+ "pin-utils",
+ "slab",
+ "wasm-bindgen-futures",
+]
+
+[[package]]
+name = "async-task"
+version = "4.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b75356056920673b02621b35afd0f7dda9306d03c79a30f5c56c44cf256e3de"
 
 [[package]]
 name = "async-trait"
@@ -186,10 +384,42 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
+name = "base64"
+version = "0.21.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
+
+[[package]]
+name = "base64"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+
+[[package]]
 name = "base64ct"
 version = "1.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
+
+[[package]]
+name = "basic-cookies"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67bd8fd42c16bdb08688243dc5f0cc117a3ca9efeeaba3a345a18a6159ad96f7"
+dependencies = [
+ "lalrpop",
+ "lalrpop-util",
+ "regex",
+]
+
+[[package]]
+name = "bit-set"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0700ddab506f33b20a03b13996eccd309a48e5ff77d0d95926aa0210fb4e95f1"
+dependencies = [
+ "bit-vec 0.6.3",
+]
 
 [[package]]
 name = "bit-set"
@@ -197,8 +427,14 @@ version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08807e080ed7f9d5433fa9b275196cfc35414f66a0c79d864dc51a0d825231a3"
 dependencies = [
- "bit-vec",
+ "bit-vec 0.8.0",
 ]
+
+[[package]]
+name = "bit-vec"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "349f9b6a179ed607305526ca489b34ad0a41aed5f7980fa90eb03160b69598fb"
 
 [[package]]
 name = "bit-vec"
@@ -240,6 +476,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
 dependencies = [
  "generic-array",
+]
+
+[[package]]
+name = "blocking"
+version = "1.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e83f8d02be6967315521be875afa792a316e28d57b5a2d401897e2a7921b7f21"
+dependencies = [
+ "async-channel 2.5.0",
+ "async-task",
+ "futures-io",
+ "futures-lite",
+ "piper",
 ]
 
 [[package]]
@@ -437,6 +686,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75984efb6ed102a0d42db99afb6c1948f0380d1d91808d5529916e6c08b49d8d"
 
 [[package]]
+name = "concurrent-queue"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ca0197aee26d1ae37445ee532fefce43251d24cc7c166799f4d46817f1d3973"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "console"
 version = "0.16.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -447,6 +705,35 @@ dependencies = [
  "once_cell",
  "unicode-width",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "cookie"
+version = "0.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ddef33a339a91ea89fb53151bd0a4689cfce27055c291dfa69945475d22c747"
+dependencies = [
+ "percent-encoding",
+ "time",
+ "version_check",
+]
+
+[[package]]
+name = "cookie_store"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15b2c103cf610ec6cae3da84a766285b42fd16aad564758459e6ecf128c75206"
+dependencies = [
+ "cookie",
+ "document-features",
+ "idna",
+ "log",
+ "publicsuffix",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "time",
+ "url",
 ]
 
 [[package]]
@@ -519,6 +806,18 @@ checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
 dependencies = [
  "cfg-if",
 ]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+
+[[package]]
+name = "crunchy"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
 name = "crypto-common"
@@ -699,6 +998,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "dirs-next"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b98cf8ebf19c3d1b223e151f99a4f9f0690dca41414773390fc824184ac833e1"
+dependencies = [
+ "cfg-if",
+ "dirs-sys-next",
+]
+
+[[package]]
 name = "dirs-sys"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -706,8 +1015,19 @@ checksum = "e01a3366d27ee9890022452ee61b2b63a67e6f13f58900b651ff5665f0bb1fab"
 dependencies = [
  "libc",
  "option-ext",
- "redox_users",
+ "redox_users 0.5.2",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "dirs-sys-next"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ebda144c4fe02d1f7ea1a7d9641b6fc6b580adcfa024ae48797ecdeb6825b4d"
+dependencies = [
+ "libc",
+ "redox_users 0.4.6",
+ "winapi",
 ]
 
 [[package]]
@@ -719,6 +1039,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.114",
+]
+
+[[package]]
+name = "document-features"
+version = "0.2.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4b8a88685455ed29a21542a33abd9cb6510b6b129abadabdcef0f4c55bc8f61"
+dependencies = [
+ "litrs",
 ]
 
 [[package]]
@@ -748,6 +1077,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 
 [[package]]
+name = "ena"
+version = "0.14.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eabffdaee24bd1bf95c5ef7cec31260444317e72ea56c4c91750e8b7ee58d5f1"
+dependencies = [
+ "log",
+]
+
+[[package]]
 name = "encode_unicode"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -770,6 +1108,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "event-listener"
+version = "2.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0206175f82b8d6bf6652ff7d71a1e27fd2e4efde587fd368662814d6ec1d9ce0"
+
+[[package]]
+name = "event-listener"
+version = "5.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e13b66accf52311f30a0db42147dadea9850cb48cd070028831ae5f5d4b856ab"
+dependencies = [
+ "concurrent-queue",
+ "parking",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "event-listener-strategy"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8be9f3dfaaffdae2972880079a491a1a8bb7cbed0b8dd7a347f668b4150a3b93"
+dependencies = [
+ "event-listener 5.4.1",
+ "pin-project-lite",
+]
+
+[[package]]
 name = "fastrand"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -780,6 +1145,12 @@ name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+
+[[package]]
+name = "fixedbitset"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
 
 [[package]]
 name = "flate2"
@@ -876,6 +1247,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9e5c1b78ca4aae1ac06c48a526a655760685149f0d465d21f37abfe57ce075c6"
 
 [[package]]
+name = "futures-lite"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f78e10609fe0e0b3f4157ffab1876319b5b0db102a2c60dc4626306dc46b44ad"
+dependencies = [
+ "fastrand",
+ "futures-core",
+ "futures-io",
+ "parking",
+ "pin-project-lite",
+]
+
+[[package]]
 name = "futures-macro"
 version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -942,8 +1326,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "wasi",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -953,9 +1339,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "r-efi",
  "wasip2",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -970,6 +1358,18 @@ dependencies = [
  "rand_core 0.10.0",
  "wasip2",
  "wasip3",
+]
+
+[[package]]
+name = "gloo-timers"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbb143cf96099802033e0d4f4963b19fd2e0b728bcf076cd9cf7f6634f092994"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "js-sys",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -1006,6 +1406,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
+name = "hermit-abi"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
+
+[[package]]
+name = "http"
+version = "0.2.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "601cbb57e577e2f5ef5be8e7b83f0f63994f25aa94d673e54a92d5c516d101f1"
+dependencies = [
+ "bytes",
+ "fnv",
+ "itoa",
+]
+
+[[package]]
 name = "http"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1017,12 +1434,23 @@ dependencies = [
 
 [[package]]
 name = "http-body"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ceab25649e9960c0311ea418d17bee82c0dcec1bd053b5f9a66e265a693bed2"
+dependencies = [
+ "bytes",
+ "http 0.2.12",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "http-body"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
 dependencies = [
  "bytes",
- "http",
+ "http 1.4.0",
 ]
 
 [[package]]
@@ -1033,8 +1461,8 @@ checksum = "b021d93e26becf5dc7e1b75b1bed1fd93124b374ceb73f43d4d4eafec896a64a"
 dependencies = [
  "bytes",
  "futures-core",
- "http",
- "http-body",
+ "http 1.4.0",
+ "http-body 1.0.1",
  "pin-project-lite",
 ]
 
@@ -1044,7 +1472,7 @@ version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eb1f1452e05dacda1597bf23d0336aa128ee1603cdf1bf539384768c5d9b8a46"
 dependencies = [
- "http",
+ "http 1.4.0",
 ]
 
 [[package]]
@@ -1052,6 +1480,63 @@ name = "httparse"
 version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
+
+[[package]]
+name = "httpdate"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
+
+[[package]]
+name = "httpmock"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08ec9586ee0910472dec1a1f0f8acf52f0fdde93aea74d70d4a3107b4be0fd5b"
+dependencies = [
+ "assert-json-diff",
+ "async-object-pool",
+ "async-std",
+ "async-trait",
+ "base64 0.21.7",
+ "basic-cookies",
+ "crossbeam-utils",
+ "form_urlencoded",
+ "futures-util",
+ "hyper 0.14.32",
+ "lazy_static",
+ "levenshtein",
+ "log",
+ "regex",
+ "serde",
+ "serde_json",
+ "serde_regex",
+ "similar",
+ "tokio",
+ "url",
+]
+
+[[package]]
+name = "hyper"
+version = "0.14.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41dfc780fdec9373c01bae43289ea34c972e40ee3c9f6b3c8801a35f35586ce7"
+dependencies = [
+ "bytes",
+ "futures-channel",
+ "futures-core",
+ "futures-util",
+ "http 0.2.12",
+ "http-body 0.4.6",
+ "httparse",
+ "httpdate",
+ "itoa",
+ "pin-project-lite",
+ "socket2 0.5.10",
+ "tokio",
+ "tower-service",
+ "tracing",
+ "want",
+]
 
 [[package]]
 name = "hyper"
@@ -1063,8 +1548,8 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-core",
- "http",
- "http-body",
+ "http 1.4.0",
+ "http-body 1.0.1",
  "httparse",
  "itoa",
  "pin-project-lite",
@@ -1075,6 +1560,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "hyper-rustls"
+version = "0.27.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3c93eb611681b207e1fe55d5a71ecf91572ec8a6705cdb6857f7d8d5242cf58"
+dependencies = [
+ "http 1.4.0",
+ "hyper 1.8.1",
+ "hyper-util",
+ "rustls",
+ "rustls-pki-types",
+ "tokio",
+ "tokio-rustls",
+ "tower-service",
+ "webpki-roots",
+]
+
+[[package]]
 name = "hyper-tls"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1082,7 +1584,7 @@ checksum = "70206fc6890eaca9fde8a0bf71caa2ddfc9fe045ac9e5c70df101a7dbde866e0"
 dependencies = [
  "bytes",
  "http-body-util",
- "hyper",
+ "hyper 1.8.1",
  "hyper-util",
  "native-tls",
  "tokio",
@@ -1096,15 +1598,18 @@ version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0"
 dependencies = [
+ "base64 0.22.1",
  "bytes",
  "futures-channel",
  "futures-util",
- "http",
- "http-body",
- "hyper",
+ "http 1.4.0",
+ "http-body 1.0.1",
+ "hyper 1.8.1",
+ "ipnet",
  "libc",
+ "percent-encoding",
  "pin-project-lite",
- "socket2",
+ "socket2 0.6.2",
  "tokio",
  "tower-service",
  "tracing",
@@ -1132,6 +1637,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
 dependencies = [
  "cc",
+]
+
+[[package]]
+name = "ibkr-broker"
+version = "0.3.5"
+dependencies = [
+ "chrono",
+ "httpmock",
+ "keyring",
+ "reqwest",
+ "rust_decimal",
+ "rust_decimal_macros",
+ "serde_json",
+ "trust-model",
 ]
 
 [[package]]
@@ -1261,10 +1780,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "ipnet"
+version = "2.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
+
+[[package]]
+name = "iri-string"
+version = "0.7.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c91338f0783edbd6195decb37bae672fd3b165faffb89bf7b9e6942f8b1a731a"
+dependencies = [
+ "memchr",
+ "serde",
+]
+
+[[package]]
 name = "is_terminal_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
+
+[[package]]
+name = "itertools"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1c173a5686ce8bfa551b3563d0c2170bf24ca44da99c7ca4bfdab5418c3fe57"
+dependencies = [
+ "either",
+]
 
 [[package]]
 name = "itoa"
@@ -1298,10 +1842,62 @@ dependencies = [
 ]
 
 [[package]]
+name = "kv-log-macro"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0de8b303297635ad57c9f5059fd9cee7a47f8e8daa09df0fcd07dd39fb22977f"
+dependencies = [
+ "log",
+]
+
+[[package]]
+name = "lalrpop"
+version = "0.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55cb077ad656299f160924eb2912aa147d7339ea7d69e1b5517326fdcec3c1ca"
+dependencies = [
+ "ascii-canvas",
+ "bit-set 0.5.3",
+ "ena",
+ "itertools",
+ "lalrpop-util",
+ "petgraph",
+ "pico-args",
+ "regex",
+ "regex-syntax",
+ "string_cache",
+ "term",
+ "tiny-keccak",
+ "unicode-xid",
+ "walkdir",
+]
+
+[[package]]
+name = "lalrpop-util"
+version = "0.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "507460a910eb7b32ee961886ff48539633b788a36b65692b95f225b844c82553"
+dependencies = [
+ "regex-automata",
+]
+
+[[package]]
+name = "lazy_static"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
+
+[[package]]
 name = "leb128fmt"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
+
+[[package]]
+name = "levenshtein"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db13adb97ab515a3691f56e4dbab09283d0b86cb45abd991d8634a9d6f501760"
 
 [[package]]
 name = "libc"
@@ -1351,10 +1947,34 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6373607a59f0be73a39b6fe456b8192fcc3585f602af20751600e974dd455e77"
 
 [[package]]
+name = "litrs"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11d3d7f243d5c5a8b9bb5d6dd2b1602c0cb0b9db1621bafc7ed66e35ff9fe092"
+
+[[package]]
+name = "lock_api"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "224399e74b87b5f3557511d98dff8b14089b3dadafcab6bb93eab67d3aace965"
+dependencies = [
+ "scopeguard",
+]
+
+[[package]]
 name = "log"
 version = "0.4.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
+dependencies = [
+ "value-bag",
+]
+
+[[package]]
+name = "lru-slab"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
 name = "memchr"
@@ -1420,6 +2040,12 @@ dependencies = [
  "security-framework-sys",
  "tempfile",
 ]
+
+[[package]]
+name = "new_debug_unreachable"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "650eef8c711430f1a879fdd01d4745a7deea475becfb90269c06775983bbf086"
 
 [[package]]
 name = "num-bigint"
@@ -1552,6 +2178,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "parking"
+version = "2.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f38d5652c16fde515bb1ecef450ab0f6a219d619a7274976324d5e377f7dceba"
+
+[[package]]
+name = "parking_lot"
+version = "0.12.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93857453250e3077bd71ff98b6a65ea6621a19bb0f559a85248955ac12c45a1a"
+dependencies = [
+ "lock_api",
+ "parking_lot_core",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.9.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "redox_syscall",
+ "smallvec",
+ "windows-link",
+]
+
+[[package]]
 name = "password-hash"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1567,6 +2222,31 @@ name = "percent-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
+
+[[package]]
+name = "petgraph"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4c5cc86750666a3ed20bdaf5ca2a0344f9c67674cae0515bec2da16fbaa47db"
+dependencies = [
+ "fixedbitset",
+ "indexmap",
+]
+
+[[package]]
+name = "phf_shared"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67eabc2ef2a60eb7faa00097bd1ffdb5bd28e62bf39990626a582201b7a754e5"
+dependencies = [
+ "siphasher",
+]
+
+[[package]]
+name = "pico-args"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5be167a7af36ee22fe3115051bc51f6e6c7054c9348e28deb4f49bd6f705a315"
 
 [[package]]
 name = "pin-project"
@@ -1601,10 +2281,35 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
+name = "piper"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c835479a4443ded371d6c535cbfd8d31ad92c5d23ae9770a61bc155e4992a3c1"
+dependencies = [
+ "atomic-waker",
+ "fastrand",
+ "futures-io",
+]
+
+[[package]]
 name = "pkg-config"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
+
+[[package]]
+name = "polling"
+version = "3.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d0e4f59085d47d8241c88ead0f274e8a0cb551f3625263c05eb8dd897c34218"
+dependencies = [
+ "cfg-if",
+ "concurrent-queue",
+ "hermit-abi",
+ "pin-project-lite",
+ "rustix",
+ "windows-sys 0.61.2",
+]
 
 [[package]]
 name = "potential_utf"
@@ -1629,6 +2334,12 @@ checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
 dependencies = [
  "zerocopy",
 ]
+
+[[package]]
+name = "precomputed-hash"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "925383efa346730478fb4838dbe9137d2a47675ad789c546d150a6e1dd4ab31c"
 
 [[package]]
 name = "prettyplease"
@@ -1686,8 +2397,8 @@ version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37566cb3fdacef14c0737f9546df7cfeadbfbc9fef10991038bf5015d0c80532"
 dependencies = [
- "bit-set",
- "bit-vec",
+ "bit-set 0.8.0",
+ "bit-vec 0.8.0",
  "bitflags",
  "num-traits",
  "rand 0.9.2",
@@ -1698,6 +2409,12 @@ dependencies = [
  "tempfile",
  "unarray",
 ]
+
+[[package]]
+name = "psl-types"
+version = "2.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33cb294fe86a74cbcf50d4445b37da762029549ebeea341421c7c70370f86cac"
 
 [[package]]
 name = "ptr_meta"
@@ -1720,10 +2437,75 @@ dependencies = [
 ]
 
 [[package]]
+name = "publicsuffix"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f42ea446cab60335f76979ec15e12619a2165b5ae2c12166bef27d283a9fadf"
+dependencies = [
+ "idna",
+ "psl-types",
+]
+
+[[package]]
 name = "quick-error"
 version = "1.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
+
+[[package]]
+name = "quinn"
+version = "0.11.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e20a958963c291dc322d98411f541009df2ced7b5a4f2bd52337638cfccf20"
+dependencies = [
+ "bytes",
+ "cfg_aliases",
+ "pin-project-lite",
+ "quinn-proto",
+ "quinn-udp",
+ "rustc-hash",
+ "rustls",
+ "socket2 0.6.2",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-proto"
+version = "0.11.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
+dependencies = [
+ "bytes",
+ "getrandom 0.3.4",
+ "lru-slab",
+ "rand 0.9.2",
+ "ring",
+ "rustc-hash",
+ "rustls",
+ "rustls-pki-types",
+ "slab",
+ "thiserror 2.0.18",
+ "tinyvec",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-udp"
+version = "0.5.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "addec6a0dcad8a8d96a771f815f0eaf55f9d1805756410b39f5fa81332574cbd"
+dependencies = [
+ "cfg_aliases",
+ "libc",
+ "once_cell",
+ "socket2 0.6.2",
+ "tracing",
+ "windows-sys 0.60.2",
+]
 
 [[package]]
 name = "quote"
@@ -1832,6 +2614,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "redox_syscall"
+version = "0.5.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
+dependencies = [
+ "bitflags",
+]
+
+[[package]]
+name = "redox_users"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba009ff324d1fc1b900bd1fdb31564febe58a8ccc8a6fdbb93b543d33b13ca43"
+dependencies = [
+ "getrandom 0.2.17",
+ "libredox",
+ "thiserror 1.0.69",
+]
+
+[[package]]
 name = "redox_users"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1840,6 +2642,29 @@ dependencies = [
  "getrandom 0.2.17",
  "libredox",
  "thiserror 2.0.18",
+]
+
+[[package]]
+name = "regex"
+version = "1.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e10754a14b9137dd7b1e3e5b0493cc9171fdd105e0ab477f51b72e7f3ac0e276"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
 ]
 
 [[package]]
@@ -1855,6 +2680,62 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "71fe3824f5629716b1589be05dacd749f6aa084c87e00e016714a8cdfccc997c"
 dependencies = [
  "bytecheck",
+]
+
+[[package]]
+name = "reqwest"
+version = "0.12.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
+dependencies = [
+ "base64 0.22.1",
+ "bytes",
+ "cookie",
+ "cookie_store",
+ "futures-channel",
+ "futures-core",
+ "futures-util",
+ "http 1.4.0",
+ "http-body 1.0.1",
+ "http-body-util",
+ "hyper 1.8.1",
+ "hyper-rustls",
+ "hyper-util",
+ "js-sys",
+ "log",
+ "percent-encoding",
+ "pin-project-lite",
+ "quinn",
+ "rustls",
+ "rustls-pki-types",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "sync_wrapper",
+ "tokio",
+ "tokio-rustls",
+ "tower",
+ "tower-http",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "webpki-roots",
+]
+
+[[package]]
+name = "ring"
+version = "0.17.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "getrandom 0.2.17",
+ "libc",
+ "untrusted",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1923,6 +2804,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustc-hash"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
+
+[[package]]
 name = "rustix"
 version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1933,6 +2820,41 @@ dependencies = [
  "libc",
  "linux-raw-sys",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "rustls"
+version = "0.23.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "758025cb5fccfd3bc2fd74708fd4682be41d99e5dff73c377c0646c6012c73a4"
+dependencies = [
+ "once_cell",
+ "ring",
+ "rustls-pki-types",
+ "rustls-webpki",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-pki-types"
+version = "1.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be040f8b0a225e40375822a563fa9524378b9d63112f53e19ffff34df5d33fdd"
+dependencies = [
+ "web-time",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-webpki"
+version = "0.103.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7df23109aa6c1567d1c575b9952556388da57401e4ace1d15f79eedad0d8f53"
+dependencies = [
+ "ring",
+ "rustls-pki-types",
+ "untrusted",
 ]
 
 [[package]]
@@ -1960,6 +2882,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
+]
+
+[[package]]
 name = "schannel"
 version = "0.1.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1967,6 +2898,12 @@ checksum = "891d81b926048e76efe18581bf793546b4c0eaf8448d72be8de2bbee5fd166e1"
 dependencies = [
  "windows-sys 0.61.2",
 ]
+
+[[package]]
+name = "scopeguard"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "seahash"
@@ -2060,6 +2997,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_regex"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8136f1a4ea815d7eac4101cfd0b16dc0cb5e1fe1b8609dfd728058656b7badf"
+dependencies = [
+ "regex",
+ "serde",
+]
+
+[[package]]
 name = "serde_spanned"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2133,6 +3080,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
+name = "signal-hook-registry"
+version = "1.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4db69cba1110affc0e9f7bcd48bbf87b3f4fc7c61fc9155afd4c469eb3d6c1b"
+dependencies = [
+ "errno",
+ "libc",
+]
+
+[[package]]
 name = "simd-adler32"
 version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2145,6 +3102,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
 
 [[package]]
+name = "similar"
+version = "2.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbbb5d9659141646ae647b42fe094daf6c6192d1620870b449d9557f748b2daa"
+
+[[package]]
+name = "siphasher"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2aa850e253778c88a04c3d7323b043aeda9d3e30d5971937c1855769763678e"
+
+[[package]]
 name = "slab"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2155,6 +3124,16 @@ name = "smallvec"
 version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
+
+[[package]]
+name = "socket2"
+version = "0.5.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e22376abed350d73dd1cd119b57ffccad95b4e585a7cda43e286245ce23c0678"
+dependencies = [
+ "libc",
+ "windows-sys 0.52.0",
+]
 
 [[package]]
 name = "socket2"
@@ -2183,6 +3162,18 @@ name = "stable_deref_trait"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
+
+[[package]]
+name = "string_cache"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf776ba3fa74f83bf4b63c3dcbbf82173db2632ed8452cb2d891d33f459de70f"
+dependencies = [
+ "new_debug_unreachable",
+ "parking_lot",
+ "phf_shared",
+ "precomputed-hash",
+]
 
 [[package]]
 name = "strsim"
@@ -2216,6 +3207,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
+]
+
+[[package]]
+name = "sync_wrapper"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263"
+dependencies = [
+ "futures-core",
 ]
 
 [[package]]
@@ -2270,6 +3270,17 @@ dependencies = [
  "once_cell",
  "rustix",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "term"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c59df8ac95d96ff9bede18eb7300b0fda5e5d8d90960e76f8e14ae765eedbf1f"
+dependencies = [
+ "dirs-next",
+ "rustversion",
+ "winapi",
 ]
 
 [[package]]
@@ -2362,6 +3373,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "tiny-keccak"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c9d3793400a45f954c52e73d068316d76b6f4e36977e3fcebb13a2721e80237"
+dependencies = [
+ "crunchy",
+]
+
+[[package]]
 name = "tinystr"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2396,7 +3416,8 @@ dependencies = [
  "libc",
  "mio",
  "pin-project-lite",
- "socket2",
+ "signal-hook-registry",
+ "socket2 0.6.2",
  "tokio-macros",
  "windows-sys 0.61.2",
 ]
@@ -2419,6 +3440,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2"
 dependencies = [
  "native-tls",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-rustls"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
+dependencies = [
+ "rustls",
  "tokio",
 ]
 
@@ -2480,6 +3511,45 @@ dependencies = [
 ]
 
 [[package]]
+name = "tower"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebe5ef63511595f1344e2d5cfa636d973292adc0eec1f0ad45fae9f0851ab1d4"
+dependencies = [
+ "futures-core",
+ "futures-util",
+ "pin-project-lite",
+ "sync_wrapper",
+ "tokio",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
+name = "tower-http"
+version = "0.6.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4e6559d53cc268e5031cd8429d05415bc4cb4aefc4aa5d6cc35fbf5b924a1f8"
+dependencies = [
+ "bitflags",
+ "bytes",
+ "futures-util",
+ "http 1.4.0",
+ "http-body 1.0.1",
+ "iri-string",
+ "pin-project-lite",
+ "tower",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
+name = "tower-layer"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "121c2a6cda46980bb0fcd1647ffaf6cd3fc79a013de288782836f6df9c48780e"
+
+[[package]]
 name = "tower-service"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2537,6 +3607,7 @@ dependencies = [
  "core",
  "db-sqlite",
  "dialoguer",
+ "ibkr-broker",
  "keyring",
  "rust_decimal",
  "rust_decimal_macros",
@@ -2571,7 +3642,7 @@ checksum = "4793cb5e56680ecbb1d843515b23b6de9a75eb04b66643e256a396d43be33c13"
 dependencies = [
  "bytes",
  "data-encoding",
- "http",
+ "http 1.4.0",
  "httparse",
  "log",
  "native-tls",
@@ -2611,6 +3682,12 @@ name = "unicode-xid"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
+
+[[package]]
+name = "untrusted"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
 name = "url"
@@ -2656,6 +3733,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "value-bag"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ba6f5989077681266825251a52748b8c1d8a4ad098cc37e440103d0ea717fc0"
+
+[[package]]
 name = "vcpkg"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2674,6 +3757,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ac3b126d3914f9849036f826e054cbabdc8519970b8998ddaf3b5bd3c65f11"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "walkdir"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
+dependencies = [
+ "same-file",
+ "winapi-util",
 ]
 
 [[package]]
@@ -2720,6 +3813,20 @@ dependencies = [
  "rustversion",
  "wasm-bindgen-macro",
  "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-futures"
+version = "0.4.58"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70a6e77fd0ae8029c9ea0063f87c46fde723e7d887703d74ad2616d792e51e6f"
+dependencies = [
+ "cfg-if",
+ "futures-util",
+ "js-sys",
+ "once_cell",
+ "wasm-bindgen",
+ "web-sys",
 ]
 
 [[package]]
@@ -2789,6 +3896,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "web-sys"
+version = "0.3.85"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "312e32e551d92129218ea9a2452120f4aabc03529ef03e4d0d82fb2780608598"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "web-time"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22cfaf3c063993ff62e73cb4311efde4db1efb31ab78a3e5c457939ad5cc0bed"
+dependencies = [
+ "rustls-pki-types",
+]
+
+[[package]]
 name = "websocket-util"
 version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2799,6 +3935,37 @@ dependencies = [
  "tokio-tungstenite",
  "tracing",
 ]
+
+[[package]]
+name = "winapi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
+dependencies = [
+ "winapi-i686-pc-windows-gnu",
+ "winapi-x86_64-pc-windows-gnu",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-util"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
+dependencies = [
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-core"
@@ -2857,6 +4024,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
 dependencies = [
  "windows-link",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets 0.52.6",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -20,15 +20,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "aho-corasick"
-version = "1.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301"
-dependencies = [
- "memchr",
-]
-
-[[package]]
 name = "alpaca-broker"
 version = "0.3.5"
 dependencies = [
@@ -120,10 +111,10 @@ dependencies = [
  "async-trait",
  "chrono",
  "futures",
- "http 1.4.0",
+ "http",
  "http-body-util",
  "http-endpoint",
- "hyper 1.8.1",
+ "hyper",
  "hyper-tls",
  "hyper-util",
  "num-decimal",
@@ -160,58 +151,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
 
 [[package]]
-name = "ascii-canvas"
-version = "3.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8824ecca2e851cec16968d54a01dd372ef8f95b244fb84b84e70128be347c3c6"
-dependencies = [
- "term",
-]
-
-[[package]]
-name = "assert-json-diff"
-version = "2.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47e4f2b81832e72834d7518d8487a0396a28cc408186a2e8854c0f98011faf12"
-dependencies = [
- "serde",
- "serde_json",
-]
-
-[[package]]
-name = "async-attributes"
-version = "1.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a3203e79f4dd9bdda415ed03cf14dae5a2bf775c683a00f94e9cd1faf0f596e5"
-dependencies = [
- "quote",
- "syn 1.0.109",
-]
-
-[[package]]
-name = "async-channel"
-version = "1.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81953c529336010edd6d8e358f886d9581267795c61b19475b71314bffa46d35"
-dependencies = [
- "concurrent-queue",
- "event-listener 2.5.3",
- "futures-core",
-]
-
-[[package]]
-name = "async-channel"
-version = "2.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "924ed96dd52d1b75e9c1a3e6275715fd320f5f9439fb5a4a11fa51f4221158d2"
-dependencies = [
- "concurrent-queue",
- "event-listener-strategy",
- "futures-core",
- "pin-project-lite",
-]
-
-[[package]]
 name = "async-compression"
 version = "0.4.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -222,143 +161,6 @@ dependencies = [
  "futures-io",
  "pin-project-lite",
 ]
-
-[[package]]
-name = "async-executor"
-version = "1.14.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c96bf972d85afc50bf5ab8fe2d54d1586b4e0b46c97c50a0c9e71e2f7bcd812a"
-dependencies = [
- "async-task",
- "concurrent-queue",
- "fastrand",
- "futures-lite",
- "pin-project-lite",
- "slab",
-]
-
-[[package]]
-name = "async-global-executor"
-version = "2.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05b1b633a2115cd122d73b955eadd9916c18c8f510ec9cd1686404c60ad1c29c"
-dependencies = [
- "async-channel 2.5.0",
- "async-executor",
- "async-io",
- "async-lock",
- "blocking",
- "futures-lite",
- "once_cell",
-]
-
-[[package]]
-name = "async-io"
-version = "2.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "456b8a8feb6f42d237746d4b3e9a178494627745c3c56c6ea55d92ba50d026fc"
-dependencies = [
- "autocfg",
- "cfg-if",
- "concurrent-queue",
- "futures-io",
- "futures-lite",
- "parking",
- "polling",
- "rustix",
- "slab",
- "windows-sys 0.61.2",
-]
-
-[[package]]
-name = "async-lock"
-version = "3.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "290f7f2596bd5b78a9fec8088ccd89180d7f9f55b94b0576823bbbdc72ee8311"
-dependencies = [
- "event-listener 5.4.1",
- "event-listener-strategy",
- "pin-project-lite",
-]
-
-[[package]]
-name = "async-object-pool"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "333c456b97c3f2d50604e8b2624253b7f787208cb72eb75e64b0ad11b221652c"
-dependencies = [
- "async-std",
-]
-
-[[package]]
-name = "async-process"
-version = "2.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc50921ec0055cdd8a16de48773bfeec5c972598674347252c0399676be7da75"
-dependencies = [
- "async-channel 2.5.0",
- "async-io",
- "async-lock",
- "async-signal",
- "async-task",
- "blocking",
- "cfg-if",
- "event-listener 5.4.1",
- "futures-lite",
- "rustix",
-]
-
-[[package]]
-name = "async-signal"
-version = "0.2.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43c070bbf59cd3570b6b2dd54cd772527c7c3620fce8be898406dd3ed6adc64c"
-dependencies = [
- "async-io",
- "async-lock",
- "atomic-waker",
- "cfg-if",
- "futures-core",
- "futures-io",
- "rustix",
- "signal-hook-registry",
- "slab",
- "windows-sys 0.61.2",
-]
-
-[[package]]
-name = "async-std"
-version = "1.13.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c8e079a4ab67ae52b7403632e4618815d6db36d2a010cfe41b02c1b1578f93b"
-dependencies = [
- "async-attributes",
- "async-channel 1.9.0",
- "async-global-executor",
- "async-io",
- "async-lock",
- "async-process",
- "crossbeam-utils",
- "futures-channel",
- "futures-core",
- "futures-io",
- "futures-lite",
- "gloo-timers",
- "kv-log-macro",
- "log",
- "memchr",
- "once_cell",
- "pin-project-lite",
- "pin-utils",
- "slab",
- "wasm-bindgen-futures",
-]
-
-[[package]]
-name = "async-task"
-version = "4.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b75356056920673b02621b35afd0f7dda9306d03c79a30f5c56c44cf256e3de"
 
 [[package]]
 name = "async-trait"
@@ -385,12 +187,6 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "base64"
-version = "0.21.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
-
-[[package]]
-name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
@@ -402,39 +198,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
 
 [[package]]
-name = "basic-cookies"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67bd8fd42c16bdb08688243dc5f0cc117a3ca9efeeaba3a345a18a6159ad96f7"
-dependencies = [
- "lalrpop",
- "lalrpop-util",
- "regex",
-]
-
-[[package]]
-name = "bit-set"
-version = "0.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0700ddab506f33b20a03b13996eccd309a48e5ff77d0d95926aa0210fb4e95f1"
-dependencies = [
- "bit-vec 0.6.3",
-]
-
-[[package]]
 name = "bit-set"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08807e080ed7f9d5433fa9b275196cfc35414f66a0c79d864dc51a0d825231a3"
 dependencies = [
- "bit-vec 0.8.0",
+ "bit-vec",
 ]
-
-[[package]]
-name = "bit-vec"
-version = "0.6.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "349f9b6a179ed607305526ca489b34ad0a41aed5f7980fa90eb03160b69598fb"
 
 [[package]]
 name = "bit-vec"
@@ -476,19 +246,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
 dependencies = [
  "generic-array",
-]
-
-[[package]]
-name = "blocking"
-version = "1.6.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e83f8d02be6967315521be875afa792a316e28d57b5a2d401897e2a7921b7f21"
-dependencies = [
- "async-channel 2.5.0",
- "async-task",
- "futures-io",
- "futures-lite",
- "piper",
 ]
 
 [[package]]
@@ -686,15 +443,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75984efb6ed102a0d42db99afb6c1948f0380d1d91808d5529916e6c08b49d8d"
 
 [[package]]
-name = "concurrent-queue"
-version = "2.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ca0197aee26d1ae37445ee532fefce43251d24cc7c166799f4d46817f1d3973"
-dependencies = [
- "crossbeam-utils",
-]
-
-[[package]]
 name = "console"
 version = "0.16.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -806,18 +554,6 @@ checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
 dependencies = [
  "cfg-if",
 ]
-
-[[package]]
-name = "crossbeam-utils"
-version = "0.8.21"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
-
-[[package]]
-name = "crunchy"
-version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
 name = "crypto-common"
@@ -998,16 +734,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "dirs-next"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b98cf8ebf19c3d1b223e151f99a4f9f0690dca41414773390fc824184ac833e1"
-dependencies = [
- "cfg-if",
- "dirs-sys-next",
-]
-
-[[package]]
 name = "dirs-sys"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1015,19 +741,8 @@ checksum = "e01a3366d27ee9890022452ee61b2b63a67e6f13f58900b651ff5665f0bb1fab"
 dependencies = [
  "libc",
  "option-ext",
- "redox_users 0.5.2",
+ "redox_users",
  "windows-sys 0.61.2",
-]
-
-[[package]]
-name = "dirs-sys-next"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ebda144c4fe02d1f7ea1a7d9641b6fc6b580adcfa024ae48797ecdeb6825b4d"
-dependencies = [
- "libc",
- "redox_users 0.4.6",
- "winapi",
 ]
 
 [[package]]
@@ -1077,15 +792,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 
 [[package]]
-name = "ena"
-version = "0.14.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eabffdaee24bd1bf95c5ef7cec31260444317e72ea56c4c91750e8b7ee58d5f1"
-dependencies = [
- "log",
-]
-
-[[package]]
 name = "encode_unicode"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1108,33 +814,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "event-listener"
-version = "2.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0206175f82b8d6bf6652ff7d71a1e27fd2e4efde587fd368662814d6ec1d9ce0"
-
-[[package]]
-name = "event-listener"
-version = "5.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e13b66accf52311f30a0db42147dadea9850cb48cd070028831ae5f5d4b856ab"
-dependencies = [
- "concurrent-queue",
- "parking",
- "pin-project-lite",
-]
-
-[[package]]
-name = "event-listener-strategy"
-version = "0.5.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8be9f3dfaaffdae2972880079a491a1a8bb7cbed0b8dd7a347f668b4150a3b93"
-dependencies = [
- "event-listener 5.4.1",
- "pin-project-lite",
-]
-
-[[package]]
 name = "fastrand"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1145,12 +824,6 @@ name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
-
-[[package]]
-name = "fixedbitset"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
 
 [[package]]
 name = "flate2"
@@ -1247,19 +920,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9e5c1b78ca4aae1ac06c48a526a655760685149f0d465d21f37abfe57ce075c6"
 
 [[package]]
-name = "futures-lite"
-version = "2.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f78e10609fe0e0b3f4157ffab1876319b5b0db102a2c60dc4626306dc46b44ad"
-dependencies = [
- "fastrand",
- "futures-core",
- "futures-io",
- "parking",
- "pin-project-lite",
-]
-
-[[package]]
 name = "futures-macro"
 version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1326,10 +986,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
 dependencies = [
  "cfg-if",
- "js-sys",
  "libc",
  "wasi",
- "wasm-bindgen",
 ]
 
 [[package]]
@@ -1339,11 +997,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
 dependencies = [
  "cfg-if",
- "js-sys",
  "libc",
  "r-efi",
  "wasip2",
- "wasm-bindgen",
 ]
 
 [[package]]
@@ -1358,18 +1014,6 @@ dependencies = [
  "rand_core 0.10.0",
  "wasip2",
  "wasip3",
-]
-
-[[package]]
-name = "gloo-timers"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbb143cf96099802033e0d4f4963b19fd2e0b728bcf076cd9cf7f6634f092994"
-dependencies = [
- "futures-channel",
- "futures-core",
- "js-sys",
- "wasm-bindgen",
 ]
 
 [[package]]
@@ -1406,23 +1050,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
-name = "hermit-abi"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
-
-[[package]]
-name = "http"
-version = "0.2.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "601cbb57e577e2f5ef5be8e7b83f0f63994f25aa94d673e54a92d5c516d101f1"
-dependencies = [
- "bytes",
- "fnv",
- "itoa",
-]
-
-[[package]]
 name = "http"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1434,23 +1061,12 @@ dependencies = [
 
 [[package]]
 name = "http-body"
-version = "0.4.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ceab25649e9960c0311ea418d17bee82c0dcec1bd053b5f9a66e265a693bed2"
-dependencies = [
- "bytes",
- "http 0.2.12",
- "pin-project-lite",
-]
-
-[[package]]
-name = "http-body"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
 dependencies = [
  "bytes",
- "http 1.4.0",
+ "http",
 ]
 
 [[package]]
@@ -1461,8 +1077,8 @@ checksum = "b021d93e26becf5dc7e1b75b1bed1fd93124b374ceb73f43d4d4eafec896a64a"
 dependencies = [
  "bytes",
  "futures-core",
- "http 1.4.0",
- "http-body 1.0.1",
+ "http",
+ "http-body",
  "pin-project-lite",
 ]
 
@@ -1472,7 +1088,7 @@ version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eb1f1452e05dacda1597bf23d0336aa128ee1603cdf1bf539384768c5d9b8a46"
 dependencies = [
- "http 1.4.0",
+ "http",
 ]
 
 [[package]]
@@ -1480,63 +1096,6 @@ name = "httparse"
 version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
-
-[[package]]
-name = "httpdate"
-version = "1.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
-
-[[package]]
-name = "httpmock"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08ec9586ee0910472dec1a1f0f8acf52f0fdde93aea74d70d4a3107b4be0fd5b"
-dependencies = [
- "assert-json-diff",
- "async-object-pool",
- "async-std",
- "async-trait",
- "base64 0.21.7",
- "basic-cookies",
- "crossbeam-utils",
- "form_urlencoded",
- "futures-util",
- "hyper 0.14.32",
- "lazy_static",
- "levenshtein",
- "log",
- "regex",
- "serde",
- "serde_json",
- "serde_regex",
- "similar",
- "tokio",
- "url",
-]
-
-[[package]]
-name = "hyper"
-version = "0.14.32"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41dfc780fdec9373c01bae43289ea34c972e40ee3c9f6b3c8801a35f35586ce7"
-dependencies = [
- "bytes",
- "futures-channel",
- "futures-core",
- "futures-util",
- "http 0.2.12",
- "http-body 0.4.6",
- "httparse",
- "httpdate",
- "itoa",
- "pin-project-lite",
- "socket2 0.5.10",
- "tokio",
- "tower-service",
- "tracing",
- "want",
-]
 
 [[package]]
 name = "hyper"
@@ -1548,8 +1107,8 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-core",
- "http 1.4.0",
- "http-body 1.0.1",
+ "http",
+ "http-body",
  "httparse",
  "itoa",
  "pin-project-lite",
@@ -1560,23 +1119,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "hyper-rustls"
-version = "0.27.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3c93eb611681b207e1fe55d5a71ecf91572ec8a6705cdb6857f7d8d5242cf58"
-dependencies = [
- "http 1.4.0",
- "hyper 1.8.1",
- "hyper-util",
- "rustls",
- "rustls-pki-types",
- "tokio",
- "tokio-rustls",
- "tower-service",
- "webpki-roots",
-]
-
-[[package]]
 name = "hyper-tls"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1584,7 +1126,7 @@ checksum = "70206fc6890eaca9fde8a0bf71caa2ddfc9fe045ac9e5c70df101a7dbde866e0"
 dependencies = [
  "bytes",
  "http-body-util",
- "hyper 1.8.1",
+ "hyper",
  "hyper-util",
  "native-tls",
  "tokio",
@@ -1598,18 +1140,18 @@ version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0"
 dependencies = [
- "base64 0.22.1",
+ "base64",
  "bytes",
  "futures-channel",
  "futures-util",
- "http 1.4.0",
- "http-body 1.0.1",
- "hyper 1.8.1",
+ "http",
+ "http-body",
+ "hyper",
  "ipnet",
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.6.2",
+ "socket2",
  "tokio",
  "tower-service",
  "tracing",
@@ -1644,7 +1186,6 @@ name = "ibkr-broker"
 version = "0.3.5"
 dependencies = [
  "chrono",
- "httpmock",
  "keyring",
  "reqwest",
  "rust_decimal",
@@ -1802,15 +1343,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
 
 [[package]]
-name = "itertools"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1c173a5686ce8bfa551b3563d0c2170bf24ca44da99c7ca4bfdab5418c3fe57"
-dependencies = [
- "either",
-]
-
-[[package]]
 name = "itoa"
 version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1842,62 +1374,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "kv-log-macro"
-version = "1.0.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0de8b303297635ad57c9f5059fd9cee7a47f8e8daa09df0fcd07dd39fb22977f"
-dependencies = [
- "log",
-]
-
-[[package]]
-name = "lalrpop"
-version = "0.20.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55cb077ad656299f160924eb2912aa147d7339ea7d69e1b5517326fdcec3c1ca"
-dependencies = [
- "ascii-canvas",
- "bit-set 0.5.3",
- "ena",
- "itertools",
- "lalrpop-util",
- "petgraph",
- "pico-args",
- "regex",
- "regex-syntax",
- "string_cache",
- "term",
- "tiny-keccak",
- "unicode-xid",
- "walkdir",
-]
-
-[[package]]
-name = "lalrpop-util"
-version = "0.20.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "507460a910eb7b32ee961886ff48539633b788a36b65692b95f225b844c82553"
-dependencies = [
- "regex-automata",
-]
-
-[[package]]
-name = "lazy_static"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
-
-[[package]]
 name = "leb128fmt"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
-
-[[package]]
-name = "levenshtein"
-version = "1.0.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db13adb97ab515a3691f56e4dbab09283d0b86cb45abd991d8634a9d6f501760"
 
 [[package]]
 name = "libc"
@@ -1953,28 +1433,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "11d3d7f243d5c5a8b9bb5d6dd2b1602c0cb0b9db1621bafc7ed66e35ff9fe092"
 
 [[package]]
-name = "lock_api"
-version = "0.4.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "224399e74b87b5f3557511d98dff8b14089b3dadafcab6bb93eab67d3aace965"
-dependencies = [
- "scopeguard",
-]
-
-[[package]]
 name = "log"
 version = "0.4.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
-dependencies = [
- "value-bag",
-]
-
-[[package]]
-name = "lru-slab"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
 name = "memchr"
@@ -2040,12 +1502,6 @@ dependencies = [
  "security-framework-sys",
  "tempfile",
 ]
-
-[[package]]
-name = "new_debug_unreachable"
-version = "1.0.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "650eef8c711430f1a879fdd01d4745a7deea475becfb90269c06775983bbf086"
 
 [[package]]
 name = "num-bigint"
@@ -2178,35 +1634,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "parking"
-version = "2.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f38d5652c16fde515bb1ecef450ab0f6a219d619a7274976324d5e377f7dceba"
-
-[[package]]
-name = "parking_lot"
-version = "0.12.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93857453250e3077bd71ff98b6a65ea6621a19bb0f559a85248955ac12c45a1a"
-dependencies = [
- "lock_api",
- "parking_lot_core",
-]
-
-[[package]]
-name = "parking_lot_core"
-version = "0.9.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
-dependencies = [
- "cfg-if",
- "libc",
- "redox_syscall",
- "smallvec",
- "windows-link",
-]
-
-[[package]]
 name = "password-hash"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2222,31 +1649,6 @@ name = "percent-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
-
-[[package]]
-name = "petgraph"
-version = "0.6.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4c5cc86750666a3ed20bdaf5ca2a0344f9c67674cae0515bec2da16fbaa47db"
-dependencies = [
- "fixedbitset",
- "indexmap",
-]
-
-[[package]]
-name = "phf_shared"
-version = "0.11.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67eabc2ef2a60eb7faa00097bd1ffdb5bd28e62bf39990626a582201b7a754e5"
-dependencies = [
- "siphasher",
-]
-
-[[package]]
-name = "pico-args"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5be167a7af36ee22fe3115051bc51f6e6c7054c9348e28deb4f49bd6f705a315"
 
 [[package]]
 name = "pin-project"
@@ -2281,35 +1683,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
-name = "piper"
-version = "0.2.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c835479a4443ded371d6c535cbfd8d31ad92c5d23ae9770a61bc155e4992a3c1"
-dependencies = [
- "atomic-waker",
- "fastrand",
- "futures-io",
-]
-
-[[package]]
 name = "pkg-config"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
-
-[[package]]
-name = "polling"
-version = "3.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d0e4f59085d47d8241c88ead0f274e8a0cb551f3625263c05eb8dd897c34218"
-dependencies = [
- "cfg-if",
- "concurrent-queue",
- "hermit-abi",
- "pin-project-lite",
- "rustix",
- "windows-sys 0.61.2",
-]
 
 [[package]]
 name = "potential_utf"
@@ -2334,12 +1711,6 @@ checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
 dependencies = [
  "zerocopy",
 ]
-
-[[package]]
-name = "precomputed-hash"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "925383efa346730478fb4838dbe9137d2a47675ad789c546d150a6e1dd4ab31c"
 
 [[package]]
 name = "prettyplease"
@@ -2397,8 +1768,8 @@ version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37566cb3fdacef14c0737f9546df7cfeadbfbc9fef10991038bf5015d0c80532"
 dependencies = [
- "bit-set 0.8.0",
- "bit-vec 0.8.0",
+ "bit-set",
+ "bit-vec",
  "bitflags",
  "num-traits",
  "rand 0.9.2",
@@ -2451,61 +1822,6 @@ name = "quick-error"
 version = "1.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
-
-[[package]]
-name = "quinn"
-version = "0.11.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9e20a958963c291dc322d98411f541009df2ced7b5a4f2bd52337638cfccf20"
-dependencies = [
- "bytes",
- "cfg_aliases",
- "pin-project-lite",
- "quinn-proto",
- "quinn-udp",
- "rustc-hash",
- "rustls",
- "socket2 0.6.2",
- "thiserror 2.0.18",
- "tokio",
- "tracing",
- "web-time",
-]
-
-[[package]]
-name = "quinn-proto"
-version = "0.11.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
-dependencies = [
- "bytes",
- "getrandom 0.3.4",
- "lru-slab",
- "rand 0.9.2",
- "ring",
- "rustc-hash",
- "rustls",
- "rustls-pki-types",
- "slab",
- "thiserror 2.0.18",
- "tinyvec",
- "tracing",
- "web-time",
-]
-
-[[package]]
-name = "quinn-udp"
-version = "0.5.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "addec6a0dcad8a8d96a771f815f0eaf55f9d1805756410b39f5fa81332574cbd"
-dependencies = [
- "cfg_aliases",
- "libc",
- "once_cell",
- "socket2 0.6.2",
- "tracing",
- "windows-sys 0.60.2",
-]
 
 [[package]]
 name = "quote"
@@ -2614,26 +1930,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "redox_syscall"
-version = "0.5.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
-dependencies = [
- "bitflags",
-]
-
-[[package]]
-name = "redox_users"
-version = "0.4.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba009ff324d1fc1b900bd1fdb31564febe58a8ccc8a6fdbb93b543d33b13ca43"
-dependencies = [
- "getrandom 0.2.17",
- "libredox",
- "thiserror 1.0.69",
-]
-
-[[package]]
 name = "redox_users"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2642,29 +1938,6 @@ dependencies = [
  "getrandom 0.2.17",
  "libredox",
  "thiserror 2.0.18",
-]
-
-[[package]]
-name = "regex"
-version = "1.12.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e10754a14b9137dd7b1e3e5b0493cc9171fdd105e0ab477f51b72e7f3ac0e276"
-dependencies = [
- "aho-corasick",
- "memchr",
- "regex-automata",
- "regex-syntax",
-]
-
-[[package]]
-name = "regex-automata"
-version = "0.4.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f"
-dependencies = [
- "aho-corasick",
- "memchr",
- "regex-syntax",
 ]
 
 [[package]]
@@ -2688,32 +1961,31 @@ version = "0.12.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
 dependencies = [
- "base64 0.22.1",
+ "base64",
  "bytes",
  "cookie",
  "cookie_store",
  "futures-channel",
  "futures-core",
  "futures-util",
- "http 1.4.0",
- "http-body 1.0.1",
+ "http",
+ "http-body",
  "http-body-util",
- "hyper 1.8.1",
- "hyper-rustls",
+ "hyper",
+ "hyper-tls",
  "hyper-util",
  "js-sys",
  "log",
+ "native-tls",
  "percent-encoding",
  "pin-project-lite",
- "quinn",
- "rustls",
  "rustls-pki-types",
  "serde",
  "serde_json",
  "serde_urlencoded",
  "sync_wrapper",
  "tokio",
- "tokio-rustls",
+ "tokio-native-tls",
  "tower",
  "tower-http",
  "tower-service",
@@ -2721,21 +1993,6 @@ dependencies = [
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
- "webpki-roots",
-]
-
-[[package]]
-name = "ring"
-version = "0.17.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
-dependencies = [
- "cc",
- "cfg-if",
- "getrandom 0.2.17",
- "libc",
- "untrusted",
- "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2804,12 +2061,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rustc-hash"
-version = "2.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
-
-[[package]]
 name = "rustix"
 version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2823,38 +2074,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "rustls"
-version = "0.23.37"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "758025cb5fccfd3bc2fd74708fd4682be41d99e5dff73c377c0646c6012c73a4"
-dependencies = [
- "once_cell",
- "ring",
- "rustls-pki-types",
- "rustls-webpki",
- "subtle",
- "zeroize",
-]
-
-[[package]]
 name = "rustls-pki-types"
 version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be040f8b0a225e40375822a563fa9524378b9d63112f53e19ffff34df5d33fdd"
 dependencies = [
- "web-time",
  "zeroize",
-]
-
-[[package]]
-name = "rustls-webpki"
-version = "0.103.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7df23109aa6c1567d1c575b9952556388da57401e4ace1d15f79eedad0d8f53"
-dependencies = [
- "ring",
- "rustls-pki-types",
- "untrusted",
 ]
 
 [[package]]
@@ -2882,15 +2107,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
-name = "same-file"
-version = "1.0.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
-dependencies = [
- "winapi-util",
-]
-
-[[package]]
 name = "schannel"
 version = "0.1.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2898,12 +2114,6 @@ checksum = "891d81b926048e76efe18581bf793546b4c0eaf8448d72be8de2bbee5fd166e1"
 dependencies = [
  "windows-sys 0.61.2",
 ]
-
-[[package]]
-name = "scopeguard"
-version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "seahash"
@@ -2997,16 +2207,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde_regex"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8136f1a4ea815d7eac4101cfd0b16dc0cb5e1fe1b8609dfd728058656b7badf"
-dependencies = [
- "regex",
- "serde",
-]
-
-[[package]]
 name = "serde_spanned"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3080,16 +2280,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
-name = "signal-hook-registry"
-version = "1.4.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4db69cba1110affc0e9f7bcd48bbf87b3f4fc7c61fc9155afd4c469eb3d6c1b"
-dependencies = [
- "errno",
- "libc",
-]
-
-[[package]]
 name = "simd-adler32"
 version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3102,18 +2292,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
 
 [[package]]
-name = "similar"
-version = "2.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbbb5d9659141646ae647b42fe094daf6c6192d1620870b449d9557f748b2daa"
-
-[[package]]
-name = "siphasher"
-version = "1.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2aa850e253778c88a04c3d7323b043aeda9d3e30d5971937c1855769763678e"
-
-[[package]]
 name = "slab"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3124,16 +2302,6 @@ name = "smallvec"
 version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
-
-[[package]]
-name = "socket2"
-version = "0.5.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e22376abed350d73dd1cd119b57ffccad95b4e585a7cda43e286245ce23c0678"
-dependencies = [
- "libc",
- "windows-sys 0.52.0",
-]
 
 [[package]]
 name = "socket2"
@@ -3162,18 +2330,6 @@ name = "stable_deref_trait"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
-
-[[package]]
-name = "string_cache"
-version = "0.8.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf776ba3fa74f83bf4b63c3dcbbf82173db2632ed8452cb2d891d33f459de70f"
-dependencies = [
- "new_debug_unreachable",
- "parking_lot",
- "phf_shared",
- "precomputed-hash",
-]
 
 [[package]]
 name = "strsim"
@@ -3273,17 +2429,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "term"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c59df8ac95d96ff9bede18eb7300b0fda5e5d8d90960e76f8e14ae765eedbf1f"
-dependencies = [
- "dirs-next",
- "rustversion",
- "winapi",
-]
-
-[[package]]
 name = "testing_table"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3373,15 +2518,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tiny-keccak"
-version = "2.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c9d3793400a45f954c52e73d068316d76b6f4e36977e3fcebb13a2721e80237"
-dependencies = [
- "crunchy",
-]
-
-[[package]]
 name = "tinystr"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3416,8 +2552,7 @@ dependencies = [
  "libc",
  "mio",
  "pin-project-lite",
- "signal-hook-registry",
- "socket2 0.6.2",
+ "socket2",
  "tokio-macros",
  "windows-sys 0.61.2",
 ]
@@ -3440,16 +2575,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2"
 dependencies = [
  "native-tls",
- "tokio",
-]
-
-[[package]]
-name = "tokio-rustls"
-version = "0.26.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
-dependencies = [
- "rustls",
  "tokio",
 ]
 
@@ -3534,8 +2659,8 @@ dependencies = [
  "bitflags",
  "bytes",
  "futures-util",
- "http 1.4.0",
- "http-body 1.0.1",
+ "http",
+ "http-body",
  "iri-string",
  "pin-project-lite",
  "tower",
@@ -3642,7 +2767,7 @@ checksum = "4793cb5e56680ecbb1d843515b23b6de9a75eb04b66643e256a396d43be33c13"
 dependencies = [
  "bytes",
  "data-encoding",
- "http 1.4.0",
+ "http",
  "httparse",
  "log",
  "native-tls",
@@ -3682,12 +2807,6 @@ name = "unicode-xid"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
-
-[[package]]
-name = "untrusted"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
 name = "url"
@@ -3733,12 +2852,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "value-bag"
-version = "1.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ba6f5989077681266825251a52748b8c1d8a4ad098cc37e440103d0ea717fc0"
-
-[[package]]
 name = "vcpkg"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3757,16 +2870,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ac3b126d3914f9849036f826e054cbabdc8519970b8998ddaf3b5bd3c65f11"
 dependencies = [
  "libc",
-]
-
-[[package]]
-name = "walkdir"
-version = "2.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
-dependencies = [
- "same-file",
- "winapi-util",
 ]
 
 [[package]]
@@ -3906,25 +3009,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "web-time"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
-dependencies = [
- "js-sys",
- "wasm-bindgen",
-]
-
-[[package]]
-name = "webpki-roots"
-version = "1.0.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22cfaf3c063993ff62e73cb4311efde4db1efb31ab78a3e5c457939ad5cc0bed"
-dependencies = [
- "rustls-pki-types",
-]
-
-[[package]]
 name = "websocket-util"
 version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3935,37 +3019,6 @@ dependencies = [
  "tokio-tungstenite",
  "tracing",
 ]
-
-[[package]]
-name = "winapi"
-version = "0.3.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
-dependencies = [
- "winapi-i686-pc-windows-gnu",
- "winapi-x86_64-pc-windows-gnu",
-]
-
-[[package]]
-name = "winapi-i686-pc-windows-gnu"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
-
-[[package]]
-name = "winapi-util"
-version = "0.1.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
-dependencies = [
- "windows-sys 0.61.2",
-]
-
-[[package]]
-name = "winapi-x86_64-pc-windows-gnu"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-core"
@@ -4024,15 +3077,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
 dependencies = [
  "windows-link",
-]
-
-[[package]]
-name = "windows-sys"
-version = "0.52.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
-dependencies = [
- "windows-targets 0.52.6",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace]
-members = ["model", "db-sqlite", "core", "cli", "alpaca-broker", "broker-sync"]
+members = ["model", "db-sqlite", "core", "cli", "alpaca-broker", "ibkr-broker", "broker-sync"]
 resolver = "2"
 
 [workspace.package]

--- a/alpaca-broker/src/cancel_trade.rs
+++ b/alpaca-broker/src/cancel_trade.rs
@@ -13,7 +13,10 @@ pub fn cancel(trade: &Trade, account: &Account) -> Result<(), Box<dyn Error>> {
     let broker_order_id = trade
         .entry
         .broker_order_id
+        .as_deref()
         .ok_or("Entry order ID is missing")?;
+    let broker_order_id = Uuid::parse_str(broker_order_id)
+        .map_err(|e| format!("Entry order ID is not a valid UUID: {e}"))?;
 
     let api_info = keys::read_api_key(&account.environment, account)?;
     let client = Client::new(api_info);

--- a/alpaca-broker/src/close_trade.rs
+++ b/alpaca-broker/src/close_trade.rs
@@ -19,7 +19,10 @@ pub fn close(trade: &Trade, account: &Account) -> Result<(Order, BrokerLog), Box
     let target_order_id = trade
         .target
         .broker_order_id
+        .as_deref()
         .ok_or("Target order ID is missing")?;
+    let target_order_id = Uuid::parse_str(target_order_id)
+        .map_err(|e| format!("Target order ID is not a valid UUID: {e}"))?;
 
     Runtime::new()
         .map_err(|e| Box::new(e) as Box<dyn Error>)?

--- a/alpaca-broker/src/executions.rs
+++ b/alpaca-broker/src/executions.rs
@@ -7,8 +7,6 @@ use rust_decimal::Decimal;
 use std::error::Error;
 use std::str::FromStr;
 use tokio::runtime::Runtime;
-use uuid::Uuid;
-
 fn map_side(side: apca::api::v2::account_activities::Side) -> ExecutionSide {
     match side {
         apca::api::v2::account_activities::Side::Buy => ExecutionSide::Buy,
@@ -73,7 +71,7 @@ pub fn fetch_executions(
                     continue;
                 }
 
-                let broker_order_id = Uuid::parse_str(&trade_activity.order_id.to_string()).ok();
+                let broker_order_id = Some(trade_activity.order_id.to_string());
                 let qty = num_to_decimal(&trade_activity.quantity)?;
                 let price = num_to_decimal(&trade_activity.price)?;
 

--- a/alpaca-broker/src/lib.rs
+++ b/alpaca-broker/src/lib.rs
@@ -31,11 +31,11 @@
 #![warn(missing_docs, rust_2018_idioms, missing_debug_implementations)]
 
 use model::{
-    Account, BarTimeframe, Broker, BrokerLog, Environment, MarketBar, MarketDataChannel,
-    MarketDataStreamEvent, MarketQuote, MarketTradeTick, Order, OrderIds, Status, Trade,
+    Account, BarTimeframe, Broker, BrokerKind, BrokerLog, Environment, MarketBar,
+    MarketDataChannel, MarketDataStreamEvent, MarketQuote, MarketTradeTick, Order, OrderIds,
+    Status, Trade,
 };
 use std::error::Error;
-use uuid::Uuid;
 
 mod asset_lookup;
 mod cancel_trade;
@@ -59,6 +59,10 @@ pub struct AlpacaBroker;
 
 /// Generic Broker API
 impl Broker for AlpacaBroker {
+    fn kind(&self) -> BrokerKind {
+        BrokerKind::Alpaca
+    }
+
     fn submit_trade(
         &self,
         trade: &Trade,
@@ -93,7 +97,7 @@ impl Broker for AlpacaBroker {
         trade: &Trade,
         account: &Account,
         new_stop_price: rust_decimal::Decimal,
-    ) -> Result<Uuid, Box<dyn Error>> {
+    ) -> Result<String, Box<dyn Error>> {
         modify_stop::modify(trade, account, new_stop_price)
     }
 
@@ -102,7 +106,7 @@ impl Broker for AlpacaBroker {
         trade: &Trade,
         account: &Account,
         new_target_price: rust_decimal::Decimal,
-    ) -> Result<Uuid, Box<dyn Error>> {
+    ) -> Result<String, Box<dyn Error>> {
         modify_target::modify(trade, account, new_target_price)
     }
 

--- a/alpaca-broker/src/modify_stop.rs
+++ b/alpaca-broker/src/modify_stop.rs
@@ -8,14 +8,17 @@ use std::{error::Error, str::FromStr};
 use tokio::runtime::Runtime;
 use uuid::Uuid;
 
-pub fn modify(trade: &Trade, account: &Account, price: Decimal) -> Result<Uuid, Box<dyn Error>> {
+pub fn modify(trade: &Trade, account: &Account, price: Decimal) -> Result<String, Box<dyn Error>> {
     assert!(trade.account_id == account.id); // Verify that the trade is for the account
 
     // Validate required input before touching keychain/network.
     let stop_order_id = trade
         .safety_stop
         .broker_order_id
+        .as_deref()
         .ok_or("Safety stop order ID is missing")?;
+    let stop_order_id = Uuid::parse_str(stop_order_id)
+        .map_err(|e| format!("Safety stop order ID is not a valid UUID: {e}"))?;
 
     let api_info = keys::read_api_key(&account.environment, account)?;
     let client = Client::new(api_info);
@@ -24,7 +27,7 @@ pub fn modify(trade: &Trade, account: &Account, price: Decimal) -> Result<Uuid, 
         .map_err(|e| Box::new(e) as Box<dyn Error>)?
         .block_on(submit(&client, stop_order_id, price))?;
 
-    Ok(alpaca_order.id.0)
+    Ok(alpaca_order.id.0.to_string())
 }
 
 async fn submit(client: &Client, order_id: Uuid, price: Decimal) -> Result<Order, Box<dyn Error>> {

--- a/alpaca-broker/src/modify_target.rs
+++ b/alpaca-broker/src/modify_target.rs
@@ -8,14 +8,17 @@ use std::{error::Error, str::FromStr};
 use tokio::runtime::Runtime;
 use uuid::Uuid;
 
-pub fn modify(trade: &Trade, account: &Account, price: Decimal) -> Result<Uuid, Box<dyn Error>> {
+pub fn modify(trade: &Trade, account: &Account, price: Decimal) -> Result<String, Box<dyn Error>> {
     assert!(trade.account_id == account.id); // Verify that the trade is for the account
 
     // Validate required input before touching keychain/network.
     let target_order_id = trade
         .target
         .broker_order_id
+        .as_deref()
         .ok_or("Target order ID is missing")?;
+    let target_order_id = Uuid::parse_str(target_order_id)
+        .map_err(|e| format!("Target order ID is not a valid UUID: {e}"))?;
 
     let api_info = keys::read_api_key(&account.environment, account)?;
     let client = Client::new(api_info);
@@ -24,7 +27,7 @@ pub fn modify(trade: &Trade, account: &Account, price: Decimal) -> Result<Uuid, 
         .map_err(|e| Box::new(e) as Box<dyn Error>)?
         .block_on(submit(&client, target_order_id, price))?;
 
-    Ok(alpaca_order.id.0)
+    Ok(alpaca_order.id.0.to_string())
 }
 
 async fn submit(client: &Client, order_id: Uuid, price: Decimal) -> Result<Order, Box<dyn Error>> {

--- a/alpaca-broker/src/order_mapper.rs
+++ b/alpaca-broker/src/order_mapper.rs
@@ -6,7 +6,6 @@ use model::{Order, OrderCategory, OrderStatus, Status, Trade};
 use rust_decimal::Decimal;
 use std::error::Error;
 use std::str::FromStr;
-use uuid::Uuid;
 
 /// Maps an Alpaca order to our domain model.
 pub fn map_entry(alpaca_order: AlpacaOrder, trade: &Trade) -> Result<Vec<Order>, Box<dyn Error>> {
@@ -18,8 +17,8 @@ pub fn map_entry(alpaca_order: AlpacaOrder, trade: &Trade) -> Result<Vec<Order>,
         let order_id_str = order.id.to_string();
 
         // Safely handle target order mapping
-        if let Some(target_broker_id) = trade.target.broker_order_id {
-            if order_id_str == target_broker_id.to_string() {
+        if let Some(target_broker_id) = trade.target.broker_order_id.as_deref() {
+            if order_id_str == target_broker_id {
                 // 1. Map target order to our domain model.
                 return match map(order, trade.target.clone()) {
                     Ok(mapped_order) => {
@@ -39,8 +38,8 @@ pub fn map_entry(alpaca_order: AlpacaOrder, trade: &Trade) -> Result<Vec<Order>,
         }
 
         // Safely handle safety stop order mapping
-        if let Some(stop_broker_id) = trade.safety_stop.broker_order_id {
-            if order_id_str == stop_broker_id.to_string() {
+        if let Some(stop_broker_id) = trade.safety_stop.broker_order_id.as_deref() {
+            if order_id_str == stop_broker_id {
                 // 1. Map stop order to our domain model.
                 return match map(order, trade.safety_stop.clone()) {
                     Ok(mapped_order) => {
@@ -87,13 +86,13 @@ fn apply_updates_to_order(original: &Order, updates: &[Order]) -> Order {
     }
 }
 
-fn has_recent_fill(order_id: Uuid, updated_orders: &[Order]) -> bool {
+fn has_recent_fill(order_id: uuid::Uuid, updated_orders: &[Order]) -> bool {
     updated_orders
         .iter()
         .any(|order| order.id == order_id && order.status == OrderStatus::Filled)
 }
 
-fn has_recent_unfill(order_id: Uuid, updated_orders: &[Order]) -> bool {
+fn has_recent_unfill(order_id: uuid::Uuid, updated_orders: &[Order]) -> bool {
     updated_orders
         .iter()
         .any(|order| order.id == order_id && order.status != OrderStatus::Filled)
@@ -141,9 +140,10 @@ pub fn map_trade_status(trade: &Trade, updated_orders: &[Order]) -> Status {
 fn map(alpaca_order: &AlpacaOrder, order: Order) -> Result<Order, Box<dyn Error>> {
     let broker_order_id = order
         .broker_order_id
+        .clone()
         .ok_or("order does not have a broker id. It can not be mapped into an alpaca order")?;
 
-    if alpaca_order.id.to_string() != broker_order_id.to_string() {
+    if alpaca_order.id.to_string() != broker_order_id {
         return Err("Order IDs do not match".into());
     }
 
@@ -167,10 +167,7 @@ fn map(alpaca_order: &AlpacaOrder, order: Order) -> Result<Order, Box<dyn Error>
 
 pub fn map_close_order(alpaca_order: &AlpacaOrder, target: Order) -> Result<Order, Box<dyn Error>> {
     let mut order = target;
-    order.broker_order_id = Some(
-        Uuid::parse_str(&alpaca_order.id.to_string())
-            .map_err(|e| format!("Failed to parse Alpaca order ID as UUID: {e}"))?,
-    );
+    order.broker_order_id = Some(alpaca_order.id.to_string());
     order.status = map_from_alpaca(alpaca_order.status);
     order.submitted_at = map_date(alpaca_order.submitted_at);
     order.category = OrderCategory::Market;
@@ -257,7 +254,9 @@ mod tests {
         let trade = Trade {
             entry: Order {
                 broker_order_id: Some(
-                    Uuid::parse_str("00000000-0000-0000-0000-000000000000").unwrap(),
+                    Uuid::parse_str("00000000-0000-0000-0000-000000000000")
+                        .unwrap()
+                        .to_string(),
                 ),
                 ..Default::default()
             },
@@ -296,7 +295,7 @@ mod tests {
 
         let trade = Trade {
             entry: Order {
-                broker_order_id: Some(entry_id),
+                broker_order_id: Some(entry_id.to_string()),
                 ..Default::default()
             },
             ..Default::default()
@@ -337,15 +336,15 @@ mod tests {
 
         let trade = Trade {
             target: Order {
-                broker_order_id: Some(target_id),
+                broker_order_id: Some(target_id.to_string()),
                 ..Default::default()
             },
             safety_stop: Order {
-                broker_order_id: Some(Uuid::new_v4()),
+                broker_order_id: Some(Uuid::new_v4().to_string()),
                 ..Default::default()
             },
             entry: Order {
-                broker_order_id: Some(entry_id),
+                broker_order_id: Some(entry_id.to_string()),
                 ..Default::default()
             },
             ..Default::default()
@@ -395,15 +394,15 @@ mod tests {
 
         let trade = Trade {
             target: Order {
-                broker_order_id: Some(Uuid::new_v4()),
+                broker_order_id: Some(Uuid::new_v4().to_string()),
                 ..Default::default()
             },
             safety_stop: Order {
-                broker_order_id: Some(stop_id),
+                broker_order_id: Some(stop_id.to_string()),
                 ..Default::default()
             },
             entry: Order {
-                broker_order_id: Some(entry_id),
+                broker_order_id: Some(entry_id.to_string()),
                 ..Default::default()
             },
             ..Default::default()
@@ -632,14 +631,18 @@ mod tests {
     fn test_map_order_ids_match() {
         let alpaca_order = default();
         let order = Order {
-            broker_order_id: Some(Uuid::parse_str("00000000-0000-0000-0000-000000000000").unwrap()),
+            broker_order_id: Some(
+                Uuid::parse_str("00000000-0000-0000-0000-000000000000")
+                    .unwrap()
+                    .to_string(),
+            ),
             ..Default::default()
         };
         let mapped_order = map(&alpaca_order, order);
 
         assert_eq!(
             mapped_order.unwrap().broker_order_id.unwrap(),
-            Uuid::parse_str("00000000-0000-0000-0000-000000000000").unwrap()
+            "00000000-0000-0000-0000-000000000000"
         );
     }
 
@@ -649,7 +652,11 @@ mod tests {
         alpaca_order.filled_quantity = Num::from(10);
 
         let order = Order {
-            broker_order_id: Some(Uuid::parse_str("00000000-0000-0000-0000-000000000000").unwrap()),
+            broker_order_id: Some(
+                Uuid::parse_str("00000000-0000-0000-0000-000000000000")
+                    .unwrap()
+                    .to_string(),
+            ),
             ..Default::default()
         };
 
@@ -664,7 +671,11 @@ mod tests {
         alpaca_order.average_fill_price = Some(Num::from_str("2112.1212").unwrap());
 
         let order = Order {
-            broker_order_id: Some(Uuid::parse_str("00000000-0000-0000-0000-000000000000").unwrap()),
+            broker_order_id: Some(
+                Uuid::parse_str("00000000-0000-0000-0000-000000000000")
+                    .unwrap()
+                    .to_string(),
+            ),
             ..Default::default()
         };
 
@@ -682,7 +693,11 @@ mod tests {
         alpaca_order.status = AlpacaStatus::Filled;
 
         let order = Order {
-            broker_order_id: Some(Uuid::parse_str("00000000-0000-0000-0000-000000000000").unwrap()),
+            broker_order_id: Some(
+                Uuid::parse_str("00000000-0000-0000-0000-000000000000")
+                    .unwrap()
+                    .to_string(),
+            ),
             ..Default::default()
         };
 
@@ -698,7 +713,11 @@ mod tests {
         alpaca_order.filled_at = Some(now);
 
         let order = Order {
-            broker_order_id: Some(Uuid::parse_str("00000000-0000-0000-0000-000000000000").unwrap()),
+            broker_order_id: Some(
+                Uuid::parse_str("00000000-0000-0000-0000-000000000000")
+                    .unwrap()
+                    .to_string(),
+            ),
             ..Default::default()
         };
         let mapped_order = map(&alpaca_order, order);
@@ -712,7 +731,11 @@ mod tests {
         alpaca_order.expired_at = Some(now);
 
         let order = Order {
-            broker_order_id: Some(Uuid::parse_str("00000000-0000-0000-0000-000000000000").unwrap()),
+            broker_order_id: Some(
+                Uuid::parse_str("00000000-0000-0000-0000-000000000000")
+                    .unwrap()
+                    .to_string(),
+            ),
             ..Default::default()
         };
 
@@ -728,7 +751,11 @@ mod tests {
         alpaca_order.canceled_at = Some(now);
 
         let order = Order {
-            broker_order_id: Some(Uuid::parse_str("00000000-0000-0000-0000-000000000000").unwrap()),
+            broker_order_id: Some(
+                Uuid::parse_str("00000000-0000-0000-0000-000000000000")
+                    .unwrap()
+                    .to_string(),
+            ),
             ..Default::default()
         };
 

--- a/alpaca-broker/src/submit_trade.rs
+++ b/alpaca-broker/src/submit_trade.rs
@@ -7,7 +7,6 @@ use num_decimal::Num;
 
 use std::str::FromStr;
 use tokio::runtime::Runtime;
-use uuid::Uuid;
 
 use model::{Account, BrokerLog, Order, OrderIds, Trade, TradeCategory};
 use std::error::Error;
@@ -76,12 +75,9 @@ fn extract_ids(order: &AlpacaOrder, trade: &Trade) -> Result<OrderIds, Box<dyn E
     let target_id = target_id.ok_or("Target ID not found")?;
 
     Ok(OrderIds {
-        stop: Uuid::from_str(&stop_id.to_string())
-            .map_err(|e| format!("Failed to parse stop UUID: {e}"))?,
-        entry: Uuid::from_str(&order.id.to_string())
-            .map_err(|e| format!("Failed to parse entry UUID: {e}"))?,
-        target: Uuid::from_str(&target_id.to_string())
-            .map_err(|e| format!("Failed to parse target UUID: {e}"))?,
+        stop: stop_id.to_string(),
+        entry: order.id.to_string(),
+        target: target_id.to_string(),
     })
 }
 
@@ -297,18 +293,9 @@ mod tests {
         let result = extract_ids(&entry, &trade).unwrap();
 
         // Check that the stop ID is correct and the target ID is a new UUID
-        assert_eq!(
-            result.stop,
-            Uuid::parse_str("8654f70e-3b42-4014-a9ac-5a7101989aad").unwrap()
-        );
-        assert_eq!(
-            result.entry,
-            Uuid::parse_str("b6b12dc0-8e21-4d2e-8315-907d3116a6b8").unwrap()
-        );
-        assert_eq!(
-            result.target,
-            Uuid::parse_str("90e41b1e-9089-444d-9f68-c204a4d32914").unwrap()
-        );
+        assert_eq!(result.stop, "8654f70e-3b42-4014-a9ac-5a7101989aad");
+        assert_eq!(result.entry, "b6b12dc0-8e21-4d2e-8315-907d3116a6b8");
+        assert_eq!(result.target, "90e41b1e-9089-444d-9f68-c204a4d32914");
     }
 
     #[test]

--- a/alpaca-broker/src/sync_trade.rs
+++ b/alpaca-broker/src/sync_trade.rs
@@ -78,11 +78,12 @@ pub fn find_target(orders: Vec<AlpacaOrder>, trade: &Trade) -> Result<AlpacaOrde
     let target_order_id = trade
         .target
         .broker_order_id
+        .as_deref()
         .ok_or("Target order ID is missing")?;
 
     orders
         .into_iter()
-        .find(|x| x.id.to_string() == target_order_id.to_string())
+        .find(|x| x.id.to_string() == target_order_id)
         .ok_or_else(|| "Target order not found, it can be that is not filled yet".into())
 }
 
@@ -428,21 +429,21 @@ mod tests {
         // 1. Create an Entry that is the parent order.
         let entry_order = Order {
             id: entry_id,
-            broker_order_id: Some(entry_broker_id),
+            broker_order_id: Some(entry_broker_id.to_string()),
             unit_price: dec!(246.2),
             ..Default::default()
         };
 
         // 2. Create a Target that is a child order of the Entry
         let target_order = Order {
-            broker_order_id: Some(target_id),
+            broker_order_id: Some(target_id.to_string()),
             unit_price: dec!(247),
             ..Default::default()
         };
 
         // 3. Create a Stop that is a child order of the Entry
         let stop_order = Order {
-            broker_order_id: Some(stop_id),
+            broker_order_id: Some(stop_id.to_string()),
             unit_price: dec!(240),
             ..Default::default()
         };
@@ -471,7 +472,7 @@ mod tests {
 
         // 1. Create a Target that is a child order of the Entry
         let target_order = Order {
-            broker_order_id: Some(target_id),
+            broker_order_id: Some(target_id.to_string()),
             unit_price: dec!(247),
             ..Default::default()
         };
@@ -495,7 +496,7 @@ mod tests {
                 .first()
                 .expect("Expected at least one order")
                 .broker_order_id,
-            Some(target_id)
+            Some(target_id.to_string())
         );
     }
 
@@ -528,7 +529,7 @@ mod tests {
 
         let trade = Trade {
             target: Order {
-                broker_order_id: Some(id),
+                broker_order_id: Some(id.to_string()),
                 ..Default::default()
             },
             ..Default::default()

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -19,6 +19,7 @@ path = "src/main.rs"
 model = { package = "trust-model", path = "../model", version = "0.3.2" }
 core = { path = "../core", version = "0.3.2" }
 alpaca-broker = { path = "../alpaca-broker", version = "0.3.2" }
+ibkr-broker = { path = "../ibkr-broker", version = "0.3.2" }
 db-sqlite = { path = "../db-sqlite", version = "0.3.2" }
 broker-sync = { path = "../broker-sync", version = "0.3.2" }
 

--- a/cli/src/commands/account_command.rs
+++ b/cli/src/commands/account_command.rs
@@ -67,6 +67,20 @@ impl AccountCommandBuilder {
                         .required(false),
                 )
                 .arg(
+                    Arg::new("broker")
+                        .long("broker")
+                        .value_name("BROKER")
+                        .help("Broker kind: alpaca|ibkr")
+                        .required(false),
+                )
+                .arg(
+                    Arg::new("broker-account-id")
+                        .long("broker-account-id")
+                        .value_name("STRING")
+                        .help("External broker account identifier (required for IBKR primary accounts)")
+                        .required(false),
+                )
+                .arg(
                     Arg::new("parent")
                         .long("parent")
                         .value_name("UUID")
@@ -180,6 +194,10 @@ mod tests {
             "30",
             "--type",
             "tax-reserve",
+            "--broker",
+            "ibkr",
+            "--broker-account-id",
+            "U1234567",
             "--parent",
             parent,
         ]);

--- a/cli/src/commands/trading_vehicle_command.rs
+++ b/cli/src/commands/trading_vehicle_command.rs
@@ -24,10 +24,16 @@ impl TradingVehicleCommandBuilder {
             Command::new("create")
                 .about("Create a new trading vehicle")
                 .arg(
+                    Arg::new("from-broker")
+                        .long("from-broker")
+                        .value_name("BROKER")
+                        .help("Fetch symbol metadata from a broker (alpaca|ibkr) instead of prompting manually"),
+                )
+                .arg(
                     Arg::new("from-alpaca")
                         .long("from-alpaca")
                         .action(ArgAction::SetTrue)
-                        .help("Fetch symbol metadata from Alpaca instead of prompting manually"),
+                        .help("Deprecated alias for --from-broker alpaca"),
                 )
                 .arg(
                     Arg::new("account")
@@ -75,7 +81,7 @@ mod tests {
     }
 
     #[test]
-    fn trading_vehicle_create_parses_alpaca_and_symbol_options() {
+    fn trading_vehicle_create_parses_broker_import_and_symbol_options() {
         let cmd = TradingVehicleCommandBuilder::new()
             .create_trading_vehicle()
             .build();
@@ -83,7 +89,8 @@ mod tests {
             .try_get_matches_from([
                 "trading-vehicle",
                 "create",
-                "--from-alpaca",
+                "--from-broker",
+                "ibkr",
                 "--account",
                 "paper",
                 "--symbol",
@@ -95,7 +102,10 @@ mod tests {
         let sub = matches
             .subcommand_matches("create")
             .expect("create subcommand");
-        assert!(sub.get_flag("from-alpaca"));
+        assert_eq!(
+            sub.get_one::<String>("from-broker").map(String::as_str),
+            Some("ibkr")
+        );
         assert_eq!(
             sub.get_one::<String>("account").map(String::as_str),
             Some("paper")

--- a/cli/src/dialogs/keys_dialog.rs
+++ b/cli/src/dialogs/keys_dialog.rs
@@ -13,9 +13,10 @@
 use std::error::Error;
 
 use crate::dialogs::{AccountSearchDialog, ConsoleDialogIo, DialogIo};
-use alpaca_broker::{AlpacaBroker, Keys};
+use alpaca_broker::AlpacaBroker;
 use core::TrustFacade;
-use model::{Account, Environment};
+use ibkr_broker::IbkrBroker;
+use model::{Account, BrokerKind, Environment};
 
 fn select_environment(io: &mut dyn DialogIo) -> Option<Environment> {
     let available_env = Environment::all();
@@ -33,9 +34,10 @@ pub struct KeysWriteDialogBuilder {
     url: String,
     key_id: String,
     key_secret: String,
+    allow_insecure_tls: bool,
     environment: Option<Environment>,
     account: Option<Account>,
-    result: Option<Result<Keys, Box<dyn Error>>>,
+    result: Option<Result<String, Box<dyn Error>>>,
 }
 
 impl KeysWriteDialogBuilder {
@@ -44,6 +46,7 @@ impl KeysWriteDialogBuilder {
             url: "".to_string(),
             key_id: "".to_string(),
             key_secret: "".to_string(),
+            allow_insecure_tls: true,
             environment: None,
             account: None,
             result: None,
@@ -51,18 +54,30 @@ impl KeysWriteDialogBuilder {
     }
 
     pub fn build(mut self) -> KeysWriteDialogBuilder {
-        self.result = Some(AlpacaBroker::setup_keys(
-            &self.key_id,
-            &self.key_secret,
-            &self.url,
-            &self
-                .environment
-                .expect("Did you forget to select an environment?"),
-            &self
-                .account
-                .clone()
-                .expect("Did you forget to select an account?"),
-        ));
+        let environment = self
+            .environment
+            .expect("Did you forget to select an environment?");
+        let account = self
+            .account
+            .clone()
+            .expect("Did you forget to select an account?");
+        self.result = Some(match account.broker_kind {
+            BrokerKind::Alpaca => AlpacaBroker::setup_keys(
+                &self.key_id,
+                &self.key_secret,
+                &self.url,
+                &environment,
+                &account,
+            )
+            .map(|keys| keys.to_string()),
+            BrokerKind::Ibkr => IbkrBroker::setup_connection(
+                &self.url,
+                self.allow_insecure_tls,
+                &environment,
+                &account,
+            )
+            .map(|config| config.to_string()),
+        });
         self
     }
 
@@ -71,7 +86,7 @@ impl KeysWriteDialogBuilder {
             .result
             .expect("No result found, did you forget to call build?")
         {
-            Ok(keys) => println!("Keys created: {:?}", keys.key_id),
+            Ok(summary) => println!("Broker settings created: {summary}"),
             Err(error) => println!("Error creating keys: {error:?}"),
         }
     }
@@ -108,6 +123,9 @@ impl KeysWriteDialogBuilder {
     }
 
     pub fn key_id_with_io(mut self, io: &mut dyn DialogIo) -> Self {
+        if self.selected_broker_kind() == Some(BrokerKind::Ibkr) {
+            return self;
+        }
         match io.input_text("Key: ", false) {
             Ok(value) => self.key_id = value,
             Err(error) => println!("Error reading key id: {error}"),
@@ -122,6 +140,9 @@ impl KeysWriteDialogBuilder {
     }
 
     pub fn key_secret_with_io(mut self, io: &mut dyn DialogIo) -> Self {
+        if self.selected_broker_kind() == Some(BrokerKind::Ibkr) {
+            return self;
+        }
         match io.input_text("Secret: ", false) {
             Ok(value) => self.key_secret = value,
             Err(error) => println!("Error reading key secret: {error}"),
@@ -143,12 +164,16 @@ impl KeysWriteDialogBuilder {
         }
         self
     }
+
+    fn selected_broker_kind(&self) -> Option<BrokerKind> {
+        self.account.as_ref().map(|account| account.broker_kind)
+    }
 }
 
 pub struct KeysReadDialogBuilder {
     environment: Option<Environment>,
     account: Option<Account>,
-    result: Option<Result<Keys, Box<dyn Error>>>,
+    result: Option<Result<String, Box<dyn Error>>>,
 }
 
 impl KeysReadDialogBuilder {
@@ -161,15 +186,21 @@ impl KeysReadDialogBuilder {
     }
 
     pub fn build(mut self) -> KeysReadDialogBuilder {
-        self.result = Some(AlpacaBroker::read_keys(
-            &self
-                .environment
-                .expect("Did you forget to select an environment?"),
-            &self
-                .account
-                .clone()
-                .expect("Did you forget to select an account?"),
-        ));
+        let environment = self
+            .environment
+            .expect("Did you forget to select an environment?");
+        let account = self
+            .account
+            .clone()
+            .expect("Did you forget to select an account?");
+        self.result = Some(match account.broker_kind {
+            BrokerKind::Alpaca => {
+                AlpacaBroker::read_keys(&environment, &account).map(|keys| keys.to_string())
+            }
+            BrokerKind::Ibkr => {
+                IbkrBroker::read_connection(&environment, &account).map(|config| config.to_string())
+            }
+        });
         self
     }
 
@@ -178,7 +209,7 @@ impl KeysReadDialogBuilder {
             .result
             .expect("No result found, did you forget to call build?")
         {
-            Ok(keys) => println!("Keys stored: {:?}", keys.key_id),
+            Ok(summary) => println!("Broker settings stored: {summary}"),
             Err(error) => println!("Error reading keys: {error:?}"),
         }
     }
@@ -226,15 +257,17 @@ impl KeysDeleteDialogBuilder {
     }
 
     pub fn build(mut self) -> KeysDeleteDialogBuilder {
-        self.result = Some(AlpacaBroker::delete_keys(
-            &self
-                .environment
-                .expect("Did you forget to select an environment?"),
-            &self
-                .account
-                .clone()
-                .expect("Did you forget to select an account?"),
-        ));
+        let environment = self
+            .environment
+            .expect("Did you forget to select an environment?");
+        let account = self
+            .account
+            .clone()
+            .expect("Did you forget to select an account?");
+        self.result = Some(match account.broker_kind {
+            BrokerKind::Alpaca => AlpacaBroker::delete_keys(&environment, &account),
+            BrokerKind::Ibkr => IbkrBroker::delete_connection(&environment, &account),
+        });
         self
     }
 
@@ -280,10 +313,10 @@ mod tests {
     use super::{KeysDeleteDialogBuilder, KeysReadDialogBuilder, KeysWriteDialogBuilder};
     use crate::dialogs::io::{scripted_push_input, scripted_push_select, scripted_reset};
     use crate::dialogs::DialogIo;
-    use alpaca_broker::{AlpacaBroker, Keys};
+    use alpaca_broker::AlpacaBroker;
     use core::TrustFacade;
     use db_sqlite::SqliteDatabase;
-    use model::Environment;
+    use model::{Account, BrokerKind, Environment};
     use rust_decimal_macros::dec;
     use std::collections::VecDeque;
     use std::io::Error as IoError;
@@ -319,6 +352,7 @@ mod tests {
         assert_eq!(write.url, "");
         assert_eq!(write.key_id, "");
         assert_eq!(write.key_secret, "");
+        assert!(write.allow_insecure_tls);
         assert!(write.environment.is_none());
         assert!(write.account.is_none());
         assert!(write.result.is_none());
@@ -335,11 +369,12 @@ mod tests {
     }
 
     #[test]
-    fn keys_builders_display_handle_error_results() {
+    fn keys_builders_display_handle_success_and_error_results() {
         KeysWriteDialogBuilder {
             url: String::new(),
             key_id: String::new(),
             key_secret: String::new(),
+            allow_insecure_tls: true,
             environment: None,
             account: None,
             result: Some(Err("synthetic failure".into())),
@@ -359,32 +394,26 @@ mod tests {
             result: Some(Err("synthetic failure".into())),
         }
         .display();
-    }
 
-    #[test]
-    fn keys_builders_display_handle_success_results() {
         KeysWriteDialogBuilder {
             url: String::new(),
             key_id: String::new(),
             key_secret: String::new(),
+            allow_insecure_tls: true,
             environment: None,
             account: None,
-            result: Some(Ok(Keys::new(
-                "id",
-                "secret",
-                "https://paper-api.alpaca.markets",
-            ))),
+            result: Some(Ok(
+                "https://paper-api.alpaca.markets id [REDACTED]".to_string()
+            )),
         }
         .display();
 
         KeysReadDialogBuilder {
             environment: None,
             account: None,
-            result: Some(Ok(Keys::new(
-                "id",
-                "secret",
-                "https://paper-api.alpaca.markets",
-            ))),
+            result: Some(Ok(
+                "https://localhost:5000/v1/api (allow_insecure_tls=true)".to_string(),
+            )),
         }
         .display();
 
@@ -412,14 +441,6 @@ mod tests {
         io.selections.push_back(Ok(Some(0)));
         let delete = KeysDeleteDialogBuilder::new().environment_with_io(&mut io);
         assert_eq!(delete.environment, Some(model::Environment::Paper));
-    }
-
-    #[test]
-    fn keys_environment_with_io_handles_cancel() {
-        let mut io = ScriptedIo::default();
-        io.selections.push_back(Ok(None));
-        let write = KeysWriteDialogBuilder::new().environment_with_io(&mut io);
-        assert!(write.environment.is_none());
     }
 
     #[test]
@@ -520,6 +541,20 @@ mod tests {
         io.selections.push_back(Ok(Some(0)));
         let write = KeysWriteDialogBuilder::new().account_with_io(&mut trust, &mut io);
         assert!(write.account.is_some(), "account should be selected");
+    }
+
+    #[test]
+    fn ibkr_accounts_skip_key_and_secret_prompts() {
+        let mut builder = KeysWriteDialogBuilder::new();
+        builder.account = Some(Account {
+            broker_kind: BrokerKind::Ibkr,
+            ..Account::default()
+        });
+        let mut io = ScriptedIo::default();
+        io.inputs.push_back(Ok("ignored".to_string()));
+        let builder = builder.key_id_with_io(&mut io).key_secret_with_io(&mut io);
+        assert_eq!(builder.key_id, "");
+        assert_eq!(builder.key_secret, "");
     }
 
     #[test]

--- a/cli/src/dialogs/trade_watch_dialog.rs
+++ b/cli/src/dialogs/trade_watch_dialog.rs
@@ -272,6 +272,10 @@ mod tests {
     struct TestBroker;
 
     impl Broker for TestBroker {
+        fn kind(&self) -> model::BrokerKind {
+            model::BrokerKind::Alpaca
+        }
+
         fn submit_trade(
             &self,
             _trade: &model::Trade,
@@ -280,9 +284,9 @@ mod tests {
             Ok((
                 BrokerLog::default(),
                 OrderIds {
-                    stop: Uuid::new_v4(),
-                    entry: Uuid::new_v4(),
-                    target: Uuid::new_v4(),
+                    stop: Uuid::new_v4().to_string(),
+                    entry: Uuid::new_v4().to_string(),
+                    target: Uuid::new_v4().to_string(),
                 },
             ))
         }
@@ -316,8 +320,8 @@ mod tests {
             _trade: &model::Trade,
             _account: &model::Account,
             _new_stop_price: rust_decimal::Decimal,
-        ) -> Result<Uuid, Box<dyn std::error::Error>> {
-            Ok(Uuid::new_v4())
+        ) -> Result<String, Box<dyn std::error::Error>> {
+            Ok(Uuid::new_v4().to_string())
         }
 
         fn modify_target(
@@ -325,8 +329,8 @@ mod tests {
             _trade: &model::Trade,
             _account: &model::Account,
             _new_price: rust_decimal::Decimal,
-        ) -> Result<Uuid, Box<dyn std::error::Error>> {
-            Ok(Uuid::new_v4())
+        ) -> Result<String, Box<dyn std::error::Error>> {
+            Ok(Uuid::new_v4().to_string())
         }
     }
 
@@ -433,6 +437,10 @@ mod tests {
     }
 
     impl Broker for ScenarioBroker {
+        fn kind(&self) -> model::BrokerKind {
+            model::BrokerKind::Alpaca
+        }
+
         fn submit_trade(
             &self,
             _trade: &model::Trade,
@@ -441,9 +449,9 @@ mod tests {
             Ok((
                 BrokerLog::default(),
                 OrderIds {
-                    stop: Uuid::new_v4(),
-                    entry: Uuid::new_v4(),
-                    target: Uuid::new_v4(),
+                    stop: Uuid::new_v4().to_string(),
+                    entry: Uuid::new_v4().to_string(),
+                    target: Uuid::new_v4().to_string(),
                 },
             ))
         }
@@ -493,8 +501,8 @@ mod tests {
             _trade: &model::Trade,
             _account: &model::Account,
             _new_stop_price: rust_decimal::Decimal,
-        ) -> Result<Uuid, Box<dyn std::error::Error>> {
-            Ok(Uuid::new_v4())
+        ) -> Result<String, Box<dyn std::error::Error>> {
+            Ok(Uuid::new_v4().to_string())
         }
 
         fn modify_target(
@@ -502,8 +510,8 @@ mod tests {
             _trade: &model::Trade,
             _account: &model::Account,
             _new_price: rust_decimal::Decimal,
-        ) -> Result<Uuid, Box<dyn std::error::Error>> {
-            Ok(Uuid::new_v4())
+        ) -> Result<String, Box<dyn std::error::Error>> {
+            Ok(Uuid::new_v4().to_string())
         }
     }
 

--- a/cli/src/dispatcher.rs
+++ b/cli/src/dispatcher.rs
@@ -29,6 +29,7 @@ use crate::dialogs::{
 };
 use crate::dialogs::{RuleDialogBuilder, RuleRemoveDialogBuilder};
 use crate::protected_keyword;
+use crate::trading_vehicle_import;
 use alpaca_broker::AlpacaBroker;
 use chrono::{DateTime, Datelike, Days, NaiveDate, Utc};
 use clap::ArgMatches;
@@ -41,11 +42,11 @@ use core::TrustFacade;
 use db_sqlite::SqliteDatabase;
 use db_sqlite::{ImportMode, ImportOptions};
 use dialoguer::Password;
+use ibkr_broker::IbkrBroker;
 use model::{
-    database::TradingVehicleUpsert, Account, AccountType, BarTimeframe, Currency, DraftTrade,
-    Environment, Level, LevelAdjustmentRules, LevelTrigger, MarketDataChannel,
-    MarketSnapshotSource, Status, Trade, TradeCategory, TradingVehicleCategory,
-    TransactionCategory,
+    Account, AccountType, BarTimeframe, BrokerKind, Currency, DraftTrade, Environment, Level,
+    LevelAdjustmentRules, LevelTrigger, MarketDataChannel, MarketSnapshotSource, Status, Trade,
+    TradeCategory, TransactionCategory,
 };
 use rust_decimal::prelude::ToPrimitive;
 use rust_decimal::Decimal;
@@ -353,6 +354,8 @@ impl ArgDispatcher {
             || sub_matches.get_one::<String>("taxes").is_some()
             || sub_matches.get_one::<String>("earnings").is_some()
             || sub_matches.get_one::<String>("type").is_some()
+            || sub_matches.get_one::<String>("broker").is_some()
+            || sub_matches.get_one::<String>("broker-account-id").is_some()
             || sub_matches.get_one::<String>("parent").is_some()
     }
 
@@ -373,7 +376,10 @@ impl ArgDispatcher {
     pub fn new_sqlite() -> Self {
         create_dir_if_necessary();
         let database = SqliteDatabase::new(ArgDispatcher::database_url().as_str());
-        let mut trust = TrustFacade::new(Box::new(database), Box::<AlpacaBroker>::default());
+        let mut trust = TrustFacade::new_with_brokers(
+            Box::new(database),
+            vec![Box::<AlpacaBroker>::default(), Box::<IbkrBroker>::default()],
+        );
         trust.enable_protected_mode();
         ArgDispatcher { trust }
     }
@@ -1278,6 +1284,8 @@ impl ArgDispatcher {
             let taxes = sub_matches.get_one::<String>("taxes").cloned();
             let earnings = sub_matches.get_one::<String>("earnings").cloned();
             let account_type = sub_matches.get_one::<String>("type").cloned();
+            let broker = sub_matches.get_one::<String>("broker").cloned();
+            let broker_account_id = sub_matches.get_one::<String>("broker-account-id").cloned();
             let parent = sub_matches.get_one::<String>("parent").cloned();
 
             let name = name.ok_or_else(|| CliError::new("missing_name", "Missing --name"))?;
@@ -1303,6 +1311,10 @@ impl ArgDispatcher {
                 Some(v) => Self::parse_account_type(&v)?,
                 None => AccountType::Primary,
             };
+            let broker_kind = match broker {
+                Some(v) => Self::parse_broker_kind(&v)?,
+                None => BrokerKind::Alpaca,
+            };
             let parent_account_id = match parent {
                 Some(v) => Some(
                     Uuid::parse_str(&v)
@@ -1310,10 +1322,21 @@ impl ArgDispatcher {
                 ),
                 None => None,
             };
+            let broker_account_id = broker_account_id.filter(|value| !value.trim().is_empty());
+
+            if broker_kind == BrokerKind::Ibkr
+                && account_type == AccountType::Primary
+                && broker_account_id.is_none()
+            {
+                return Err(CliError::new(
+                    "missing_broker_account_id",
+                    "Missing --broker-account-id for an IBKR primary account",
+                ));
+            }
 
             let account = self
                 .trust
-                .create_account_with_hierarchy(
+                .create_account_with_profile(
                     &name,
                     &description,
                     environment,
@@ -1321,12 +1344,19 @@ impl ArgDispatcher {
                     earnings_percentage,
                     account_type,
                     parent_account_id,
+                    broker_kind,
+                    broker_account_id.as_deref(),
                 )
                 .map_err(|e| CliError::new("create_account_failed", e.to_string()))?;
             println!("Account created:");
             println!("  id: {}", account.id);
             println!("  name: {}", account.name);
             println!("  type: {}", account.account_type);
+            println!("  broker: {}", account.broker_kind);
+            println!(
+                "  broker_account_id: {}",
+                account.broker_account_id.as_deref().unwrap_or("none")
+            );
             println!(
                 "  parent: {}",
                 account
@@ -1459,6 +1489,15 @@ impl ArgDispatcher {
                 "Invalid --type value (expected primary|earnings|tax-reserve|reinvestment)",
             )),
         }
+    }
+
+    fn parse_broker_kind(raw: &str) -> Result<BrokerKind, CliError> {
+        raw.parse::<BrokerKind>().map_err(|_| {
+            CliError::new(
+                "invalid_broker_kind",
+                "Invalid --broker value (expected alpaca|ibkr)",
+            )
+        })
     }
 }
 
@@ -2772,7 +2811,11 @@ impl ArgDispatcher {
             "trading-vehicle creation",
         )?;
         if matches.get_flag("from-alpaca") {
-            return self.create_trading_vehicle_from_alpaca(matches);
+            return self.create_trading_vehicle_from_broker(matches, BrokerKind::Alpaca);
+        }
+        if let Some(broker) = matches.get_one::<String>("from-broker") {
+            return self
+                .create_trading_vehicle_from_broker(matches, Self::parse_broker_kind(broker)?);
         }
 
         TradingVehicleDialogBuilder::new()
@@ -2786,13 +2829,17 @@ impl ArgDispatcher {
     }
 
     #[allow(clippy::too_many_lines)]
-    fn create_trading_vehicle_from_alpaca(&mut self, matches: &ArgMatches) -> Result<(), CliError> {
+    fn create_trading_vehicle_from_broker(
+        &mut self,
+        matches: &ArgMatches,
+        broker_kind: BrokerKind,
+    ) -> Result<(), CliError> {
         let account_name = match matches.get_one::<String>("account") {
             Some(value) if !value.trim().is_empty() => value.trim(),
             _ => {
                 return Err(CliError::new(
-                    "alpaca_import_invalid_args",
-                    "--account is required when using --from-alpaca",
+                    "broker_import_invalid_args",
+                    "--account is required when importing from broker metadata",
                 ));
             }
         };
@@ -2801,8 +2848,8 @@ impl ArgDispatcher {
             Some(value) if !value.trim().is_empty() => value.trim(),
             _ => {
                 return Err(CliError::new(
-                    "alpaca_import_invalid_args",
-                    "--symbol is required when using --from-alpaca",
+                    "broker_import_invalid_args",
+                    "--symbol is required when importing from broker metadata",
                 ));
             }
         };
@@ -2811,73 +2858,25 @@ impl ArgDispatcher {
             Ok(account) => account,
             Err(error) => {
                 return Err(CliError::new(
-                    "alpaca_import_account_not_found",
+                    "broker_import_account_not_found",
                     format!("{error}"),
                 ));
             }
         };
 
-        let metadata = match AlpacaBroker::fetch_asset_metadata(&account, symbol) {
-            Ok(metadata) => metadata,
-            Err(error) => {
-                return Err(CliError::new("alpaca_import_failed", format!("{error}")));
-            }
-        };
+        let imported = trading_vehicle_import::import_from_broker(&account, symbol, broker_kind)
+            .map_err(|error| CliError::new(error.code(), error.message().to_string()))?;
 
-        if !metadata.is_active {
-            return Err(CliError::new(
-                "alpaca_import_unavailable",
-                format!("symbol '{}' is inactive", metadata.symbol),
-            ));
-        }
-
-        if !metadata.tradable {
-            return Err(CliError::new(
-                "alpaca_import_unavailable",
-                format!("symbol '{}' is not tradable", metadata.symbol),
-            ));
-        }
-
-        let upsert = TradingVehicleUpsert {
-            symbol: metadata.symbol.clone(),
-            isin: None,
-            category: metadata.category,
-            broker: "alpaca".to_string(),
-            broker_asset_id: Some(metadata.broker_identifier.clone()),
-            exchange: Some(metadata.exchange.clone()),
-            broker_asset_class: None,
-            broker_asset_status: Some(if metadata.is_active {
-                "active".to_string()
-            } else {
-                "inactive".to_string()
-            }),
-            tradable: Some(metadata.tradable),
-            marginable: Some(metadata.marginable),
-            shortable: Some(metadata.shortable),
-            easy_to_borrow: Some(metadata.easy_to_borrow),
-            fractionable: Some(metadata.fractionable),
-        };
-
-        let result = self.trust.upsert_trading_vehicle(upsert);
+        let result = self.trust.upsert_trading_vehicle(imported.upsert);
 
         match result {
             Ok(tv) => {
-                println!(
-                    "Imported from Alpaca: symbol={}, category={}, exchange={}, tradable={}, marginable={}, shortable={}, fractionable={}, broker_id={}",
-                    tv.symbol,
-                    category_to_str(tv.category),
-                    metadata.exchange,
-                    metadata.tradable,
-                    metadata.marginable,
-                    metadata.shortable,
-                    metadata.fractionable,
-                    metadata.broker_identifier,
-                );
+                println!("{}", imported.summary);
                 crate::views::TradingVehicleView::display(tv);
             }
             Err(error) => {
                 return Err(CliError::new(
-                    "alpaca_import_store_failed",
+                    "broker_import_store_failed",
                     format!("{error}"),
                 ));
             }
@@ -2892,11 +2891,12 @@ impl ArgDispatcher {
     }
 }
 
-fn category_to_str(category: TradingVehicleCategory) -> &'static str {
+#[cfg(test)]
+fn category_to_str(category: model::TradingVehicleCategory) -> &'static str {
     match category {
-        TradingVehicleCategory::Crypto => "crypto",
-        TradingVehicleCategory::Fiat => "fiat",
-        TradingVehicleCategory::Stock => "stock",
+        model::TradingVehicleCategory::Crypto => "crypto",
+        model::TradingVehicleCategory::Fiat => "fiat",
+        model::TradingVehicleCategory::Stock => "stock",
         _ => "unknown",
     }
 }
@@ -7075,15 +7075,16 @@ mod tests {
     use core::TrustFacade;
     use db_sqlite::SqliteDatabase;
     use model::{
-        AccountType, Broker, BrokerLog, Currency, Environment, Level, LevelAdjustmentRules,
-        LevelDirection, LevelStatus, LevelTrigger, MarketBar, MarketDataChannel,
-        MarketDataStreamEvent, MarketQuote, MarketSnapshotSource, MarketSnapshotV2,
-        MarketTradeTick, OrderIds, Status, Trade, TradingVehicleCategory, TransactionCategory,
+        AccountType, Broker, BrokerKind, BrokerLog, Currency, Environment, Level,
+        LevelAdjustmentRules, LevelDirection, LevelStatus, LevelTrigger, MarketBar,
+        MarketDataChannel, MarketDataStreamEvent, MarketQuote, MarketSnapshotSource,
+        MarketSnapshotV2, MarketTradeTick, OrderIds, Status, Trade, TradingVehicleCategory,
+        TransactionCategory,
     };
     use rust_decimal::Decimal;
     use rust_decimal_macros::dec;
     use std::error::Error;
-    use std::sync::{Mutex, OnceLock};
+    use std::sync::{Mutex, MutexGuard, OnceLock};
     use uuid::Uuid;
 
     #[derive(Clone)]
@@ -7155,6 +7156,10 @@ mod tests {
     }
 
     impl Broker for StubBroker {
+        fn kind(&self) -> BrokerKind {
+            BrokerKind::Alpaca
+        }
+
         fn submit_trade(
             &self,
             _trade: &Trade,
@@ -7192,7 +7197,7 @@ mod tests {
             _trade: &Trade,
             _account: &model::Account,
             _new_stop_price: Decimal,
-        ) -> Result<Uuid, Box<dyn Error>> {
+        ) -> Result<String, Box<dyn Error>> {
             Err("not implemented in test stub".into())
         }
 
@@ -7201,7 +7206,7 @@ mod tests {
             _trade: &Trade,
             _account: &model::Account,
             _new_price: Decimal,
-        ) -> Result<Uuid, Box<dyn Error>> {
+        ) -> Result<String, Box<dyn Error>> {
             Err("not implemented in test stub".into())
         }
 
@@ -7249,6 +7254,13 @@ mod tests {
         LOCK.get_or_init(|| Mutex::new(()))
     }
 
+    fn env_guard() -> MutexGuard<'static, ()> {
+        match env_lock().lock() {
+            Ok(guard) => guard,
+            Err(poisoned) => poisoned.into_inner(),
+        }
+    }
+
     fn test_dispatcher() -> ArgDispatcher {
         let trust = TrustFacade::new(
             Box::new(SqliteDatabase::new_in_memory()),
@@ -7273,6 +7285,8 @@ mod tests {
             .arg(Arg::new("taxes").long("taxes"))
             .arg(Arg::new("earnings").long("earnings"))
             .arg(Arg::new("type").long("type"))
+            .arg(Arg::new("broker").long("broker"))
+            .arg(Arg::new("broker-account-id").long("broker-account-id"))
             .arg(Arg::new("parent").long("parent"))
             .get_matches_from(argv)
     }
@@ -7649,6 +7663,27 @@ mod tests {
         assert_eq!(
             error.to_string(),
             "invalid_account_type: Invalid --type value (expected primary|earnings|tax-reserve|reinvestment)"
+        );
+    }
+
+    #[test]
+    fn test_parse_broker_kind_accepts_supported_values() {
+        assert_eq!(
+            ArgDispatcher::parse_broker_kind("alpaca").unwrap(),
+            BrokerKind::Alpaca
+        );
+        assert_eq!(
+            ArgDispatcher::parse_broker_kind("IBKR").unwrap(),
+            BrokerKind::Ibkr
+        );
+    }
+
+    #[test]
+    fn test_parse_broker_kind_rejects_invalid_value() {
+        let error = ArgDispatcher::parse_broker_kind("binance").unwrap_err();
+        assert_eq!(
+            error.to_string(),
+            "invalid_broker_kind: Invalid --broker value (expected alpaca|ibkr)"
         );
     }
 
@@ -8720,16 +8755,16 @@ mod tests {
     }
 
     #[test]
-    fn test_create_trading_vehicle_from_alpaca_validates_required_args_and_account_lookup() {
+    fn test_create_trading_vehicle_from_broker_validates_required_args_and_account_lookup() {
         let mut dispatcher = test_dispatcher();
         let missing_account = Command::new("test")
             .arg(Arg::new("account").long("account"))
             .arg(Arg::new("symbol").long("symbol"))
             .get_matches_from(["test", "--symbol", "AAPL"]);
         let error = dispatcher
-            .create_trading_vehicle_from_alpaca(&missing_account)
+            .create_trading_vehicle_from_broker(&missing_account, BrokerKind::Alpaca)
             .expect_err("missing account should fail");
-        assert!(error.to_string().contains("alpaca_import_invalid_args"));
+        assert!(error.to_string().contains("broker_import_invalid_args"));
         assert!(error.to_string().contains("--account is required"));
 
         let missing_symbol = Command::new("test")
@@ -8737,9 +8772,9 @@ mod tests {
             .arg(Arg::new("symbol").long("symbol"))
             .get_matches_from(["test", "--account", "paper-main"]);
         let error = dispatcher
-            .create_trading_vehicle_from_alpaca(&missing_symbol)
+            .create_trading_vehicle_from_broker(&missing_symbol, BrokerKind::Alpaca)
             .expect_err("missing symbol should fail");
-        assert!(error.to_string().contains("alpaca_import_invalid_args"));
+        assert!(error.to_string().contains("broker_import_invalid_args"));
         assert!(error.to_string().contains("--symbol is required"));
 
         let unknown_account = Command::new("test")
@@ -8747,11 +8782,11 @@ mod tests {
             .arg(Arg::new("symbol").long("symbol"))
             .get_matches_from(["test", "--account", "paper-main", "--symbol", "AAPL"]);
         let error = dispatcher
-            .create_trading_vehicle_from_alpaca(&unknown_account)
+            .create_trading_vehicle_from_broker(&unknown_account, BrokerKind::Alpaca)
             .expect_err("unknown account should fail");
         assert!(error
             .to_string()
-            .contains("alpaca_import_account_not_found"));
+            .contains("broker_import_account_not_found"));
     }
 
     #[test]
@@ -9055,7 +9090,7 @@ mod tests {
 
     #[test]
     fn test_advisor_commands_validate_inputs_and_history_defaults() {
-        let _guard = env_lock().lock().expect("lock");
+        let _guard = env_guard();
         std::env::set_var("TRUST_PROTECTED_KEYWORD_EXPECTED", "secret");
         let mut dispatcher = test_dispatcher();
         let (account, _) = seed_account_and_vehicle(&mut dispatcher);
@@ -9664,7 +9699,7 @@ mod tests {
 
     #[test]
     fn test_ensure_protected_keyword_requires_argument_and_validates_value() {
-        let _guard = env_lock().lock().expect("lock");
+        let _guard = env_guard();
         crate::protected_keyword::delete().expect("reset protected keyword state");
         crate::protected_keyword::store("secret").expect("seed protected keyword");
 
@@ -9763,7 +9798,7 @@ mod tests {
 
     #[test]
     fn test_protected_keyword_lifecycle_set_rotate_and_delete_requires_valid_confirmation() {
-        let _guard = env_lock().lock().expect("lock");
+        let _guard = env_guard();
         std::env::set_var("TRUST_DISABLE_KEYCHAIN", "1");
         crate::protected_keyword::delete().expect("reset protected keyword");
         let mut dispatcher = test_dispatcher();
@@ -10155,7 +10190,7 @@ mod tests {
 
     #[test]
     fn test_create_account_non_interactive_missing_required_fields() {
-        let _guard = env_lock().lock().expect("lock");
+        let _guard = env_guard();
         std::env::set_var("TRUST_PROTECTED_KEYWORD_EXPECTED", "secret");
         let mut dispatcher = test_dispatcher();
 
@@ -10170,7 +10205,7 @@ mod tests {
 
     #[test]
     fn test_create_account_non_interactive_rejects_invalid_parent_uuid() {
-        let _guard = env_lock().lock().expect("lock");
+        let _guard = env_guard();
         std::env::set_var("TRUST_PROTECTED_KEYWORD_EXPECTED", "secret");
         let mut dispatcher = test_dispatcher();
 
@@ -10199,8 +10234,38 @@ mod tests {
     }
 
     #[test]
+    fn test_create_account_non_interactive_requires_ibkr_primary_account_id() {
+        let _guard = env_guard();
+        std::env::set_var("TRUST_PROTECTED_KEYWORD_EXPECTED", "secret");
+        let mut dispatcher = test_dispatcher();
+
+        let matches = account_matches(&[
+            "--confirm-protected",
+            "secret",
+            "--name",
+            "ibkr-main",
+            "--description",
+            "ibkr trading",
+            "--environment",
+            "paper",
+            "--taxes",
+            "20",
+            "--earnings",
+            "10",
+            "--broker",
+            "ibkr",
+        ]);
+        let error = dispatcher
+            .create_account(&matches)
+            .expect_err("missing ibkr broker account id should fail");
+        assert!(error.to_string().contains("missing_broker_account_id"));
+
+        std::env::remove_var("TRUST_PROTECTED_KEYWORD_EXPECTED");
+    }
+
+    #[test]
     fn test_create_account_non_interactive_success_with_hierarchy() {
-        let _guard = env_lock().lock().expect("lock");
+        let _guard = env_guard();
         std::env::set_var("TRUST_PROTECTED_KEYWORD_EXPECTED", "secret");
         let mut dispatcher = test_dispatcher();
 
@@ -10379,7 +10444,7 @@ mod tests {
 
     #[test]
     fn test_dispatch_transactions_non_interactive_success_and_validation_errors() {
-        let _guard = env_lock().lock().expect("lock");
+        let _guard = env_guard();
         std::env::set_var("TRUST_PROTECTED_KEYWORD_EXPECTED", "secret");
         let mut dispatcher = test_dispatcher();
 
@@ -10690,7 +10755,7 @@ mod tests {
 
     #[test]
     fn test_dispatchers_cover_non_interactive_routes_with_safe_error_paths() {
-        let _guard = env_lock().lock().expect("lock");
+        let _guard = env_guard();
         std::env::set_var("TRUST_DISABLE_KEYCHAIN", "1");
         std::env::set_var("TRUST_PROTECTED_KEYWORD_EXPECTED", "secret");
 
@@ -10987,7 +11052,7 @@ mod tests {
 
     #[test]
     fn test_reporting_policy_and_onboarding_handlers_cover_text_and_json_paths() {
-        let _guard = env_lock().lock().expect("lock");
+        let _guard = env_guard();
         std::env::set_var("TRUST_PROTECTED_KEYWORD_EXPECTED", "secret");
         let mut dispatcher = test_dispatcher();
         let (account, vehicle) = seed_account_and_vehicle(&mut dispatcher);
@@ -11300,7 +11365,7 @@ mod tests {
 
     #[test]
     fn test_database_url_prefers_env_override() {
-        let _guard = env_lock().lock().expect("lock");
+        let _guard = env_guard();
         std::env::set_var("TRUST_DB_URL", "/tmp/trust-custom.db");
         let value = ArgDispatcher::database_url();
         assert_eq!(value, "/tmp/trust-custom.db");
@@ -11309,7 +11374,7 @@ mod tests {
 
     #[test]
     fn test_database_url_uses_default_when_env_missing() {
-        let _guard = env_lock().lock().expect("lock");
+        let _guard = env_guard();
         std::env::remove_var("TRUST_DB_URL");
         let value = ArgDispatcher::database_url();
         assert!(
@@ -11320,7 +11385,7 @@ mod tests {
 
     #[test]
     fn test_new_sqlite_dispatcher_initializes_with_custom_db_url() {
-        let _guard = env_lock().lock().expect("lock");
+        let _guard = env_guard();
         let db_path = format!("/tmp/trust-cli-{}.db", Uuid::new_v4());
         std::env::set_var("TRUST_DB_URL", &db_path);
 
@@ -11336,7 +11401,7 @@ mod tests {
 
     #[test]
     fn test_top_level_dispatch_routes_all_command_families_and_external() {
-        let _guard = env_lock().lock().expect("lock");
+        let _guard = env_guard();
         std::env::set_var("TRUST_DISABLE_KEYCHAIN", "1");
         std::env::set_var("TRUST_PROTECTED_KEYWORD_EXPECTED", "secret");
 
@@ -11485,7 +11550,7 @@ mod tests {
 
     #[test]
     fn test_dispatch_level_advisor_and_keys_remaining_subcommands_are_reachable() {
-        let _guard = env_lock().lock().expect("lock");
+        let _guard = env_guard();
         std::env::set_var("TRUST_DISABLE_KEYCHAIN", "1");
         std::env::set_var("TRUST_PROTECTED_KEYWORD_EXPECTED", "secret");
         crate::protected_keyword::delete().expect("reset protected keyword");

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -45,6 +45,7 @@ mod dialogs;
 mod dispatcher;
 mod exporters;
 mod protected_keyword;
+mod trading_vehicle_import;
 mod views;
 
 fn build_keys_subcommand() -> Command {

--- a/cli/src/trading_vehicle_import.rs
+++ b/cli/src/trading_vehicle_import.rs
@@ -1,0 +1,183 @@
+use alpaca_broker::{AlpacaBroker, AssetMetadata};
+use ibkr_broker::{ContractMetadata, IbkrBroker};
+use model::{database::TradingVehicleUpsert, Account, BrokerKind, TradingVehicleCategory};
+
+#[derive(Debug, Clone)]
+pub(crate) struct ImportedTradingVehicle {
+    pub(crate) upsert: TradingVehicleUpsert,
+    pub(crate) summary: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct TradingVehicleImportError {
+    code: &'static str,
+    message: String,
+}
+
+impl TradingVehicleImportError {
+    pub(crate) fn code(&self) -> &'static str {
+        self.code
+    }
+
+    pub(crate) fn message(&self) -> &str {
+        &self.message
+    }
+
+    fn new(code: &'static str, message: impl Into<String>) -> Self {
+        Self {
+            code,
+            message: message.into(),
+        }
+    }
+}
+
+pub(crate) fn import_from_broker(
+    account: &Account,
+    symbol: &str,
+    broker_kind: BrokerKind,
+) -> Result<ImportedTradingVehicle, TradingVehicleImportError> {
+    match broker_kind {
+        BrokerKind::Alpaca => {
+            let metadata =
+                AlpacaBroker::fetch_asset_metadata(account, symbol).map_err(|error| {
+                    TradingVehicleImportError::new("alpaca_import_failed", format!("{error}"))
+                })?;
+            imported_from_alpaca(metadata)
+        }
+        BrokerKind::Ibkr => {
+            let metadata =
+                IbkrBroker::fetch_contract_metadata(account, symbol).map_err(|error| {
+                    TradingVehicleImportError::new("ibkr_import_failed", format!("{error}"))
+                })?;
+            Ok(imported_from_ibkr(metadata))
+        }
+    }
+}
+
+fn imported_from_alpaca(
+    metadata: AssetMetadata,
+) -> Result<ImportedTradingVehicle, TradingVehicleImportError> {
+    if !metadata.is_active {
+        return Err(TradingVehicleImportError::new(
+            "alpaca_import_unavailable",
+            format!("symbol '{}' is inactive", metadata.symbol),
+        ));
+    }
+
+    if !metadata.tradable {
+        return Err(TradingVehicleImportError::new(
+            "alpaca_import_unavailable",
+            format!("symbol '{}' is not tradable", metadata.symbol),
+        ));
+    }
+
+    Ok(ImportedTradingVehicle {
+        upsert: TradingVehicleUpsert {
+            symbol: metadata.symbol.clone(),
+            isin: None,
+            category: metadata.category,
+            broker: "alpaca".to_string(),
+            broker_asset_id: Some(metadata.broker_identifier.clone()),
+            exchange: Some(metadata.exchange.clone()),
+            broker_asset_class: None,
+            broker_asset_status: Some(if metadata.is_active {
+                "active".to_string()
+            } else {
+                "inactive".to_string()
+            }),
+            tradable: Some(metadata.tradable),
+            marginable: Some(metadata.marginable),
+            shortable: Some(metadata.shortable),
+            easy_to_borrow: Some(metadata.easy_to_borrow),
+            fractionable: Some(metadata.fractionable),
+        },
+        summary: format!(
+            "Imported from Alpaca: symbol={}, category={}, exchange={}, tradable={}, marginable={}, shortable={}, fractionable={}, broker_id={}",
+            metadata.symbol,
+            metadata.category,
+            metadata.exchange,
+            metadata.tradable,
+            metadata.marginable,
+            metadata.shortable,
+            metadata.fractionable,
+            metadata.broker_identifier,
+        ),
+    })
+}
+
+fn imported_from_ibkr(metadata: ContractMetadata) -> ImportedTradingVehicle {
+    let exchange = metadata.exchange.clone().or(metadata.description.clone());
+    ImportedTradingVehicle {
+        upsert: TradingVehicleUpsert {
+            symbol: metadata.symbol.clone(),
+            isin: None,
+            category: TradingVehicleCategory::Stock,
+            broker: "ibkr".to_string(),
+            broker_asset_id: Some(metadata.conid.clone()),
+            exchange,
+            broker_asset_class: Some("stock".to_string()),
+            broker_asset_status: None,
+            tradable: None,
+            marginable: None,
+            shortable: None,
+            easy_to_borrow: None,
+            fractionable: None,
+        },
+        summary: format!(
+            "Imported from IBKR: symbol={}, conid={}, exchange={}",
+            metadata.symbol,
+            metadata.conid,
+            metadata.exchange.unwrap_or_else(|| "-".to_string()),
+        ),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{imported_from_alpaca, imported_from_ibkr};
+    use alpaca_broker::AssetMetadata;
+    use ibkr_broker::ContractMetadata;
+    use model::TradingVehicleCategory;
+
+    #[test]
+    fn alpaca_import_rejects_inactive_symbols() {
+        let error = imported_from_alpaca(AssetMetadata {
+            symbol: "AAPL".to_string(),
+            broker_identifier: "asset-1".to_string(),
+            category: TradingVehicleCategory::Stock,
+            exchange: "NASDAQ".to_string(),
+            tradable: true,
+            is_active: false,
+            marginable: true,
+            shortable: true,
+            easy_to_borrow: true,
+            fractionable: true,
+        })
+        .expect_err("inactive symbols should be rejected");
+
+        assert_eq!(error.code(), "alpaca_import_unavailable");
+        assert_eq!(error.message(), "symbol 'AAPL' is inactive");
+    }
+
+    #[test]
+    fn ibkr_import_maps_contract_metadata_into_upsert_shape() {
+        let imported = imported_from_ibkr(ContractMetadata {
+            conid: "265598".to_string(),
+            symbol: "AAPL".to_string(),
+            company_name: Some("Apple Inc".to_string()),
+            description: Some("NASDAQ".to_string()),
+            currency: Some("USD".to_string()),
+            exchange: Some("SMART".to_string()),
+        });
+
+        assert_eq!(imported.upsert.symbol, "AAPL");
+        assert_eq!(imported.upsert.broker, "ibkr");
+        assert_eq!(imported.upsert.broker_asset_id.as_deref(), Some("265598"));
+        assert_eq!(imported.upsert.exchange.as_deref(), Some("SMART"));
+        assert_eq!(imported.upsert.broker_asset_class.as_deref(), Some("stock"));
+        assert_eq!(
+            imported.summary,
+            "Imported from IBKR: symbol=AAPL, conid=265598, exchange=SMART"
+        );
+    }
+}

--- a/cli/src/views/account_view.rs
+++ b/cli/src/views/account_view.rs
@@ -8,6 +8,8 @@ pub struct AccountView {
     pub name: String,
     pub description: String,
     pub env: String,
+    pub broker: String,
+    pub broker_account: String,
 }
 
 impl AccountView {
@@ -16,6 +18,8 @@ impl AccountView {
             name: account.name,
             description: account.description,
             env: account.environment.to_string(),
+            broker: account.broker_kind.to_string(),
+            broker_account: account.broker_account_id.unwrap_or_else(|| "-".to_string()),
         }
     }
 
@@ -93,6 +97,8 @@ mod tests {
         assert_eq!(view.name, "paper");
         assert_eq!(view.description, "test account");
         assert_eq!(view.env, "paper");
+        assert_eq!(view.broker, "alpaca");
+        assert_eq!(view.broker_account, "-");
     }
 
     #[test]

--- a/cli/src/views/execution_view.rs
+++ b/cli/src/views/execution_view.rs
@@ -57,7 +57,7 @@ mod tests {
             trade_id: Some(Uuid::new_v4()),
             order_id: Some(Uuid::new_v4()),
             broker_execution_id: "exec-1".to_string(),
-            broker_order_id: Some(Uuid::new_v4()),
+            broker_order_id: Some(Uuid::new_v4().to_string()),
             symbol: "AAPL".to_string(),
             side: ExecutionSide::Buy,
             qty: dec!(1.5),

--- a/cli/tests/integration_test_account.rs
+++ b/cli/tests/integration_test_account.rs
@@ -8,7 +8,6 @@ use model::{
 use rust_decimal::Decimal;
 use rust_decimal_macros::dec;
 use std::error::Error;
-use uuid::Uuid;
 
 fn create_trust() -> TrustFacade {
     let db = SqliteDatabase::new_in_memory();
@@ -252,6 +251,10 @@ fn test_withdrawal_tax_and_earnings_transactions() {
 
 struct MockBroker;
 impl Broker for MockBroker {
+    fn kind(&self) -> model::BrokerKind {
+        model::BrokerKind::Alpaca
+    }
+
     fn submit_trade(
         &self,
         _trade: &Trade,
@@ -285,7 +288,7 @@ impl Broker for MockBroker {
         trade: &Trade,
         account: &Account,
         new_stop_price: Decimal,
-    ) -> Result<Uuid, Box<dyn Error>> {
+    ) -> Result<String, Box<dyn Error>> {
         unimplemented!(
             "Modify stop: {:?} {:?} {:?}",
             trade,
@@ -299,7 +302,7 @@ impl Broker for MockBroker {
         trade: &Trade,
         account: &Account,
         new_target_price: rust_decimal::Decimal,
-    ) -> Result<Uuid, Box<dyn Error>> {
+    ) -> Result<String, Box<dyn Error>> {
         unimplemented!(
             "Modify target: {:?} {:?} {:?}",
             trade,

--- a/cli/tests/integration_test_bug_hunt.rs
+++ b/cli/tests/integration_test_bug_hunt.rs
@@ -133,6 +133,10 @@ fn create_short_draft(account: &Account, tv: &model::TradingVehicle, qty: i64) -
 struct NoOpBroker;
 
 impl Broker for NoOpBroker {
+    fn kind(&self) -> model::BrokerKind {
+        model::BrokerKind::Alpaca
+    }
+
     fn submit_trade(
         &self,
         _trade: &Trade,
@@ -141,9 +145,9 @@ impl Broker for NoOpBroker {
         Ok((
             BrokerLog::default(),
             OrderIds {
-                entry: Uuid::new_v4(),
-                target: Uuid::new_v4(),
-                stop: Uuid::new_v4(),
+                entry: Uuid::new_v4().to_string(),
+                target: Uuid::new_v4().to_string(),
+                stop: Uuid::new_v4().to_string(),
             },
         ))
     }
@@ -169,16 +173,16 @@ impl Broker for NoOpBroker {
         _trade: &Trade,
         _account: &Account,
         _new_stop_price: Decimal,
-    ) -> Result<Uuid, Box<dyn Error>> {
-        Ok(Uuid::new_v4())
+    ) -> Result<String, Box<dyn Error>> {
+        Ok(Uuid::new_v4().to_string())
     }
     fn modify_target(
         &self,
         _trade: &Trade,
         _account: &Account,
         _new_target_price: Decimal,
-    ) -> Result<Uuid, Box<dyn Error>> {
-        Ok(Uuid::new_v4())
+    ) -> Result<String, Box<dyn Error>> {
+        Ok(Uuid::new_v4().to_string())
     }
 }
 
@@ -188,6 +192,10 @@ struct SyncBroker {
 }
 
 impl Broker for SyncBroker {
+    fn kind(&self) -> model::BrokerKind {
+        model::BrokerKind::Alpaca
+    }
+
     fn submit_trade(
         &self,
         _trade: &Trade,
@@ -196,9 +204,9 @@ impl Broker for SyncBroker {
         Ok((
             BrokerLog::default(),
             OrderIds {
-                entry: Uuid::new_v4(),
-                target: Uuid::new_v4(),
-                stop: Uuid::new_v4(),
+                entry: Uuid::new_v4().to_string(),
+                target: Uuid::new_v4().to_string(),
+                stop: Uuid::new_v4().to_string(),
             },
         ))
     }
@@ -229,16 +237,16 @@ impl Broker for SyncBroker {
         _trade: &Trade,
         _account: &Account,
         _new_stop_price: Decimal,
-    ) -> Result<Uuid, Box<dyn Error>> {
-        Ok(Uuid::new_v4())
+    ) -> Result<String, Box<dyn Error>> {
+        Ok(Uuid::new_v4().to_string())
     }
     fn modify_target(
         &self,
         _trade: &Trade,
         _account: &Account,
         _new_target_price: Decimal,
-    ) -> Result<Uuid, Box<dyn Error>> {
-        Ok(Uuid::new_v4())
+    ) -> Result<String, Box<dyn Error>> {
+        Ok(Uuid::new_v4().to_string())
     }
 }
 
@@ -938,7 +946,7 @@ fn bug_029_double_fund_same_trade() {
 fn make_entry_filled_orders(trade: &Trade) -> (Status, Vec<Order>) {
     let entry = Order {
         id: trade.entry.id,
-        broker_order_id: trade.entry.broker_order_id,
+        broker_order_id: trade.entry.broker_order_id.clone(),
         filled_quantity: trade.entry.quantity,
         average_filled_price: Some(trade.entry.unit_price),
         status: OrderStatus::Filled,
@@ -947,13 +955,13 @@ fn make_entry_filled_orders(trade: &Trade) -> (Status, Vec<Order>) {
     };
     let target = Order {
         id: trade.target.id,
-        broker_order_id: trade.target.broker_order_id,
+        broker_order_id: trade.target.broker_order_id.clone(),
         status: OrderStatus::Accepted,
         ..Default::default()
     };
     let stop = Order {
         id: trade.safety_stop.id,
-        broker_order_id: trade.safety_stop.broker_order_id,
+        broker_order_id: trade.safety_stop.broker_order_id.clone(),
         status: OrderStatus::Held,
         ..Default::default()
     };
@@ -964,7 +972,7 @@ fn make_entry_filled_orders(trade: &Trade) -> (Status, Vec<Order>) {
 fn make_target_filled_orders(trade: &Trade) -> (Status, Vec<Order>) {
     let entry = Order {
         id: trade.entry.id,
-        broker_order_id: trade.entry.broker_order_id,
+        broker_order_id: trade.entry.broker_order_id.clone(),
         filled_quantity: trade.entry.quantity,
         average_filled_price: Some(trade.entry.unit_price),
         status: OrderStatus::Filled,
@@ -973,7 +981,7 @@ fn make_target_filled_orders(trade: &Trade) -> (Status, Vec<Order>) {
     };
     let target = Order {
         id: trade.target.id,
-        broker_order_id: trade.target.broker_order_id,
+        broker_order_id: trade.target.broker_order_id.clone(),
         filled_quantity: trade.target.quantity,
         average_filled_price: Some(trade.target.unit_price),
         status: OrderStatus::Filled,
@@ -982,7 +990,7 @@ fn make_target_filled_orders(trade: &Trade) -> (Status, Vec<Order>) {
     };
     let stop = Order {
         id: trade.safety_stop.id,
-        broker_order_id: trade.safety_stop.broker_order_id,
+        broker_order_id: trade.safety_stop.broker_order_id.clone(),
         status: OrderStatus::Canceled,
         ..Default::default()
     };
@@ -993,7 +1001,7 @@ fn make_target_filled_orders(trade: &Trade) -> (Status, Vec<Order>) {
 fn make_stop_filled_orders(trade: &Trade) -> (Status, Vec<Order>) {
     let entry = Order {
         id: trade.entry.id,
-        broker_order_id: trade.entry.broker_order_id,
+        broker_order_id: trade.entry.broker_order_id.clone(),
         filled_quantity: trade.entry.quantity,
         average_filled_price: Some(trade.entry.unit_price),
         status: OrderStatus::Filled,
@@ -1002,13 +1010,13 @@ fn make_stop_filled_orders(trade: &Trade) -> (Status, Vec<Order>) {
     };
     let target = Order {
         id: trade.target.id,
-        broker_order_id: trade.target.broker_order_id,
+        broker_order_id: trade.target.broker_order_id.clone(),
         status: OrderStatus::Canceled,
         ..Default::default()
     };
     let stop = Order {
         id: trade.safety_stop.id,
-        broker_order_id: trade.safety_stop.broker_order_id,
+        broker_order_id: trade.safety_stop.broker_order_id.clone(),
         filled_quantity: trade.safety_stop.quantity,
         average_filled_price: Some(trade.safety_stop.unit_price),
         status: OrderStatus::Filled,

--- a/cli/tests/integration_test_bug_regressions.rs
+++ b/cli/tests/integration_test_bug_regressions.rs
@@ -12,6 +12,10 @@ use uuid::Uuid;
 struct NoOpBroker;
 
 impl Broker for NoOpBroker {
+    fn kind(&self) -> model::BrokerKind {
+        model::BrokerKind::Alpaca
+    }
+
     fn submit_trade(
         &self,
         _trade: &Trade,
@@ -20,9 +24,9 @@ impl Broker for NoOpBroker {
         Ok((
             BrokerLog::default(),
             OrderIds {
-                entry: Uuid::new_v4(),
-                target: Uuid::new_v4(),
-                stop: Uuid::new_v4(),
+                entry: Uuid::new_v4().to_string(),
+                target: Uuid::new_v4().to_string(),
+                stop: Uuid::new_v4().to_string(),
             },
         ))
     }
@@ -34,7 +38,7 @@ impl Broker for NoOpBroker {
     ) -> Result<(Status, Vec<Order>, BrokerLog), Box<dyn Error>> {
         let entry = Order {
             id: trade.entry.id,
-            broker_order_id: trade.entry.broker_order_id,
+            broker_order_id: trade.entry.broker_order_id.clone(),
             filled_quantity: trade.entry.quantity,
             average_filled_price: Some(trade.entry.unit_price),
             status: model::OrderStatus::Filled,
@@ -43,13 +47,13 @@ impl Broker for NoOpBroker {
         };
         let target = Order {
             id: trade.target.id,
-            broker_order_id: trade.target.broker_order_id,
+            broker_order_id: trade.target.broker_order_id.clone(),
             status: model::OrderStatus::Held,
             ..Default::default()
         };
         let stop = Order {
             id: trade.safety_stop.id,
-            broker_order_id: trade.safety_stop.broker_order_id,
+            broker_order_id: trade.safety_stop.broker_order_id.clone(),
             status: model::OrderStatus::Held,
             ..Default::default()
         };
@@ -81,8 +85,8 @@ impl Broker for NoOpBroker {
         _trade: &Trade,
         _account: &Account,
         _new_stop_price: Decimal,
-    ) -> Result<Uuid, Box<dyn Error>> {
-        Ok(Uuid::new_v4())
+    ) -> Result<String, Box<dyn Error>> {
+        Ok(Uuid::new_v4().to_string())
     }
 
     fn modify_target(
@@ -90,8 +94,8 @@ impl Broker for NoOpBroker {
         _trade: &Trade,
         _account: &Account,
         _new_target_price: Decimal,
-    ) -> Result<Uuid, Box<dyn Error>> {
-        Ok(Uuid::new_v4())
+    ) -> Result<String, Box<dyn Error>> {
+        Ok(Uuid::new_v4().to_string())
     }
 }
 

--- a/cli/tests/integration_test_cancel_trade.rs
+++ b/cli/tests/integration_test_cancel_trade.rs
@@ -8,7 +8,6 @@ use model::{
 use rust_decimal::Decimal;
 use rust_decimal_macros::dec;
 use std::error::Error;
-use uuid::Uuid;
 
 fn create_trust() -> TrustFacade {
     let db = SqliteDatabase::new_in_memory();
@@ -106,6 +105,10 @@ fn test_cancel_of_funded_trade() {
 
 struct MockBroker;
 impl Broker for MockBroker {
+    fn kind(&self) -> model::BrokerKind {
+        model::BrokerKind::Alpaca
+    }
+
     fn submit_trade(
         &self,
         _trade: &Trade,
@@ -139,7 +142,7 @@ impl Broker for MockBroker {
         trade: &Trade,
         account: &Account,
         new_stop_price: Decimal,
-    ) -> Result<Uuid, Box<dyn Error>> {
+    ) -> Result<String, Box<dyn Error>> {
         unimplemented!(
             "Modify stop: {:?} {:?} {:?}",
             trade,
@@ -153,7 +156,7 @@ impl Broker for MockBroker {
         trade: &Trade,
         account: &Account,
         new_target_price: rust_decimal::Decimal,
-    ) -> Result<Uuid, Box<dyn Error>> {
+    ) -> Result<String, Box<dyn Error>> {
         unimplemented!(
             "Modify target: {:?} {:?} {:?}",
             trade,

--- a/cli/tests/integration_test_level.rs
+++ b/cli/tests/integration_test_level.rs
@@ -10,7 +10,6 @@ use model::{
 use rust_decimal::Decimal;
 use rust_decimal_macros::dec;
 use std::error::Error;
-use uuid::Uuid;
 
 fn create_trust() -> TrustFacade {
     let db = SqliteDatabase::new_in_memory();
@@ -492,6 +491,10 @@ fn test_invalid_level_adjustment_rules_are_rejected() {
 struct MockBroker;
 
 impl Broker for MockBroker {
+    fn kind(&self) -> model::BrokerKind {
+        model::BrokerKind::Alpaca
+    }
+
     fn submit_trade(
         &self,
         _trade: &Trade,
@@ -525,7 +528,7 @@ impl Broker for MockBroker {
         _trade: &Trade,
         _account: &Account,
         _new_stop_price: Decimal,
-    ) -> Result<Uuid, Box<dyn Error>> {
+    ) -> Result<String, Box<dyn Error>> {
         unimplemented!()
     }
 
@@ -534,7 +537,7 @@ impl Broker for MockBroker {
         _trade: &Trade,
         _account: &Account,
         _new_price: Decimal,
-    ) -> Result<Uuid, Box<dyn Error>> {
+    ) -> Result<String, Box<dyn Error>> {
         unimplemented!()
     }
 }

--- a/cli/tests/integration_test_level_stress.rs
+++ b/cli/tests/integration_test_level_stress.rs
@@ -263,6 +263,10 @@ fn test_levels_long_run_with_mixed_paths_never_leaves_bounds() {
 struct MockBroker;
 
 impl Broker for MockBroker {
+    fn kind(&self) -> model::BrokerKind {
+        model::BrokerKind::Alpaca
+    }
+
     fn submit_trade(
         &self,
         _trade: &Trade,
@@ -296,7 +300,7 @@ impl Broker for MockBroker {
         _trade: &Trade,
         _account: &Account,
         _new_stop_price: Decimal,
-    ) -> Result<Uuid, Box<dyn Error>> {
+    ) -> Result<String, Box<dyn Error>> {
         unimplemented!()
     }
 
@@ -305,7 +309,7 @@ impl Broker for MockBroker {
         _trade: &Trade,
         _account: &Account,
         _new_price: Decimal,
-    ) -> Result<Uuid, Box<dyn Error>> {
+    ) -> Result<String, Box<dyn Error>> {
         unimplemented!()
     }
 }

--- a/cli/tests/integration_test_risk_guards.rs
+++ b/cli/tests/integration_test_risk_guards.rs
@@ -13,6 +13,10 @@ use uuid::Uuid;
 struct RiskTestBroker;
 
 impl Broker for RiskTestBroker {
+    fn kind(&self) -> model::BrokerKind {
+        model::BrokerKind::Alpaca
+    }
+
     fn submit_trade(
         &self,
         _trade: &Trade,
@@ -21,9 +25,9 @@ impl Broker for RiskTestBroker {
         Ok((
             BrokerLog::default(),
             OrderIds {
-                entry: Uuid::new_v4(),
-                target: Uuid::new_v4(),
-                stop: Uuid::new_v4(),
+                entry: Uuid::new_v4().to_string(),
+                target: Uuid::new_v4().to_string(),
+                stop: Uuid::new_v4().to_string(),
             },
         ))
     }
@@ -35,7 +39,7 @@ impl Broker for RiskTestBroker {
     ) -> Result<(Status, Vec<Order>, BrokerLog), Box<dyn Error>> {
         let entry = Order {
             id: trade.entry.id,
-            broker_order_id: trade.entry.broker_order_id,
+            broker_order_id: trade.entry.broker_order_id.clone(),
             filled_quantity: trade.entry.quantity,
             average_filled_price: Some(trade.entry.unit_price),
             status: model::OrderStatus::Filled,
@@ -44,13 +48,13 @@ impl Broker for RiskTestBroker {
         };
         let target = Order {
             id: trade.target.id,
-            broker_order_id: trade.target.broker_order_id,
+            broker_order_id: trade.target.broker_order_id.clone(),
             status: model::OrderStatus::Held,
             ..Default::default()
         };
         let stop = Order {
             id: trade.safety_stop.id,
-            broker_order_id: trade.safety_stop.broker_order_id,
+            broker_order_id: trade.safety_stop.broker_order_id.clone(),
             status: model::OrderStatus::Held,
             ..Default::default()
         };
@@ -82,8 +86,8 @@ impl Broker for RiskTestBroker {
         _trade: &Trade,
         _account: &Account,
         _new_stop_price: Decimal,
-    ) -> Result<Uuid, Box<dyn Error>> {
-        Ok(Uuid::new_v4())
+    ) -> Result<String, Box<dyn Error>> {
+        Ok(Uuid::new_v4().to_string())
     }
 
     fn modify_target(
@@ -91,8 +95,8 @@ impl Broker for RiskTestBroker {
         _trade: &Trade,
         _account: &Account,
         _new_target_price: Decimal,
-    ) -> Result<Uuid, Box<dyn Error>> {
-        Ok(Uuid::new_v4())
+    ) -> Result<String, Box<dyn Error>> {
+        Ok(Uuid::new_v4().to_string())
     }
 }
 

--- a/cli/tests/integration_test_trade.rs
+++ b/cli/tests/integration_test_trade.rs
@@ -687,7 +687,7 @@ fn test_trade_modify_stop_long() {
     assert_eq!(trade.safety_stop.unit_price, dec!(39));
     assert_eq!(
         trade.safety_stop.broker_order_id.unwrap(),
-        Uuid::parse_str("7654f70e-3b42-4014-a9ac-5a7101989aad").unwrap()
+        "7654f70e-3b42-4014-a9ac-5a7101989aad"
     );
 }
 
@@ -728,7 +728,7 @@ fn test_trade_modify_target() {
     assert_eq!(trade.target.unit_price, dec!(100.1));
     assert_eq!(
         trade.target.broker_order_id.unwrap(),
-        Uuid::parse_str("5654f70e-3b42-4014-a9ac-5a7101989aad").unwrap()
+        "5654f70e-3b42-4014-a9ac-5a7101989aad"
     );
 }
 
@@ -738,7 +738,7 @@ impl BrokerResponse {
     fn orders_accepted(trade: &Trade) -> (Status, Vec<Order>) {
         let entry = Order {
             id: trade.entry.id,
-            broker_order_id: Some(Uuid::parse_str("b6b12dc0-8e21-4d2e-8315-907d3116a6b8").unwrap()),
+            broker_order_id: Some("b6b12dc0-8e21-4d2e-8315-907d3116a6b8".to_string()),
             filled_quantity: 0,
             average_filled_price: None,
             status: OrderStatus::Accepted,
@@ -750,7 +750,7 @@ impl BrokerResponse {
 
         let target = Order {
             id: trade.target.id,
-            broker_order_id: Some(Uuid::parse_str("b6b12dc0-8e21-4d2e-8315-907d3116a6b8").unwrap()),
+            broker_order_id: Some("b6b12dc0-8e21-4d2e-8315-907d3116a6b8".to_string()),
             filled_quantity: 0,
             average_filled_price: None,
             status: OrderStatus::Held,
@@ -762,7 +762,7 @@ impl BrokerResponse {
 
         let stop = Order {
             id: trade.safety_stop.id,
-            broker_order_id: Some(Uuid::parse_str("b6b12dc0-8e21-4d2e-8315-907d3116a6b8").unwrap()),
+            broker_order_id: Some("b6b12dc0-8e21-4d2e-8315-907d3116a6b8".to_string()),
             filled_quantity: 0,
             average_filled_price: None,
             status: OrderStatus::Held,
@@ -778,7 +778,7 @@ impl BrokerResponse {
     fn orders_entry_filled(trade: &Trade) -> (Status, Vec<Order>) {
         let entry = Order {
             id: trade.entry.id,
-            broker_order_id: Some(Uuid::parse_str("b6b12dc0-8e21-4d2e-8315-907d3116a6b8").unwrap()),
+            broker_order_id: Some("b6b12dc0-8e21-4d2e-8315-907d3116a6b8".to_string()),
             filled_quantity: 500,
             average_filled_price: Some(dec!(39.9)),
             status: OrderStatus::Filled,
@@ -790,7 +790,7 @@ impl BrokerResponse {
 
         let target = Order {
             id: trade.target.id,
-            broker_order_id: Some(Uuid::parse_str("b6b12dc0-8e21-4d2e-8315-907d3116a6b8").unwrap()),
+            broker_order_id: Some("b6b12dc0-8e21-4d2e-8315-907d3116a6b8".to_string()),
             filled_quantity: 0,
             average_filled_price: None,
             status: OrderStatus::Accepted,
@@ -802,7 +802,7 @@ impl BrokerResponse {
 
         let stop = Order {
             id: trade.safety_stop.id,
-            broker_order_id: Some(Uuid::parse_str("b6b12dc0-8e21-4d2e-8315-907d3116a6b8").unwrap()),
+            broker_order_id: Some("b6b12dc0-8e21-4d2e-8315-907d3116a6b8".to_string()),
             filled_quantity: 0,
             average_filled_price: None,
             status: OrderStatus::Held,
@@ -818,7 +818,7 @@ impl BrokerResponse {
     fn orders_target_filled(trade: &Trade) -> (Status, Vec<Order>) {
         let entry = Order {
             id: trade.entry.id,
-            broker_order_id: Some(Uuid::parse_str("b6b12dc0-8e21-4d2e-8315-907d3116a6b8").unwrap()),
+            broker_order_id: Some("b6b12dc0-8e21-4d2e-8315-907d3116a6b8".to_string()),
             filled_quantity: 500,
             average_filled_price: Some(dec!(39.9)),
             status: OrderStatus::Filled,
@@ -830,7 +830,7 @@ impl BrokerResponse {
 
         let target = Order {
             id: trade.target.id,
-            broker_order_id: Some(Uuid::parse_str("b6b12dc0-8e21-4d2e-8315-907d3116a6b8").unwrap()),
+            broker_order_id: Some("b6b12dc0-8e21-4d2e-8315-907d3116a6b8".to_string()),
             filled_quantity: 500,
             average_filled_price: Some(dec!(52.9)),
             status: OrderStatus::Filled,
@@ -842,7 +842,7 @@ impl BrokerResponse {
 
         let stop = Order {
             id: trade.safety_stop.id,
-            broker_order_id: Some(Uuid::parse_str("b6b12dc0-8e21-4d2e-8315-907d3116a6b8").unwrap()),
+            broker_order_id: Some("b6b12dc0-8e21-4d2e-8315-907d3116a6b8".to_string()),
             filled_quantity: 0,
             average_filled_price: None,
             status: OrderStatus::Canceled,
@@ -858,7 +858,7 @@ impl BrokerResponse {
     fn orders_stop_filled(trade: &Trade) -> (Status, Vec<Order>) {
         let entry = Order {
             id: trade.entry.id,
-            broker_order_id: Some(Uuid::parse_str("b6b12dc0-8e21-4d2e-8315-907d3116a6b8").unwrap()),
+            broker_order_id: Some("b6b12dc0-8e21-4d2e-8315-907d3116a6b8".to_string()),
             filled_quantity: 500,
             average_filled_price: Some(dec!(39.9)),
             status: OrderStatus::Filled,
@@ -870,7 +870,7 @@ impl BrokerResponse {
 
         let target = Order {
             id: trade.target.id,
-            broker_order_id: Some(Uuid::parse_str("b6b12dc0-8e21-4d2e-8315-907d3116a6b8").unwrap()),
+            broker_order_id: Some("b6b12dc0-8e21-4d2e-8315-907d3116a6b8".to_string()),
             filled_quantity: 0,
             average_filled_price: None,
             status: OrderStatus::Canceled,
@@ -882,7 +882,7 @@ impl BrokerResponse {
 
         let stop = Order {
             id: trade.safety_stop.id,
-            broker_order_id: Some(Uuid::parse_str("b6b12dc0-8e21-4d2e-8315-907d3116a6b8").unwrap()),
+            broker_order_id: Some("b6b12dc0-8e21-4d2e-8315-907d3116a6b8".to_string()),
             filled_quantity: 500,
             average_filled_price: Some(dec!(39)),
             status: OrderStatus::Filled,
@@ -898,7 +898,7 @@ impl BrokerResponse {
     fn orders_stop_filled_slippage(trade: &Trade) -> (Status, Vec<Order>) {
         let entry = Order {
             id: trade.entry.id,
-            broker_order_id: Some(Uuid::parse_str("b6b12dc0-8e21-4d2e-8315-907d3116a6b8").unwrap()),
+            broker_order_id: Some("b6b12dc0-8e21-4d2e-8315-907d3116a6b8".to_string()),
             filled_quantity: 500,
             average_filled_price: Some(dec!(39.9)),
             status: OrderStatus::Filled,
@@ -910,7 +910,7 @@ impl BrokerResponse {
 
         let stop = Order {
             id: trade.safety_stop.id,
-            broker_order_id: Some(Uuid::parse_str("b6b12dc0-8e21-4d2e-8315-907d3116a6b8").unwrap()),
+            broker_order_id: Some("b6b12dc0-8e21-4d2e-8315-907d3116a6b8".to_string()),
             filled_quantity: 500,
             average_filled_price: Some(dec!(30.2)),
             status: OrderStatus::Filled,
@@ -926,7 +926,7 @@ impl BrokerResponse {
     fn closed_order(trade: &Trade) -> Option<Order> {
         Some(Order {
             id: trade.target.id,
-            broker_order_id: Some(Uuid::parse_str("b6b12dc0-8e21-4d2e-8315-907d3116a6b8").unwrap()),
+            broker_order_id: Some("b6b12dc0-8e21-4d2e-8315-907d3116a6b8".to_string()),
             status: OrderStatus::PendingNew,
             category: OrderCategory::Market,
             filled_at: None,
@@ -955,6 +955,10 @@ impl MockBroker {
 }
 
 impl Broker for MockBroker {
+    fn kind(&self) -> model::BrokerKind {
+        model::BrokerKind::Alpaca
+    }
+
     fn submit_trade(
         &self,
         _trade: &Trade,
@@ -962,9 +966,9 @@ impl Broker for MockBroker {
     ) -> Result<(BrokerLog, OrderIds), Box<dyn Error>> {
         let log = BrokerLog::default();
         let ids = OrderIds {
-            entry: Uuid::parse_str("b6b12dc0-8e21-4d2e-8315-907d3116a6b8").unwrap(),
-            target: Uuid::parse_str("90e41b1e-9089-444d-9f68-c204a4d32914").unwrap(),
-            stop: Uuid::parse_str("8654f70e-3b42-4014-a9ac-5a7101989aad").unwrap(),
+            entry: "b6b12dc0-8e21-4d2e-8315-907d3116a6b8".to_string(),
+            target: "90e41b1e-9089-444d-9f68-c204a4d32914".to_string(),
+            stop: "8654f70e-3b42-4014-a9ac-5a7101989aad".to_string(),
         };
         Ok((log, ids))
     }
@@ -998,12 +1002,12 @@ impl Broker for MockBroker {
         trade: &Trade,
         account: &Account,
         new_stop_price: Decimal,
-    ) -> Result<Uuid, Box<dyn Error>> {
+    ) -> Result<String, Box<dyn Error>> {
         assert_eq!(trade.account_id, account.id);
         assert_eq!(trade.safety_stop.unit_price, dec!(38));
         assert_eq!(new_stop_price, dec!(39));
 
-        Ok(Uuid::parse_str("7654f70e-3b42-4014-a9ac-5a7101989aad").unwrap())
+        Ok("7654f70e-3b42-4014-a9ac-5a7101989aad".to_string())
     }
 
     fn modify_target(
@@ -1011,12 +1015,12 @@ impl Broker for MockBroker {
         trade: &Trade,
         account: &Account,
         new_target_price: rust_decimal::Decimal,
-    ) -> Result<Uuid, Box<dyn Error>> {
+    ) -> Result<String, Box<dyn Error>> {
         assert_eq!(trade.account_id, account.id);
         assert_eq!(trade.target.unit_price, dec!(50));
         assert_eq!(new_target_price, dec!(100.1));
 
-        Ok(Uuid::parse_str("5654f70e-3b42-4014-a9ac-5a7101989aad").unwrap())
+        Ok("5654f70e-3b42-4014-a9ac-5a7101989aad".to_string())
     }
 }
 
@@ -1158,7 +1162,7 @@ fn test_short_trade_funding_with_better_entry_execution() {
 fn orders_short_trade_filled(trade: &Trade) -> (Status, Vec<Order>) {
     let entry = Order {
         id: trade.entry.id,
-        broker_order_id: Some(Uuid::new_v4()),
+        broker_order_id: Some(Uuid::new_v4().to_string()),
         filled_quantity: trade.entry.quantity,
         average_filled_price: Some(dec!(11)), // Better than expected $10
         status: OrderStatus::Filled,
@@ -1168,14 +1172,14 @@ fn orders_short_trade_filled(trade: &Trade) -> (Status, Vec<Order>) {
 
     let target = Order {
         id: trade.target.id,
-        broker_order_id: Some(Uuid::new_v4()),
+        broker_order_id: Some(Uuid::new_v4().to_string()),
         status: OrderStatus::Accepted,
         ..Default::default()
     };
 
     let stop = Order {
         id: trade.safety_stop.id,
-        broker_order_id: Some(Uuid::new_v4()),
+        broker_order_id: Some(Uuid::new_v4().to_string()),
         status: OrderStatus::Held,
         ..Default::default()
     };

--- a/cli/tests/integration_test_trading_vehicle_alpaca.rs
+++ b/cli/tests/integration_test_trading_vehicle_alpaca.rs
@@ -94,7 +94,7 @@ fn test_create_from_alpaca_requires_account() {
 
     assert!(!output.status.success(), "command should fail");
     let stderr = String::from_utf8_lossy(&output.stderr);
-    assert!(stderr.contains("alpaca_import_invalid_args"));
+    assert!(stderr.contains("broker_import_invalid_args"));
     assert!(stderr.contains("--account is required"));
 }
 
@@ -121,7 +121,7 @@ fn test_create_from_alpaca_requires_symbol() {
 
     assert!(!output.status.success(), "command should fail");
     let stderr = String::from_utf8_lossy(&output.stderr);
-    assert!(stderr.contains("alpaca_import_invalid_args"));
+    assert!(stderr.contains("broker_import_invalid_args"));
     assert!(stderr.contains("--symbol is required"));
 }
 
@@ -150,5 +150,5 @@ fn test_create_from_alpaca_unknown_account_fails() {
 
     assert!(!output.status.success(), "command should fail");
     let stderr = String::from_utf8_lossy(&output.stderr);
-    assert!(stderr.contains("alpaca_import_account_not_found"));
+    assert!(stderr.contains("broker_import_account_not_found"));
 }

--- a/cli/tests/integration_test_use_cases.rs
+++ b/cli/tests/integration_test_use_cases.rs
@@ -27,8 +27,8 @@ struct BrokerState {
     modify_stop_error: Option<String>,
     modify_target_error: Option<String>,
     sync_queue: VecDeque<SyncOutcome>,
-    modify_stop_id: Uuid,
-    modify_target_id: Uuid,
+    modify_stop_id: String,
+    modify_target_id: String,
 }
 
 #[derive(Clone, Debug)]
@@ -46,8 +46,8 @@ impl TestBroker {
                 modify_stop_error: None,
                 modify_target_error: None,
                 sync_queue: VecDeque::new(),
-                modify_stop_id: Uuid::from_u128(0x11111111111111111111111111111111),
-                modify_target_id: Uuid::from_u128(0x22222222222222222222222222222222),
+                modify_stop_id: Uuid::from_u128(0x11111111111111111111111111111111).to_string(),
+                modify_target_id: Uuid::from_u128(0x22222222222222222222222222222222).to_string(),
             })),
         }
     }
@@ -72,19 +72,28 @@ impl TestBroker {
             .push_back(outcome);
     }
 
-    fn modify_stop_id(&self) -> Uuid {
-        self.state.lock().expect("broker state lock").modify_stop_id
+    fn modify_stop_id(&self) -> String {
+        self.state
+            .lock()
+            .expect("broker state lock")
+            .modify_stop_id
+            .clone()
     }
 
-    fn modify_target_id(&self) -> Uuid {
+    fn modify_target_id(&self) -> String {
         self.state
             .lock()
             .expect("broker state lock")
             .modify_target_id
+            .clone()
     }
 }
 
 impl Broker for TestBroker {
+    fn kind(&self) -> model::BrokerKind {
+        model::BrokerKind::Alpaca
+    }
+
     fn submit_trade(
         &self,
         trade: &Trade,
@@ -102,9 +111,9 @@ impl Broker for TestBroker {
         };
 
         let ids = OrderIds {
-            entry: Uuid::from_u128(0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa),
-            target: Uuid::from_u128(0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb),
-            stop: Uuid::from_u128(0xcccccccccccccccccccccccccccccccc),
+            entry: Uuid::from_u128(0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa).to_string(),
+            target: Uuid::from_u128(0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb).to_string(),
+            stop: Uuid::from_u128(0xcccccccccccccccccccccccccccccccc).to_string(),
         };
 
         Ok((log, ids))
@@ -170,12 +179,12 @@ impl Broker for TestBroker {
         _trade: &Trade,
         _account: &Account,
         _new_stop_price: Decimal,
-    ) -> Result<Uuid, Box<dyn Error>> {
+    ) -> Result<String, Box<dyn Error>> {
         let state = self.state.lock().expect("broker state lock");
         if let Some(message) = &state.modify_stop_error {
             return Err(message.clone().into());
         }
-        Ok(state.modify_stop_id)
+        Ok(state.modify_stop_id.clone())
     }
 
     fn modify_target(
@@ -183,12 +192,12 @@ impl Broker for TestBroker {
         _trade: &Trade,
         _account: &Account,
         _new_target_price: Decimal,
-    ) -> Result<Uuid, Box<dyn Error>> {
+    ) -> Result<String, Box<dyn Error>> {
         let state = self.state.lock().expect("broker state lock");
         if let Some(message) = &state.modify_target_error {
             return Err(message.clone().into());
         }
-        Ok(state.modify_target_id)
+        Ok(state.modify_target_id.clone())
     }
 }
 

--- a/core/src/broker_registry.rs
+++ b/core/src/broker_registry.rs
@@ -1,0 +1,360 @@
+use chrono::{DateTime, Utc};
+use model::{
+    Account, BarTimeframe, Broker, BrokerKind, BrokerLog, Execution, FeeActivity, MarketBar,
+    MarketDataChannel, MarketDataStreamEvent, MarketQuote, MarketTradeTick, Order, OrderIds,
+    Status, Trade,
+};
+use rust_decimal::Decimal;
+use std::collections::HashMap;
+use std::error::Error;
+
+pub(crate) struct BrokerRegistry {
+    brokers: HashMap<BrokerKind, Box<dyn Broker>>,
+    fallback_kind: BrokerKind,
+}
+
+impl BrokerRegistry {
+    pub(crate) fn from_single(broker: Box<dyn Broker>) -> Self {
+        let fallback_kind = broker.kind();
+        let mut brokers = HashMap::new();
+        brokers.insert(fallback_kind, broker);
+        Self {
+            brokers,
+            fallback_kind,
+        }
+    }
+
+    pub(crate) fn from_many(brokers: Vec<Box<dyn Broker>>) -> Self {
+        let mut brokers_by_kind = HashMap::new();
+        let mut fallback_kind = BrokerKind::Alpaca;
+
+        for (index, broker) in brokers.into_iter().enumerate() {
+            let kind = broker.kind();
+            if index == 0 {
+                fallback_kind = kind;
+            }
+            brokers_by_kind.insert(kind, broker);
+        }
+
+        Self {
+            brokers: brokers_by_kind,
+            fallback_kind,
+        }
+    }
+
+    fn broker_for_account(&self, account: &Account) -> Result<&dyn Broker, Box<dyn Error>> {
+        self.brokers
+            .get(&account.broker_kind)
+            .map(Box::as_ref)
+            .ok_or_else(|| {
+                format!(
+                    "broker '{}' is not configured for account '{}'",
+                    account.broker_kind, account.name
+                )
+                .into()
+            })
+    }
+}
+
+impl std::fmt::Debug for BrokerRegistry {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let configured: Vec<&'static str> = self.brokers.keys().map(BrokerKind::as_str).collect();
+        f.debug_struct("BrokerRegistry")
+            .field("configured", &configured)
+            .field("fallback_kind", &self.fallback_kind)
+            .finish()
+    }
+}
+
+impl Broker for BrokerRegistry {
+    fn kind(&self) -> BrokerKind {
+        self.fallback_kind
+    }
+
+    fn submit_trade(
+        &self,
+        trade: &Trade,
+        account: &Account,
+    ) -> Result<(BrokerLog, OrderIds), Box<dyn Error>> {
+        self.broker_for_account(account)?
+            .submit_trade(trade, account)
+    }
+
+    fn sync_trade(
+        &self,
+        trade: &Trade,
+        account: &Account,
+    ) -> Result<(Status, Vec<Order>, BrokerLog), Box<dyn Error>> {
+        self.broker_for_account(account)?.sync_trade(trade, account)
+    }
+
+    fn close_trade(
+        &self,
+        trade: &Trade,
+        account: &Account,
+    ) -> Result<(Order, BrokerLog), Box<dyn Error>> {
+        self.broker_for_account(account)?
+            .close_trade(trade, account)
+    }
+
+    fn cancel_trade(&self, trade: &Trade, account: &Account) -> Result<(), Box<dyn Error>> {
+        self.broker_for_account(account)?
+            .cancel_trade(trade, account)
+    }
+
+    fn modify_stop(
+        &self,
+        trade: &Trade,
+        account: &Account,
+        new_stop_price: Decimal,
+    ) -> Result<String, Box<dyn Error>> {
+        self.broker_for_account(account)?
+            .modify_stop(trade, account, new_stop_price)
+    }
+
+    fn modify_target(
+        &self,
+        trade: &Trade,
+        account: &Account,
+        new_price: Decimal,
+    ) -> Result<String, Box<dyn Error>> {
+        self.broker_for_account(account)?
+            .modify_target(trade, account, new_price)
+    }
+
+    fn get_bars(
+        &self,
+        symbol: &str,
+        start: DateTime<Utc>,
+        end: DateTime<Utc>,
+        timeframe: BarTimeframe,
+        account: &Account,
+    ) -> Result<Vec<MarketBar>, Box<dyn Error>> {
+        self.broker_for_account(account)?
+            .get_bars(symbol, start, end, timeframe, account)
+    }
+
+    fn get_latest_quote(
+        &self,
+        symbol: &str,
+        account: &Account,
+    ) -> Result<MarketQuote, Box<dyn Error>> {
+        self.broker_for_account(account)?
+            .get_latest_quote(symbol, account)
+    }
+
+    fn get_latest_trade(
+        &self,
+        symbol: &str,
+        account: &Account,
+    ) -> Result<MarketTradeTick, Box<dyn Error>> {
+        self.broker_for_account(account)?
+            .get_latest_trade(symbol, account)
+    }
+
+    fn stream_market_data(
+        &self,
+        symbols: &[String],
+        channels: &[MarketDataChannel],
+        max_events: usize,
+        timeout_seconds: u64,
+        account: &Account,
+    ) -> Result<Vec<MarketDataStreamEvent>, Box<dyn Error>> {
+        self.broker_for_account(account)?.stream_market_data(
+            symbols,
+            channels,
+            max_events,
+            timeout_seconds,
+            account,
+        )
+    }
+
+    fn fetch_executions(
+        &self,
+        trade: &Trade,
+        account: &Account,
+        after: Option<DateTime<Utc>>,
+    ) -> Result<Vec<Execution>, Box<dyn Error>> {
+        self.broker_for_account(account)?
+            .fetch_executions(trade, account, after)
+    }
+
+    fn fetch_fee_activities(
+        &self,
+        trade: &Trade,
+        account: &Account,
+        after: Option<DateTime<Utc>>,
+    ) -> Result<Vec<FeeActivity>, Box<dyn Error>> {
+        self.broker_for_account(account)?
+            .fetch_fee_activities(trade, account, after)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::BrokerRegistry;
+    use model::{
+        Account, Broker, BrokerKind, BrokerLog, Execution, FeeActivity, MarketBar,
+        MarketDataChannel, MarketDataStreamEvent, MarketQuote, MarketTradeTick, Order, OrderIds,
+        Status, Trade,
+    };
+    use rust_decimal::Decimal;
+    use std::error::Error;
+
+    struct StubBroker {
+        kind: BrokerKind,
+    }
+
+    impl StubBroker {
+        fn new(kind: BrokerKind) -> Self {
+            Self { kind }
+        }
+    }
+
+    impl Broker for StubBroker {
+        fn kind(&self) -> BrokerKind {
+            self.kind
+        }
+
+        fn submit_trade(
+            &self,
+            _trade: &Trade,
+            _account: &Account,
+        ) -> Result<(BrokerLog, OrderIds), Box<dyn Error>> {
+            Ok((
+                BrokerLog::default(),
+                OrderIds {
+                    stop: format!("{}-stop", self.kind),
+                    entry: format!("{}-entry", self.kind),
+                    target: format!("{}-target", self.kind),
+                },
+            ))
+        }
+
+        fn sync_trade(
+            &self,
+            _trade: &Trade,
+            _account: &Account,
+        ) -> Result<(Status, Vec<Order>, BrokerLog), Box<dyn Error>> {
+            Ok((Status::Submitted, vec![], BrokerLog::default()))
+        }
+
+        fn close_trade(
+            &self,
+            _trade: &Trade,
+            _account: &Account,
+        ) -> Result<(Order, BrokerLog), Box<dyn Error>> {
+            Ok((Order::default(), BrokerLog::default()))
+        }
+
+        fn cancel_trade(&self, _trade: &Trade, _account: &Account) -> Result<(), Box<dyn Error>> {
+            Ok(())
+        }
+
+        fn modify_stop(
+            &self,
+            _trade: &Trade,
+            _account: &Account,
+            _new_stop_price: Decimal,
+        ) -> Result<String, Box<dyn Error>> {
+            Ok(format!("{}-stop", self.kind))
+        }
+
+        fn modify_target(
+            &self,
+            _trade: &Trade,
+            _account: &Account,
+            _new_price: Decimal,
+        ) -> Result<String, Box<dyn Error>> {
+            Ok(format!("{}-target", self.kind))
+        }
+
+        fn get_bars(
+            &self,
+            _symbol: &str,
+            _start: chrono::DateTime<chrono::Utc>,
+            _end: chrono::DateTime<chrono::Utc>,
+            _timeframe: model::BarTimeframe,
+            _account: &Account,
+        ) -> Result<Vec<MarketBar>, Box<dyn Error>> {
+            Ok(vec![])
+        }
+
+        fn get_latest_quote(
+            &self,
+            _symbol: &str,
+            _account: &Account,
+        ) -> Result<MarketQuote, Box<dyn Error>> {
+            Err("not used".into())
+        }
+
+        fn get_latest_trade(
+            &self,
+            _symbol: &str,
+            _account: &Account,
+        ) -> Result<MarketTradeTick, Box<dyn Error>> {
+            Err("not used".into())
+        }
+
+        fn stream_market_data(
+            &self,
+            _symbols: &[String],
+            _channels: &[MarketDataChannel],
+            _max_events: usize,
+            _timeout_seconds: u64,
+            _account: &Account,
+        ) -> Result<Vec<MarketDataStreamEvent>, Box<dyn Error>> {
+            Ok(vec![])
+        }
+
+        fn fetch_executions(
+            &self,
+            _trade: &Trade,
+            _account: &Account,
+            _after: Option<chrono::DateTime<chrono::Utc>>,
+        ) -> Result<Vec<Execution>, Box<dyn Error>> {
+            Ok(vec![])
+        }
+
+        fn fetch_fee_activities(
+            &self,
+            _trade: &Trade,
+            _account: &Account,
+            _after: Option<chrono::DateTime<chrono::Utc>>,
+        ) -> Result<Vec<FeeActivity>, Box<dyn Error>> {
+            Ok(vec![])
+        }
+    }
+
+    #[test]
+    fn registry_routes_submit_trade_by_account_broker_kind() {
+        let registry = BrokerRegistry::from_many(vec![
+            Box::new(StubBroker::new(BrokerKind::Alpaca)),
+            Box::new(StubBroker::new(BrokerKind::Ibkr)),
+        ]);
+
+        let account = Account {
+            broker_kind: BrokerKind::Ibkr,
+            ..Account::default()
+        };
+
+        let (_, ids) = registry.submit_trade(&Trade::default(), &account).unwrap();
+        assert_eq!(ids.entry, "ibkr-entry");
+    }
+
+    #[test]
+    fn registry_returns_clear_error_when_account_broker_is_not_registered() {
+        let registry = BrokerRegistry::from_single(Box::new(StubBroker::new(BrokerKind::Alpaca)));
+        let account = Account {
+            broker_kind: BrokerKind::Ibkr,
+            name: "ibkr-main".to_string(),
+            ..Account::default()
+        };
+
+        let err = registry
+            .submit_trade(&Trade::default(), &account)
+            .expect_err("missing broker should fail");
+        assert!(err.to_string().contains("ibkr"));
+        assert!(err.to_string().contains("ibkr-main"));
+    }
+}

--- a/core/src/commands/order.rs
+++ b/core/src/commands/order.rs
@@ -97,7 +97,7 @@ pub fn record_timestamp_target(
 pub fn modify(
     order: &Order,
     new_price: Decimal,
-    broker_id: Uuid,
+    broker_id: String,
     write_database: &mut dyn OrderWrite,
 ) -> Result<Order, Box<dyn std::error::Error>> {
     let stop = write_database.update_price(order, new_price, broker_id)?;

--- a/core/src/commands/trade.rs
+++ b/core/src/commands/trade.rs
@@ -583,9 +583,9 @@ fn persist_executions_for_trade(
     executions: &[model::Execution],
 ) -> Result<(), Box<dyn Error>> {
     let trade_symbol = trade.trading_vehicle.symbol.as_str();
-    let entry_broker_id = trade.entry.broker_order_id;
-    let target_broker_id = trade.target.broker_order_id;
-    let stop_broker_id = trade.safety_stop.broker_order_id;
+    let entry_broker_id = trade.entry.broker_order_id.as_deref();
+    let target_broker_id = trade.target.broker_order_id.as_deref();
+    let stop_broker_id = trade.safety_stop.broker_order_id.as_deref();
 
     let mut write = database.execution_write();
     for exec in executions {
@@ -616,7 +616,7 @@ fn persist_executions_for_trade(
             continue;
         }
 
-        let Some(broker_order_id) = exec.broker_order_id else {
+        let Some(broker_order_id) = exec.broker_order_id.as_deref() else {
             continue;
         };
 
@@ -670,7 +670,7 @@ fn derive_trade_update_executions(
         {
             continue;
         }
-        let Some(broker_order_id) = updated_order.broker_order_id else {
+        let Some(broker_order_id) = updated_order.broker_order_id.clone() else {
             continue;
         };
         let Some(price) = updated_order.average_filled_price else {
@@ -795,13 +795,13 @@ fn allocated_fee_totals_for_trade(trade: &Trade, fees: &[FeeActivity]) -> (Decim
 
     for fee in fees {
         // Direct matching by broker order id has highest priority.
-        if let Some(fee_order_id) = fee.broker_order_id {
-            if trade.entry.broker_order_id == Some(fee_order_id) {
+        if let Some(fee_order_id) = fee.broker_order_id.as_deref() {
+            if trade.entry.broker_order_id.as_deref() == Some(fee_order_id) {
                 open = open.checked_add(fee.amount).unwrap_or(open);
                 continue;
             }
-            if trade.target.broker_order_id == Some(fee_order_id)
-                || trade.safety_stop.broker_order_id == Some(fee_order_id)
+            if trade.target.broker_order_id.as_deref() == Some(fee_order_id)
+                || trade.safety_stop.broker_order_id.as_deref() == Some(fee_order_id)
             {
                 close = close.checked_add(fee.amount).unwrap_or(close);
                 continue;
@@ -922,7 +922,7 @@ struct ResolvedSyncOrders {
 
 fn merge_sync_order_state(base: &Order, update: &Order) -> Order {
     let mut merged = base.clone();
-    merged.broker_order_id = update.broker_order_id;
+    merged.broker_order_id = update.broker_order_id.clone();
     merged.status = update.status;
     merged.filled_quantity = update.filled_quantity;
     merged.average_filled_price = update.average_filled_price;
@@ -1130,7 +1130,7 @@ mod tests {
             ..Trade::default()
         };
         previous.trading_vehicle.symbol = "AAPL".to_string();
-        previous.entry.broker_order_id = Some(Uuid::new_v4());
+        previous.entry.broker_order_id = Some(Uuid::new_v4().to_string());
         previous.entry.filled_quantity = 5;
         previous.entry.average_filled_price = Some(dec!(100.50));
 
@@ -1146,7 +1146,7 @@ mod tests {
                 .and_hms_opt(10, 0, 0)
                 .unwrap(),
         );
-        resolved.target.broker_order_id = Some(Uuid::new_v4());
+        resolved.target.broker_order_id = Some(Uuid::new_v4().to_string());
         resolved.target.filled_quantity = 10;
         resolved.target.average_filled_price = Some(dec!(102.75));
         resolved.target.filled_at = Some(

--- a/core/src/integration_tests.rs
+++ b/core/src/integration_tests.rs
@@ -6,7 +6,7 @@
 #![allow(clippy::cognitive_complexity)]
 
 use chrono::Utc;
-use model::{Account, AccountType, Currency, Environment, Trade, TradeBalance};
+use model::{Account, AccountType, BrokerKind, Currency, Environment, Trade, TradeBalance};
 use rust_decimal::Decimal;
 use rust_decimal_macros::dec;
 use std::error::Error;
@@ -409,6 +409,8 @@ impl IntegrationTestSuite {
             earnings_percentage: dec!(30.0),
             account_type: model::AccountType::Primary,
             parent_account_id: Some(Uuid::new_v4()), // Invalid!
+            broker_kind: BrokerKind::Alpaca,
+            broker_account_id: None,
         };
 
         // This would be caught by validation in real system
@@ -510,6 +512,8 @@ impl IntegrationTestSuite {
             earnings_percentage: dec!(30.0),
             account_type,
             parent_account_id: parent_id,
+            broker_kind: BrokerKind::Alpaca,
+            broker_account_id: None,
         })
     }
 

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -38,13 +38,14 @@ use argon2::{
     password_hash::{PasswordHash, PasswordHasher, PasswordVerifier, SaltString},
     Argon2,
 };
+use broker_registry::BrokerRegistry;
 use calculators_trade::{
     LevelAdjustedQuantity, QuantityCalculator, TradeHypothesis, TradeHypothesisCalculator,
 };
 use events::trade::{CloseReason, TradeClosed};
 use model::database::TradingVehicleUpsert;
 use model::{
-    Account, AccountBalance, AccountType, BarTimeframe, Broker, BrokerLog, Currency,
+    Account, AccountBalance, AccountType, BarTimeframe, Broker, BrokerKind, BrokerLog, Currency,
     DatabaseFactory, DistributionHistory, DistributionResult, DistributionRules, DraftTrade,
     Environment, Execution, Level, LevelAdjustmentRules, LevelChange, LevelTrigger, MarketBar,
     MarketDataChannel, MarketDataStreamEvent, MarketSnapshot, MarketSnapshotSource,
@@ -296,13 +297,21 @@ impl TrustFacade {
     pub fn new(factory: Box<dyn DatabaseFactory>, broker: Box<dyn Broker>) -> Self {
         TrustFacade {
             factory,
-            broker,
+            broker: Box::new(BrokerRegistry::from_single(broker)),
             protected_mode: false,
             protected_authorized: false,
             distribution_rules_cache: HashMap::new(),
             level_snapshot_cache: HashMap::new(),
             advisory_history: Vec::new(),
         }
+    }
+
+    /// Creates a new instance of Trust with broker routing per account.
+    pub fn new_with_brokers(
+        factory: Box<dyn DatabaseFactory>,
+        brokers: Vec<Box<dyn Broker>>,
+    ) -> Self {
+        Self::new(factory, Box::new(BrokerRegistry::from_many(brokers)))
     }
 
     /// Enables protected-mutation enforcement for this facade instance.
@@ -338,32 +347,17 @@ impl TrustFacade {
         taxes_percentage: Decimal,
         earnings_percentage: Decimal,
     ) -> Result<Account, Box<dyn std::error::Error>> {
-        self.consume_protected_authorization("create_account")?;
-        let savepoint = "create_account_with_level";
-        self.factory.begin_savepoint(savepoint)?;
-
-        let account = match self.factory.account_write().create(
+        self.create_account_with_profile(
             name,
             description,
             environment,
             taxes_percentage,
             earnings_percentage,
-        ) {
-            Ok(account) => account,
-            Err(error) => {
-                let _ = self.factory.rollback_to_savepoint(savepoint);
-                return Err(error);
-            }
-        };
-
-        if let Err(error) = self.factory.level_write().create_default_level(&account) {
-            let _ = self.factory.rollback_to_savepoint(savepoint);
-            return Err(error);
-        }
-
-        self.factory.release_savepoint(savepoint)?;
-
-        Ok(account)
+            AccountType::Primary,
+            None,
+            BrokerKind::Alpaca,
+            None,
+        )
     }
 
     /// Returns current level for an account.
@@ -1621,11 +1615,7 @@ impl TrustFacade {
         account_type: AccountType,
         parent_account_id: Option<Uuid>,
     ) -> Result<Account, Box<dyn std::error::Error>> {
-        self.consume_protected_authorization("create_account_with_hierarchy")?;
-        let savepoint = "create_account_with_hierarchy";
-        self.factory.begin_savepoint(savepoint)?;
-
-        let account = match self.factory.account_write().create_with_hierarchy(
+        self.create_account_with_profile(
             name,
             description,
             environment,
@@ -1633,6 +1623,39 @@ impl TrustFacade {
             earnings_percentage,
             account_type,
             parent_account_id,
+            BrokerKind::Alpaca,
+            None,
+        )
+    }
+
+    /// Creates a new account with hierarchy and broker-profile metadata.
+    #[allow(clippy::too_many_arguments)]
+    pub fn create_account_with_profile(
+        &mut self,
+        name: &str,
+        description: &str,
+        environment: Environment,
+        taxes_percentage: Decimal,
+        earnings_percentage: Decimal,
+        account_type: AccountType,
+        parent_account_id: Option<Uuid>,
+        broker_kind: BrokerKind,
+        broker_account_id: Option<&str>,
+    ) -> Result<Account, Box<dyn std::error::Error>> {
+        self.consume_protected_authorization("create_account_with_profile")?;
+        let savepoint = "create_account_with_profile";
+        self.factory.begin_savepoint(savepoint)?;
+
+        let account = match self.factory.account_write().create_with_profile(
+            name,
+            description,
+            environment,
+            taxes_percentage,
+            earnings_percentage,
+            account_type,
+            parent_account_id,
+            broker_kind,
+            broker_account_id,
         ) {
             Ok(account) => account,
             Err(error) => {
@@ -1963,6 +1986,7 @@ fn hash_distribution_password_legacy_sha256(
     Ok(format!("{digest:x}"))
 }
 
+mod broker_registry;
 mod calculators_account;
 pub mod calculators_advanced_metrics;
 pub mod calculators_concentration;

--- a/core/src/services/fund_transfer_service.rs
+++ b/core/src/services/fund_transfer_service.rs
@@ -241,6 +241,8 @@ mod tests {
             earnings_percentage: dec!(30),
             account_type,
             parent_account_id: parent_id,
+            broker_kind: model::BrokerKind::Alpaca,
+            broker_account_id: None,
         }
     }
 
@@ -341,6 +343,8 @@ mod tests {
             earnings_percentage: dec!(0),
             account_type: AccountType::Earnings,
             parent_account_id: Some(from_account.id),
+            broker_kind: model::BrokerKind::Alpaca,
+            broker_account_id: None,
         };
 
         let amount = dec!(500);

--- a/core/src/services/profit_distribution_service.rs
+++ b/core/src/services/profit_distribution_service.rs
@@ -313,6 +313,8 @@ mod tests {
             earnings_percentage: dec!(30),
             account_type,
             parent_account_id: parent_id,
+            broker_kind: model::BrokerKind::Alpaca,
+            broker_account_id: None,
         }
     }
 

--- a/db-sqlite/migrations/2026-03-18-120000_add_account_broker_profile/down.sql
+++ b/db-sqlite/migrations/2026-03-18-120000_add_account_broker_profile/down.sql
@@ -1,0 +1,5 @@
+DROP INDEX IF EXISTS idx_accounts_broker_account_id;
+DROP INDEX IF EXISTS idx_accounts_broker_kind;
+
+UPDATE accounts SET broker_kind = 'alpaca' WHERE broker_kind IS NOT NULL;
+UPDATE accounts SET broker_account_id = NULL;

--- a/db-sqlite/migrations/2026-03-18-120000_add_account_broker_profile/up.sql
+++ b/db-sqlite/migrations/2026-03-18-120000_add_account_broker_profile/up.sql
@@ -1,0 +1,5 @@
+ALTER TABLE accounts ADD COLUMN broker_kind TEXT NOT NULL DEFAULT 'alpaca';
+ALTER TABLE accounts ADD COLUMN broker_account_id TEXT;
+
+CREATE INDEX idx_accounts_broker_kind ON accounts(broker_kind);
+CREATE INDEX idx_accounts_broker_account_id ON accounts(broker_account_id);

--- a/db-sqlite/src/backup.rs
+++ b/db-sqlite/src/backup.rs
@@ -113,10 +113,18 @@ pub struct AccountRow {
     pub account_type: String,
     #[serde(default)]
     pub parent_account_id: Option<String>,
+    #[serde(default = "default_broker_kind")]
+    pub broker_kind: String,
+    #[serde(default)]
+    pub broker_account_id: Option<String>,
 }
 
 fn default_account_type() -> String {
     "primary".to_string()
+}
+
+fn default_broker_kind() -> String {
+    "alpaca".to_string()
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Queryable, Insertable)]
@@ -648,6 +656,8 @@ mod tests {
                 earnings_percentage: "0".to_string(),
                 account_type: "primary".to_string(),
                 parent_account_id: None,
+                broker_kind: "alpaca".to_string(),
+                broker_account_id: None,
             })
             .execute(&mut conn1)
             .unwrap();

--- a/db-sqlite/src/database.rs
+++ b/db-sqlite/src/database.rs
@@ -382,7 +382,11 @@ impl OrderWrite for SqliteDatabase {
         )
     }
 
-    fn submit_of(&mut self, order: &Order, broker_order_id: Uuid) -> Result<Order, Box<dyn Error>> {
+    fn submit_of(
+        &mut self,
+        order: &Order,
+        broker_order_id: String,
+    ) -> Result<Order, Box<dyn Error>> {
         WorkerOrder::update_submitted_at(
             &mut self.connection.lock().unwrap_or_else(|e| {
                 eprintln!("Failed to acquire connection lock: {e}");
@@ -416,7 +420,7 @@ impl OrderWrite for SqliteDatabase {
         &mut self,
         order: &Order,
         price: Decimal,
-        new_broker_id: Uuid,
+        new_broker_id: String,
     ) -> Result<Order, Box<dyn Error>> {
         WorkerOrder::update_price(
             &mut self.connection.lock().unwrap_or_else(|e| {

--- a/db-sqlite/src/schema.rs
+++ b/db-sqlite/src/schema.rs
@@ -13,6 +13,8 @@ diesel::table! {
         earnings_percentage -> Text,
         account_type -> Text,
         parent_account_id -> Nullable<Text>,
+        broker_kind -> Text,
+        broker_account_id -> Nullable<Text>,
     }
 }
 
@@ -29,6 +31,47 @@ diesel::table! {
         taxed -> Text,
         currency -> Text,
         total_earnings -> Text,
+    }
+}
+
+diesel::table! {
+    advisory_thresholds (id) {
+        id -> Text,
+        created_at -> Timestamp,
+        updated_at -> Timestamp,
+        account_id -> Text,
+        sector_limit_pct -> Text,
+        asset_class_limit_pct -> Text,
+        single_position_limit_pct -> Text,
+    }
+}
+
+diesel::table! {
+    distribution_history (id) {
+        id -> Text,
+        created_at -> Timestamp,
+        updated_at -> Timestamp,
+        source_account_id -> Text,
+        trade_id -> Nullable<Text>,
+        original_amount -> Text,
+        distribution_date -> Timestamp,
+        earnings_amount -> Nullable<Text>,
+        tax_amount -> Nullable<Text>,
+        reinvestment_amount -> Nullable<Text>,
+    }
+}
+
+diesel::table! {
+    distribution_rules (id) {
+        id -> Text,
+        created_at -> Timestamp,
+        updated_at -> Timestamp,
+        account_id -> Text,
+        earnings_percent -> Text,
+        tax_percent -> Text,
+        reinvestment_percent -> Text,
+        minimum_threshold -> Text,
+        configuration_password_hash -> Text,
     }
 }
 
@@ -78,35 +121,6 @@ diesel::table! {
 }
 
 diesel::table! {
-    distribution_history (id) {
-        id -> Text,
-        created_at -> Timestamp,
-        updated_at -> Timestamp,
-        source_account_id -> Text,
-        trade_id -> Nullable<Text>,
-        original_amount -> Text,
-        distribution_date -> Timestamp,
-        earnings_amount -> Nullable<Text>,
-        tax_amount -> Nullable<Text>,
-        reinvestment_amount -> Nullable<Text>,
-    }
-}
-
-diesel::table! {
-    distribution_rules (id) {
-        id -> Text,
-        created_at -> Timestamp,
-        updated_at -> Timestamp,
-        account_id -> Text,
-        earnings_percent -> Text,
-        tax_percent -> Text,
-        reinvestment_percent -> Text,
-        minimum_threshold -> Text,
-        configuration_password_hash -> Text,
-    }
-}
-
-diesel::table! {
     level_changes (id) {
         id -> Text,
         created_at -> Timestamp,
@@ -144,22 +158,6 @@ diesel::table! {
         deleted_at -> Nullable<Timestamp>,
         log -> Text,
         trade_id -> Text,
-    }
-}
-
-diesel::table! {
-    broker_events (id) {
-        id -> Text,
-        created_at -> Timestamp,
-        updated_at -> Timestamp,
-        deleted_at -> Nullable<Timestamp>,
-        account_id -> Text,
-        trade_id -> Text,
-        source -> Text,
-        stream -> Text,
-        event_type -> Text,
-        broker_order_id -> Nullable<Text>,
-        payload_json -> Text,
     }
 }
 
@@ -303,6 +301,10 @@ diesel::table! {
 }
 
 diesel::joinable!(accounts_balances -> accounts (account_id));
+diesel::joinable!(advisory_thresholds -> accounts (account_id));
+diesel::joinable!(distribution_history -> accounts (source_account_id));
+diesel::joinable!(distribution_history -> trades (trade_id));
+diesel::joinable!(distribution_rules -> accounts (account_id));
 diesel::joinable!(executions -> accounts (account_id));
 diesel::joinable!(executions -> orders (order_id));
 diesel::joinable!(executions -> trades (trade_id));
@@ -310,11 +312,6 @@ diesel::joinable!(level_adjustment_rules -> accounts (account_id));
 diesel::joinable!(level_changes -> accounts (account_id));
 diesel::joinable!(levels -> accounts (account_id));
 diesel::joinable!(logs -> trades (trade_id));
-diesel::joinable!(broker_events -> accounts (account_id));
-diesel::joinable!(broker_events -> trades (trade_id));
-diesel::joinable!(distribution_history -> accounts (source_account_id));
-diesel::joinable!(distribution_history -> trades (trade_id));
-diesel::joinable!(distribution_rules -> accounts (account_id));
 diesel::joinable!(orders -> trading_vehicles (trading_vehicle_id));
 diesel::joinable!(rules -> accounts (account_id));
 diesel::joinable!(trade_grades -> trades (trade_id));
@@ -327,11 +324,11 @@ diesel::joinable!(transactions -> trades (trade_id));
 diesel::allow_tables_to_appear_in_same_query!(
     accounts,
     accounts_balances,
-    executions,
-    broker_events,
-    level_adjustment_rules,
+    advisory_thresholds,
     distribution_history,
     distribution_rules,
+    executions,
+    level_adjustment_rules,
     level_changes,
     levels,
     logs,

--- a/db-sqlite/src/workers/accounts.rs
+++ b/db-sqlite/src/workers/accounts.rs
@@ -3,7 +3,7 @@ use crate::schema::accounts;
 use chrono::{NaiveDateTime, Utc};
 use diesel::prelude::*;
 use model::AccountRead;
-use model::{Account, AccountType, AccountWrite, Environment};
+use model::{Account, AccountType, AccountWrite, BrokerKind, Environment};
 use rust_decimal::Decimal;
 use std::error::Error;
 use std::str::FromStr;
@@ -34,36 +34,17 @@ impl AccountWrite for AccountDB {
         taxes_percentage: Decimal,
         earnings_percentage: Decimal,
     ) -> Result<Account, Box<dyn Error>> {
-        let uuid = Uuid::new_v4().to_string();
-        let now = Utc::now().naive_utc();
-
-        let new_account = NewAccount {
-            id: uuid,
-            created_at: now,
-            updated_at: now,
-            deleted_at: None,
-            name: name.to_lowercase(),
-            description: description.to_lowercase(),
-            environment: environment.to_string(),
-            taxes_percentage: taxes_percentage.to_string(),
-            earnings_percentage: earnings_percentage.to_string(),
-            account_type: "primary".to_string(), // Default to primary account type
-            parent_account_id: None,             // No parent by default
-        };
-
-        let connection: &mut SqliteConnection = &mut self.connection.lock().unwrap_or_else(|e| {
-            eprintln!("Failed to acquire connection lock: {e}");
-            std::process::exit(1);
-        });
-
-        diesel::insert_into(accounts::table)
-            .values(&new_account)
-            .get_result::<AccountSQLite>(connection)
-            .map_err(|error| {
-                error!("Error creating account: {:?}", error);
-                error
-            })?
-            .into_domain_model()
+        self.create_with_profile(
+            name,
+            description,
+            environment,
+            taxes_percentage,
+            earnings_percentage,
+            AccountType::Primary,
+            None,
+            BrokerKind::Alpaca,
+            None,
+        )
     }
 
     fn create_with_hierarchy(
@@ -75,6 +56,31 @@ impl AccountWrite for AccountDB {
         earnings_percentage: Decimal,
         account_type: AccountType,
         parent_account_id: Option<Uuid>,
+    ) -> Result<Account, Box<dyn Error>> {
+        self.create_with_profile(
+            name,
+            description,
+            environment,
+            taxes_percentage,
+            earnings_percentage,
+            account_type,
+            parent_account_id,
+            BrokerKind::Alpaca,
+            None,
+        )
+    }
+
+    fn create_with_profile(
+        &mut self,
+        name: &str,
+        description: &str,
+        environment: Environment,
+        taxes_percentage: Decimal,
+        earnings_percentage: Decimal,
+        account_type: AccountType,
+        parent_account_id: Option<Uuid>,
+        broker_kind: BrokerKind,
+        broker_account_id: Option<&str>,
     ) -> Result<Account, Box<dyn Error>> {
         if account_type.requires_parent() && parent_account_id.is_none() {
             return Err("Child account types require a parent account ID".into());
@@ -118,6 +124,8 @@ impl AccountWrite for AccountDB {
             earnings_percentage: earnings_percentage.to_string(),
             account_type: account_type.to_string(),
             parent_account_id: parent_account_id.map(|id| id.to_string()),
+            broker_kind: broker_kind.to_string(),
+            broker_account_id: broker_account_id.map(ToOwned::to_owned),
         };
 
         diesel::insert_into(accounts::table)
@@ -196,6 +204,8 @@ pub struct AccountSQLite {
     pub earnings_percentage: String,
     pub account_type: String,
     pub parent_account_id: Option<String>,
+    pub broker_kind: String,
+    pub broker_account_id: Option<String>,
 }
 
 impl TryFrom<AccountSQLite> for Account {
@@ -242,6 +252,9 @@ impl TryFrom<AccountSQLite> for Account {
             })?,
             account_type,
             parent_account_id,
+            broker_kind: BrokerKind::from_str(&value.broker_kind)
+                .map_err(|_| ConversionError::new("broker_kind", "Failed to parse broker kind"))?,
+            broker_account_id: value.broker_account_id,
         })
     }
 }
@@ -267,6 +280,8 @@ struct NewAccount {
     earnings_percentage: String,
     account_type: String,
     parent_account_id: Option<String>,
+    broker_kind: String,
+    broker_account_id: Option<String>,
 }
 
 #[cfg(test)]

--- a/db-sqlite/src/workers/worker_execution.rs
+++ b/db-sqlite/src/workers/worker_execution.rs
@@ -47,10 +47,7 @@ impl TryFrom<ExecutionSQLite> for Execution {
             trade_id: value.trade_id.map(|x| Uuid::parse_str(&x)).transpose()?,
             order_id: value.order_id.map(|x| Uuid::parse_str(&x)).transpose()?,
             broker_execution_id: value.broker_execution_id,
-            broker_order_id: value
-                .broker_order_id
-                .map(|x| Uuid::parse_str(&x))
-                .transpose()?,
+            broker_order_id: value.broker_order_id,
             symbol: value.symbol,
             side: ExecutionSide::from_str(&value.side)
                 .map_err(|_| "invalid execution.side in database")?,
@@ -77,7 +74,7 @@ impl From<&Execution> for ExecutionSQLite {
             trade_id: value.trade_id.map(|x| x.to_string()),
             order_id: value.order_id.map(|x| x.to_string()),
             broker_execution_id: value.broker_execution_id.clone(),
-            broker_order_id: value.broker_order_id.map(|x| x.to_string()),
+            broker_order_id: value.broker_order_id.clone(),
             symbol: value.symbol.clone(),
             side: value.side.to_string(),
             qty: value.qty.to_string(),
@@ -190,6 +187,8 @@ mod tests {
             earnings_percentage: dec!(0),
             account_type: AccountType::Primary,
             parent_account_id: None,
+            broker_kind: model::BrokerKind::Alpaca,
+            broker_account_id: None,
         }
     }
 

--- a/db-sqlite/src/workers/worker_order.rs
+++ b/db-sqlite/src/workers/worker_order.rs
@@ -68,7 +68,7 @@ impl WorkerOrder {
             .filter(orders::id.eq(&order.id.to_string()))
             .set((
                 orders::updated_at.eq(now),
-                orders::broker_order_id.eq(order.broker_order_id.map(|id| id.to_string())),
+                orders::broker_order_id.eq(order.broker_order_id.clone()),
                 orders::status.eq(order.status.to_string()),
                 #[allow(clippy::cast_possible_truncation)]
                 orders::filled_quantity.eq(Some(order.filled_quantity as i32)),
@@ -92,7 +92,7 @@ impl WorkerOrder {
         connection: &mut SqliteConnection,
         order: &Order,
         new_price: Decimal,
-        new_broker_id: Uuid,
+        new_broker_id: String,
     ) -> Result<Order, Box<dyn Error>> {
         let now: NaiveDateTime = Utc::now().naive_utc();
         diesel::update(orders::table)
@@ -114,7 +114,7 @@ impl WorkerOrder {
     pub fn update_submitted_at(
         connection: &mut SqliteConnection,
         order: &Order,
-        broker_order_id: Uuid,
+        broker_order_id: String,
     ) -> Result<Order, Box<dyn Error>> {
         let now = Utc::now().naive_utc();
         diesel::update(orders::table)
@@ -201,9 +201,7 @@ impl TryFrom<OrderSQLite> for Order {
         Ok(Order {
             id: Uuid::parse_str(&value.id)
                 .map_err(|_| ConversionError::new("id", "Failed to parse order ID"))?,
-            broker_order_id: value
-                .broker_order_id
-                .and_then(|id| Uuid::parse_str(&id).ok()),
+            broker_order_id: value.broker_order_id,
             created_at: value.created_at,
             updated_at: value.updated_at,
             deleted_at: value.deleted_at,

--- a/ibkr-broker/Cargo.toml
+++ b/ibkr-broker/Cargo.toml
@@ -9,9 +9,8 @@ model = { package = "trust-model", path = "../model", version = "0.3.2" }
 chrono = { workspace = true }
 rust_decimal = { workspace = true }
 serde_json = { workspace = true }
-reqwest = { version = "0.12.24", default-features = false, features = ["blocking", "cookies", "json", "rustls-tls"] }
+reqwest = { version = "0.12.24", default-features = false, features = ["blocking", "cookies", "json", "native-tls"] }
 keyring = { workspace = true }
 
 [dev-dependencies]
-httpmock = "0.7.0"
 rust_decimal_macros = { workspace = true }

--- a/ibkr-broker/Cargo.toml
+++ b/ibkr-broker/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "ibkr-broker"
+version = { workspace = true }
+edition = "2021"
+license = "GPL-3.0-only"
+
+[dependencies]
+model = { package = "trust-model", path = "../model", version = "0.3.2" }
+chrono = { workspace = true }
+rust_decimal = { workspace = true }
+serde_json = { workspace = true }
+reqwest = { version = "0.12.24", default-features = false, features = ["blocking", "cookies", "json", "rustls-tls"] }
+keyring = { workspace = true }
+
+[dev-dependencies]
+httpmock = "0.7.0"
+rust_decimal_macros = { workspace = true }

--- a/ibkr-broker/src/client.rs
+++ b/ibkr-broker/src/client.rs
@@ -1,0 +1,229 @@
+use crate::config::ConnectionConfig;
+use crate::orders::find_live_order_by_ref;
+use crate::parsing::string_field_optional;
+use crate::support::broker_account_id;
+use crate::{LIVE_ORDER_LOOKUP_DELAY_MS, LIVE_ORDER_LOOKUP_RETRIES};
+use model::Account;
+use reqwest::blocking::{Client, Response};
+use serde_json::{json, Value};
+use std::error::Error;
+use std::thread::sleep;
+use std::time::Duration;
+
+#[derive(Debug)]
+pub(crate) struct IbkrClient {
+    http: Client,
+    config: ConnectionConfig,
+}
+
+impl IbkrClient {
+    pub(crate) fn for_account(account: &Account) -> Result<Self, Box<dyn Error>> {
+        let config = ConnectionConfig::read(&account.environment, account)?;
+        let http = Client::builder()
+            .cookie_store(true)
+            .danger_accept_invalid_certs(config.allow_insecure_tls)
+            .timeout(Duration::from_secs(20))
+            .build()?;
+        Ok(Self { http, config })
+    }
+
+    pub(crate) fn prepare_trading_session(
+        &self,
+        account: Option<&Account>,
+    ) -> Result<(), Box<dyn Error>> {
+        self.ensure_authenticated()?;
+        let _ = self.get_json_value("/iserver/accounts", &[])?;
+        if let Some(account) = account {
+            if let Some(account_id) = account.broker_account_id.as_deref() {
+                let _ =
+                    self.post_json_value("/iserver/account", &json!({ "acctId": account_id }))?;
+            }
+        }
+        Ok(())
+    }
+
+    pub(crate) fn live_orders(&self, account: &Account) -> Result<Vec<Value>, Box<dyn Error>> {
+        let account_id = broker_account_id(account)?;
+        let response = self.get_json_value(
+            "/iserver/account/orders",
+            &[
+                ("accountId", account_id.to_string()),
+                ("force", "true".to_string()),
+            ],
+        )?;
+        if let Some(array) = response.as_array() {
+            return Ok(array.clone());
+        }
+        response
+            .get("orders")
+            .and_then(Value::as_array)
+            .cloned()
+            .ok_or_else(|| "IBKR live orders response did not include orders".into())
+    }
+
+    pub(crate) fn resolve_live_order_id(
+        &self,
+        account: &Account,
+        order_ref: &str,
+    ) -> Result<String, Box<dyn Error>> {
+        for _ in 0..LIVE_ORDER_LOOKUP_RETRIES {
+            let live_orders = self.live_orders(account)?;
+            if let Some(live_order) = find_live_order_by_ref(&live_orders, order_ref) {
+                if let Some(order_id) = string_field_optional(live_order, "orderId")
+                    .or_else(|| string_field_optional(live_order, "order_id"))
+                {
+                    return Ok(order_id);
+                }
+            }
+            sleep(Duration::from_millis(LIVE_ORDER_LOOKUP_DELAY_MS));
+        }
+
+        Err(format!("IBKR order '{order_ref}' was not found in live orders").into())
+    }
+
+    pub(crate) fn account_trades(&self) -> Result<Vec<Value>, Box<dyn Error>> {
+        let response = self.get_json_value("/iserver/account/trades", &[])?;
+        response
+            .as_array()
+            .cloned()
+            .ok_or_else(|| "IBKR account trades response was not an array".into())
+    }
+
+    pub(crate) fn snapshot(&self, conid: &str, fields: &[&str]) -> Result<Value, Box<dyn Error>> {
+        let field_csv = fields.join(",");
+        for _ in 0..LIVE_ORDER_LOOKUP_RETRIES {
+            let response = self.get_json_value(
+                "/iserver/marketdata/snapshot",
+                &[("conids", conid.to_string()), ("fields", field_csv.clone())],
+            )?;
+            let snapshot = response
+                .as_array()
+                .and_then(|items| items.first())
+                .cloned()
+                .ok_or("IBKR snapshot response was empty")?;
+            if fields.iter().all(|field| snapshot.get(*field).is_some()) {
+                return Ok(snapshot);
+            }
+            sleep(Duration::from_millis(LIVE_ORDER_LOOKUP_DELAY_MS));
+        }
+
+        Err("IBKR snapshot response did not include all requested fields".into())
+    }
+
+    pub(crate) fn get_json_value(
+        &self,
+        path: &str,
+        query: &[(&str, String)],
+    ) -> Result<Value, Box<dyn Error>> {
+        let response = self
+            .http
+            .get(self.url(path))
+            .query(query)
+            .send()
+            .map_err(|error| format!("IBKR GET {path} failed: {error}"))?;
+        parse_json_response("GET", path, response)
+    }
+
+    pub(crate) fn post_json_value(
+        &self,
+        path: &str,
+        body: &Value,
+    ) -> Result<Value, Box<dyn Error>> {
+        let response = self
+            .http
+            .post(self.url(path))
+            .json(body)
+            .send()
+            .map_err(|error| format!("IBKR POST {path} failed: {error}"))?;
+        parse_json_response("POST", path, response)
+    }
+
+    pub(crate) fn post_json_with_replies(
+        &self,
+        path: &str,
+        body: &Value,
+    ) -> Result<Value, Box<dyn Error>> {
+        let mut response = self.post_json_value(path, body)?;
+
+        for _ in 0..4usize {
+            if response.is_array() {
+                return Ok(response);
+            }
+
+            let Some(reply_id) = string_field_optional(&response, "id") else {
+                return Ok(response);
+            };
+
+            response = self.post_json_value(
+                &format!("/iserver/reply/{reply_id}"),
+                &json!({ "confirmed": true }),
+            )?;
+        }
+
+        Err("IBKR order confirmation loop exceeded the maximum reply depth".into())
+    }
+
+    pub(crate) fn delete_no_content(&self, path: &str) -> Result<(), Box<dyn Error>> {
+        let response = self
+            .http
+            .delete(self.url(path))
+            .send()
+            .map_err(|error| format!("IBKR DELETE {path} failed: {error}"))?;
+
+        if response.status().is_success() {
+            return Ok(());
+        }
+
+        let status = response.status();
+        let body = response.text().unwrap_or_default();
+        Err(format!("IBKR DELETE {path} returned {status}: {body}").into())
+    }
+
+    fn ensure_authenticated(&self) -> Result<(), Box<dyn Error>> {
+        let status = self.get_json_value("/iserver/auth/status", &[])?;
+        let authenticated = status
+            .get("authenticated")
+            .and_then(Value::as_bool)
+            .unwrap_or(false);
+        let connected = status
+            .get("connected")
+            .and_then(Value::as_bool)
+            .unwrap_or(true);
+
+        if authenticated && connected {
+            return Ok(());
+        }
+
+        Err(format!(
+            "IBKR Client Portal Gateway is not ready. Authenticate in the local gateway browser session first (base URL: {}).",
+            self.config.base_url
+        )
+        .into())
+    }
+
+    fn url(&self, path: &str) -> String {
+        format!(
+            "{}/{}",
+            self.config.base_url.trim_end_matches('/'),
+            path.trim_start_matches('/')
+        )
+    }
+}
+
+pub(crate) fn parse_json_response(
+    method: &str,
+    path: &str,
+    response: Response,
+) -> Result<Value, Box<dyn Error>> {
+    let status = response.status();
+    let body = response.text().unwrap_or_default();
+    if !status.is_success() {
+        return Err(format!("IBKR {method} {path} returned {status}: {body}").into());
+    }
+    if body.trim().is_empty() {
+        return Ok(Value::Null);
+    }
+    serde_json::from_str(&body).map_err(|error| {
+        format!("IBKR {method} {path} returned invalid JSON: {error}: {body}").into()
+    })
+}

--- a/ibkr-broker/src/config.rs
+++ b/ibkr-broker/src/config.rs
@@ -1,0 +1,168 @@
+use keyring::Entry;
+use model::{Account, Environment};
+use std::fmt::{self, Display, Formatter};
+use std::str::FromStr;
+
+const DEFAULT_GATEWAY_URL: &str = "https://localhost:5000/v1/api";
+const ENV_URL: &str = "TRUST_IBKR_URL";
+const ENV_ALLOW_INSECURE_TLS: &str = "TRUST_IBKR_ALLOW_INSECURE_TLS";
+
+/// Connection settings for the local or hosted IBKR Client Portal endpoint.
+#[derive(Clone, PartialEq, Eq)]
+pub struct ConnectionConfig {
+    /// Base URL for the gateway or API endpoint.
+    pub base_url: String,
+    /// Whether TLS certificate validation should be relaxed.
+    pub allow_insecure_tls: bool,
+}
+
+impl Default for ConnectionConfig {
+    fn default() -> Self {
+        Self {
+            base_url: DEFAULT_GATEWAY_URL.to_string(),
+            allow_insecure_tls: true,
+        }
+    }
+}
+
+impl ConnectionConfig {
+    /// Create a new connection config.
+    pub fn new(base_url: &str, allow_insecure_tls: bool) -> Self {
+        Self {
+            base_url: normalize_base_url(base_url),
+            allow_insecure_tls,
+        }
+    }
+
+    /// Read persisted settings for an account.
+    pub fn read(environment: &Environment, account: &Account) -> keyring::Result<Self> {
+        if let Some(config) = Self::from_env() {
+            return Ok(config);
+        }
+
+        let entry = entry(environment, &account.name)?;
+        match entry.get_password() {
+            Ok(raw) => ConnectionConfig::from_str(&raw).map_err(|_| {
+                keyring::Error::PlatformFailure(
+                    "Failed to parse IBKR connection config from keychain"
+                        .to_string()
+                        .into(),
+                )
+            }),
+            Err(keyring::Error::NoEntry) => Ok(Self::default()),
+            Err(error) => Err(error),
+        }
+    }
+
+    /// Persist settings for an account.
+    pub fn store(self, environment: &Environment, account: &Account) -> keyring::Result<Self> {
+        let entry = entry(environment, &account.name)?;
+        entry.set_password(&self.to_keychain_string())?;
+        Ok(self)
+    }
+
+    /// Remove persisted settings for an account.
+    pub fn delete(environment: &Environment, account: &Account) -> keyring::Result<()> {
+        let entry = entry(environment, &account.name)?;
+        match entry.delete_credential() {
+            Ok(()) | Err(keyring::Error::NoEntry) => Ok(()),
+            Err(error) => Err(error),
+        }
+    }
+
+    fn to_keychain_string(&self) -> String {
+        format!("{} {}", self.base_url, self.allow_insecure_tls)
+    }
+
+    fn from_env() -> Option<Self> {
+        let base_url = std::env::var(ENV_URL).ok()?;
+        let allow_insecure_tls = std::env::var(ENV_ALLOW_INSECURE_TLS)
+            .ok()
+            .map(|value| parse_bool_flag(&value))
+            .unwrap_or(true);
+        Some(Self::new(&base_url, allow_insecure_tls))
+    }
+}
+
+impl std::fmt::Debug for ConnectionConfig {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        f.debug_struct("ConnectionConfig")
+            .field("base_url", &self.base_url)
+            .field("allow_insecure_tls", &self.allow_insecure_tls)
+            .finish()
+    }
+}
+
+impl Display for ConnectionConfig {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "{} (allow_insecure_tls={})",
+            self.base_url, self.allow_insecure_tls
+        )
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ConnectionConfigParseError;
+
+impl FromStr for ConnectionConfig {
+    type Err = ConnectionConfigParseError;
+
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        let mut parts = value.split_whitespace();
+        let base_url = parts.next().ok_or(ConnectionConfigParseError)?;
+        let allow_insecure_tls = parts.next().map(parse_bool_flag).unwrap_or(true);
+        Ok(Self::new(base_url, allow_insecure_tls))
+    }
+}
+
+fn entry(environment: &Environment, account_name: &str) -> keyring::Result<Entry> {
+    Entry::new(
+        &format!("trust-ibkr:{account_name}"),
+        environment.to_string().as_str(),
+    )
+}
+
+fn normalize_base_url(base_url: &str) -> String {
+    base_url.trim().trim_end_matches('/').to_string()
+}
+
+fn parse_bool_flag(value: &str) -> bool {
+    matches!(
+        value.trim().to_ascii_lowercase().as_str(),
+        "1" | "true" | "yes" | "y" | "on"
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{ConnectionConfig, ConnectionConfigParseError};
+    use std::str::FromStr;
+
+    #[test]
+    fn config_default_matches_local_gateway_expectations() {
+        let config = ConnectionConfig::default();
+        assert_eq!(config.base_url, "https://localhost:5000/v1/api");
+        assert!(config.allow_insecure_tls);
+    }
+
+    #[test]
+    fn config_roundtrips_via_display_format() {
+        let config = ConnectionConfig::from_str("https://ibkr.local/v1/api false").unwrap();
+        assert_eq!(config.base_url, "https://ibkr.local/v1/api");
+        assert!(!config.allow_insecure_tls);
+        assert_eq!(
+            ConnectionConfig::from_str("https://ibkr.local/v1/api false").unwrap(),
+            config
+        );
+    }
+
+    #[test]
+    fn config_parser_rejects_missing_base_url() {
+        assert_eq!(
+            ConnectionConfig::from_str("").unwrap_err(),
+            ConnectionConfigParseError
+        );
+    }
+}

--- a/ibkr-broker/src/contracts.rs
+++ b/ibkr-broker/src/contracts.rs
@@ -1,0 +1,140 @@
+use crate::client::IbkrClient;
+use crate::parsing::string_field_optional;
+use model::{TradingVehicle, TradingVehicleCategory};
+use serde_json::Value;
+use std::error::Error;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+/// Minimal contract metadata returned by IBKR symbol lookup.
+pub struct ContractMetadata {
+    /// Broker contract identifier.
+    pub conid: String,
+    /// Trading symbol.
+    pub symbol: String,
+    /// Optional company name from IBKR.
+    pub company_name: Option<String>,
+    /// Optional exchange/description field from IBKR.
+    pub description: Option<String>,
+    /// Optional currency when IBKR returns it.
+    pub currency: Option<String>,
+    /// Optional exchange when IBKR returns it.
+    pub exchange: Option<String>,
+}
+
+pub(crate) fn fetch_contract_metadata_with_client(
+    client: &IbkrClient,
+    symbol: &str,
+) -> Result<ContractMetadata, Box<dyn Error>> {
+    let response = client.get_json_value(
+        "/iserver/secdef/search",
+        &[
+            ("symbol", symbol.to_uppercase()),
+            ("secType", "STK".to_string()),
+        ],
+    )?;
+    parse_contract_metadata(&response, symbol)
+}
+
+pub(crate) fn parse_contract_metadata(
+    response: &Value,
+    symbol: &str,
+) -> Result<ContractMetadata, Box<dyn Error>> {
+    let matches = response
+        .as_array()
+        .ok_or("IBKR contract search response was not an array")?;
+    let target_symbol = symbol.to_ascii_uppercase();
+    let contract = matches
+        .iter()
+        .find(|item| {
+            string_field_optional(item, "symbol")
+                .map(|value| value.eq_ignore_ascii_case(&target_symbol))
+                .unwrap_or(false)
+        })
+        .or_else(|| matches.first())
+        .ok_or_else(|| format!("IBKR contract search returned no matches for '{symbol}'"))?;
+
+    Ok(ContractMetadata {
+        conid: string_field_optional(contract, "conid")
+            .ok_or("IBKR contract match did not include conid")?,
+        symbol: string_field_optional(contract, "symbol").unwrap_or_else(|| symbol.to_uppercase()),
+        company_name: string_field_optional(contract, "companyName"),
+        description: string_field_optional(contract, "description"),
+        currency: string_field_optional(contract, "currency"),
+        exchange: string_field_optional(contract, "exchange"),
+    })
+}
+
+pub(crate) fn resolve_conid(
+    client: &IbkrClient,
+    vehicle: &TradingVehicle,
+) -> Result<String, Box<dyn Error>> {
+    if let Some(conid) = vehicle
+        .broker_asset_id
+        .as_ref()
+        .filter(|value| !value.trim().is_empty())
+    {
+        return Ok(conid.to_string());
+    }
+    match vehicle.category {
+        TradingVehicleCategory::Stock => {
+            Ok(fetch_contract_metadata_with_client(client, &vehicle.symbol)?.conid)
+        }
+        _ => Err(format!(
+            "IBKR broker currently supports stock contract lookup only, got '{}'",
+            vehicle.category
+        )
+        .into()),
+    }
+}
+
+pub(crate) fn sec_type_for_vehicle(
+    vehicle: &TradingVehicle,
+) -> Result<&'static str, Box<dyn Error>> {
+    match vehicle.category {
+        TradingVehicleCategory::Stock => Ok("STK"),
+        _ => Err(format!(
+            "IBKR broker currently supports stock orders only, got '{}'",
+            vehicle.category
+        )
+        .into()),
+    }
+}
+
+pub(crate) fn listing_exchange(vehicle: &TradingVehicle) -> String {
+    vehicle
+        .exchange
+        .as_ref()
+        .filter(|value| !value.trim().is_empty())
+        .map(|value| value.to_string())
+        .unwrap_or_else(|| "SMART".to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::parse_contract_metadata;
+    use serde_json::json;
+
+    #[test]
+    fn contract_search_prefers_exact_symbol_match() {
+        let payload = json!([
+            { "conid": "1", "symbol": "AAPL1", "exchange": "TEST" },
+            { "conid": "2", "symbol": "AAPL", "exchange": "SMART" }
+        ]);
+
+        let metadata = parse_contract_metadata(&payload, "aapl").expect("metadata");
+
+        assert_eq!(metadata.conid, "2");
+        assert_eq!(metadata.symbol, "AAPL");
+        assert_eq!(metadata.exchange.as_deref(), Some("SMART"));
+    }
+
+    #[test]
+    fn contract_search_falls_back_to_first_match() {
+        let payload = json!([{ "conid": "1", "symbol": "MSFT", "exchange": "SMART" }]);
+
+        let metadata = parse_contract_metadata(&payload, "unknown").expect("metadata");
+
+        assert_eq!(metadata.conid, "1");
+        assert_eq!(metadata.symbol, "MSFT");
+    }
+}

--- a/ibkr-broker/src/executions.rs
+++ b/ibkr-broker/src/executions.rs
@@ -1,0 +1,139 @@
+use crate::client::IbkrClient;
+use crate::orders::{entry_side, tracked_order_refs};
+use crate::parsing::{
+    decimal_field_any, decimal_field_optional_any, string_field_optional, trade_timestamp,
+};
+use crate::{support::ensure_trade_account, BROKER_NAME};
+use chrono::{DateTime, Utc};
+use model::{
+    Account, Execution, ExecutionSide, ExecutionSource, FeeActivity, Trade, TradeCategory,
+};
+use std::error::Error;
+
+pub(crate) fn fetch_executions(
+    client: &IbkrClient,
+    trade: &Trade,
+    account: &Account,
+    after: Option<DateTime<Utc>>,
+) -> Result<Vec<Execution>, Box<dyn Error>> {
+    ensure_trade_account(trade, account)?;
+    let rows = client.account_trades()?;
+    let refs = tracked_order_refs(trade);
+    let mut executions = Vec::new();
+
+    for row in rows {
+        let symbol = string_field_optional(&row, "symbol")
+            .or_else(|| string_field_optional(&row, "ticker"))
+            .unwrap_or_default();
+        if symbol != trade.trading_vehicle.symbol {
+            continue;
+        }
+
+        let broker_order_id = string_field_optional(&row, "order_ref");
+        let Some(order_ref) = broker_order_id.clone() else {
+            continue;
+        };
+        if !refs.contains(&order_ref) {
+            continue;
+        }
+
+        let executed_at = trade_timestamp(&row).ok_or("IBKR trade row missing timestamp")?;
+        if let Some(after) = after {
+            if executed_at.and_utc() <= after {
+                continue;
+            }
+        }
+
+        let broker_execution_id = string_field_optional(&row, "execution_id")
+            .or_else(|| string_field_optional(&row, "exec_id"))
+            .ok_or("IBKR trade row missing execution id")?;
+        let qty = decimal_field_any(&row, &["size", "qty", "quantity"])?;
+        let price = decimal_field_any(&row, &["price", "trade_price"])?;
+
+        let mut execution = Execution::new(
+            BROKER_NAME.to_string(),
+            ExecutionSource::AccountActivities,
+            account.id,
+            broker_execution_id,
+            Some(order_ref),
+            symbol,
+            parse_execution_side(&row, trade.category),
+            qty,
+            price,
+            executed_at,
+        );
+        execution.raw_json = Some(row.to_string());
+        executions.push(execution);
+    }
+
+    Ok(executions)
+}
+
+pub(crate) fn fetch_fee_activities(
+    client: &IbkrClient,
+    trade: &Trade,
+    account: &Account,
+    after: Option<DateTime<Utc>>,
+) -> Result<Vec<FeeActivity>, Box<dyn Error>> {
+    ensure_trade_account(trade, account)?;
+    let rows = client.account_trades()?;
+    let refs = tracked_order_refs(trade);
+    let mut fees = Vec::new();
+
+    for row in rows {
+        let Some(order_ref) = string_field_optional(&row, "order_ref") else {
+            continue;
+        };
+        if !refs.contains(&order_ref) {
+            continue;
+        }
+
+        let Some(commission) = decimal_field_optional_any(&row, &["commission", "comm"]) else {
+            continue;
+        };
+        if commission.is_zero() {
+            continue;
+        }
+
+        let occurred_at = trade_timestamp(&row).ok_or("IBKR fee row missing timestamp")?;
+        if let Some(after) = after {
+            if occurred_at.and_utc() <= after {
+                continue;
+            }
+        }
+
+        let Some(execution_id) = string_field_optional(&row, "execution_id")
+            .or_else(|| string_field_optional(&row, "exec_id"))
+        else {
+            continue;
+        };
+
+        fees.push(FeeActivity {
+            broker: BROKER_NAME.to_string(),
+            broker_activity_id: format!("{execution_id}:commission"),
+            account_id: account.id,
+            broker_order_id: Some(order_ref),
+            symbol: string_field_optional(&row, "symbol")
+                .or_else(|| string_field_optional(&row, "ticker")),
+            activity_type: "commission".to_string(),
+            amount: commission.abs(),
+            occurred_at,
+            raw_json: Some(row.to_string()),
+        });
+    }
+
+    Ok(fees)
+}
+
+fn parse_execution_side(value: &serde_json::Value, trade_category: TradeCategory) -> ExecutionSide {
+    let side = string_field_optional(value, "side")
+        .unwrap_or_else(|| entry_side(trade_category).to_string())
+        .to_ascii_lowercase();
+    if side.contains("short") {
+        return ExecutionSide::SellShort;
+    }
+    if side.starts_with('b') {
+        return ExecutionSide::Buy;
+    }
+    ExecutionSide::Sell
+}

--- a/ibkr-broker/src/lib.rs
+++ b/ibkr-broker/src/lib.rs
@@ -333,8 +333,10 @@ mod tests {
     use serde_json::json;
 
     fn sample_trade() -> Trade {
-        let mut trade = Trade::default();
-        trade.account_id = Account::default().id;
+        let mut trade = Trade {
+            account_id: Account::default().id,
+            ..Trade::default()
+        };
         trade.trading_vehicle.symbol = "AAPL".to_string();
         trade.trading_vehicle.category = TradingVehicleCategory::Stock;
         trade.entry.unit_price = dec!(100);
@@ -370,11 +372,31 @@ mod tests {
         let trade = sample_trade();
         let orders = build_bracket_orders(&trade, "U1234567", "265598").expect("orders");
         assert_eq!(orders.len(), 3);
-        assert_eq!(orders[0]["cOID"], json!(trade.entry.id.to_string()));
-        assert_eq!(orders[1]["parentId"], json!(trade.entry.id.to_string()));
-        assert_eq!(orders[2]["parentId"], json!(trade.entry.id.to_string()));
-        assert_eq!(orders[1]["cOID"], json!(trade.target.id.to_string()));
-        assert_eq!(orders[2]["cOID"], json!(trade.safety_stop.id.to_string()));
+
+        let entry_order = orders.first().expect("entry order");
+        let target_order = orders.get(1).expect("target order");
+        let stop_order = orders.get(2).expect("stop order");
+
+        assert_eq!(
+            entry_order.get("cOID"),
+            Some(&json!(trade.entry.id.to_string()))
+        );
+        assert_eq!(
+            target_order.get("parentId"),
+            Some(&json!(trade.entry.id.to_string()))
+        );
+        assert_eq!(
+            stop_order.get("parentId"),
+            Some(&json!(trade.entry.id.to_string()))
+        );
+        assert_eq!(
+            target_order.get("cOID"),
+            Some(&json!(trade.target.id.to_string()))
+        );
+        assert_eq!(
+            stop_order.get("cOID"),
+            Some(&json!(trade.safety_stop.id.to_string()))
+        );
     }
 
     #[test]

--- a/ibkr-broker/src/lib.rs
+++ b/ibkr-broker/src/lib.rs
@@ -1,0 +1,436 @@
+//! Trust Interactive Brokers Client Portal integration.
+
+#![deny(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::indexing_slicing,
+    clippy::panic,
+    clippy::float_arithmetic,
+    clippy::arithmetic_side_effects,
+    clippy::cast_precision_loss,
+    clippy::cast_possible_truncation,
+    clippy::cast_sign_loss,
+    clippy::cognitive_complexity,
+    clippy::too_many_lines
+)]
+#![cfg_attr(test, allow(clippy::unwrap_used, clippy::expect_used))]
+#![warn(missing_docs, rust_2018_idioms, missing_debug_implementations)]
+
+mod client;
+mod config;
+mod contracts;
+mod executions;
+mod market_data;
+mod orders;
+mod parsing;
+mod support;
+
+pub use config::ConnectionConfig;
+pub use contracts::ContractMetadata;
+
+use chrono::{DateTime, Utc};
+use client::IbkrClient;
+use contracts::{fetch_contract_metadata_with_client, resolve_conid};
+use executions::{fetch_executions, fetch_fee_activities};
+use market_data::{get_bars, get_latest_quote, get_latest_trade};
+use model::{
+    Account, BarTimeframe, Broker, BrokerKind, BrokerLog, MarketBar, MarketQuote, MarketTradeTick,
+    Order, OrderCategory, OrderIds, Status, Trade,
+};
+use orders::{
+    build_bracket_orders, build_close_order, build_modify_order, find_live_order_by_ref,
+    map_live_order, map_trade_status, normalize_order_ref,
+};
+use std::error::Error;
+use support::{broker_account_id, ensure_trade_account};
+
+pub(crate) const BROKER_NAME: &str = "ibkr";
+pub(crate) const LIVE_ORDER_LOOKUP_RETRIES: usize = 5;
+pub(crate) const LIVE_ORDER_LOOKUP_DELAY_MS: u64 = 150;
+
+#[derive(Default)]
+/// Interactive Brokers broker implementation backed by the Client Portal Gateway.
+#[derive(Debug)]
+pub struct IbkrBroker;
+
+impl Broker for IbkrBroker {
+    fn kind(&self) -> BrokerKind {
+        BrokerKind::Ibkr
+    }
+
+    fn submit_trade(
+        &self,
+        trade: &Trade,
+        account: &Account,
+    ) -> Result<(BrokerLog, OrderIds), Box<dyn Error>> {
+        ensure_trade_account(trade, account)?;
+        let client = IbkrClient::for_account(account)?;
+        let account_id = broker_account_id(account)?;
+        client.prepare_trading_session(Some(account))?;
+        let conid = resolve_conid(&client, &trade.trading_vehicle)?;
+        let payload = serde_json::json!({
+            "orders": build_bracket_orders(trade, account_id, &conid)?,
+        });
+        let response = client
+            .post_json_with_replies(&format!("/iserver/account/{account_id}/orders"), &payload)?;
+
+        let entry_ref = normalize_order_ref(&trade.entry);
+        let target_ref = normalize_order_ref(&trade.target);
+        let stop_ref = normalize_order_ref(&trade.safety_stop);
+
+        Ok((
+            BrokerLog {
+                trade_id: trade.id,
+                log: response.to_string(),
+                ..Default::default()
+            },
+            OrderIds {
+                stop: stop_ref,
+                entry: entry_ref,
+                target: target_ref,
+            },
+        ))
+    }
+
+    fn sync_trade(
+        &self,
+        trade: &Trade,
+        account: &Account,
+    ) -> Result<(Status, Vec<Order>, BrokerLog), Box<dyn Error>> {
+        ensure_trade_account(trade, account)?;
+        let client = IbkrClient::for_account(account)?;
+        client.prepare_trading_session(Some(account))?;
+        let live_orders = client.live_orders(account)?;
+
+        let mut updated_orders = Vec::new();
+        for base in [&trade.entry, &trade.target, &trade.safety_stop] {
+            if let Some(live_order) =
+                find_live_order_by_ref(&live_orders, &normalize_order_ref(base))
+            {
+                let mapped = map_live_order(base, live_order)?;
+                if mapped != *base {
+                    updated_orders.push(mapped);
+                }
+            }
+        }
+
+        let status = map_trade_status(trade, &updated_orders);
+        Ok((
+            status,
+            updated_orders,
+            BrokerLog {
+                trade_id: trade.id,
+                log: serde_json::Value::Array(live_orders).to_string(),
+                ..Default::default()
+            },
+        ))
+    }
+
+    fn close_trade(
+        &self,
+        trade: &Trade,
+        account: &Account,
+    ) -> Result<(Order, BrokerLog), Box<dyn Error>> {
+        ensure_trade_account(trade, account)?;
+        let client = IbkrClient::for_account(account)?;
+        let account_id = broker_account_id(account)?;
+        client.prepare_trading_session(Some(account))?;
+
+        let target_ref = normalize_order_ref(&trade.target);
+        let target_order_id = client.resolve_live_order_id(account, &target_ref)?;
+        client.delete_no_content(&format!(
+            "/iserver/account/{account_id}/order/{target_order_id}"
+        ))?;
+
+        let conid = resolve_conid(&client, &trade.trading_vehicle)?;
+        let close_ref = format!("{target_ref}:manual-close");
+        let payload = build_close_order(trade, account_id, &conid, &close_ref)?;
+        let response = client.post_json_with_replies(
+            &format!("/iserver/account/{account_id}/orders"),
+            &serde_json::json!({ "orders": [payload] }),
+        )?;
+
+        let now = Utc::now().naive_utc();
+        let mut order = trade.target.clone();
+        order.broker_order_id = Some(close_ref);
+        order.category = OrderCategory::Market;
+        order.status = model::OrderStatus::New;
+        order.submitted_at = Some(now);
+
+        Ok((
+            order,
+            BrokerLog {
+                trade_id: trade.id,
+                log: response.to_string(),
+                ..Default::default()
+            },
+        ))
+    }
+
+    fn cancel_trade(&self, trade: &Trade, account: &Account) -> Result<(), Box<dyn Error>> {
+        ensure_trade_account(trade, account)?;
+        let client = IbkrClient::for_account(account)?;
+        let account_id = broker_account_id(account)?;
+        client.prepare_trading_session(Some(account))?;
+        let order_id = client.resolve_live_order_id(account, &normalize_order_ref(&trade.entry))?;
+        client.delete_no_content(&format!("/iserver/account/{account_id}/order/{order_id}"))
+    }
+
+    fn modify_stop(
+        &self,
+        trade: &Trade,
+        account: &Account,
+        new_stop_price: rust_decimal::Decimal,
+    ) -> Result<String, Box<dyn Error>> {
+        ensure_trade_account(trade, account)?;
+        let client = IbkrClient::for_account(account)?;
+        let account_id = broker_account_id(account)?;
+        client.prepare_trading_session(Some(account))?;
+        let order_ref = normalize_order_ref(&trade.safety_stop);
+        let order_id = client.resolve_live_order_id(account, &order_ref)?;
+        let conid = resolve_conid(&client, &trade.trading_vehicle)?;
+        let payload = build_modify_order(
+            trade,
+            account_id,
+            &conid,
+            &trade.safety_stop,
+            new_stop_price,
+        )?;
+        let _ = client.post_json_with_replies(
+            &format!("/iserver/account/{account_id}/order/{order_id}"),
+            &payload,
+        )?;
+        Ok(order_ref)
+    }
+
+    fn modify_target(
+        &self,
+        trade: &Trade,
+        account: &Account,
+        new_price: rust_decimal::Decimal,
+    ) -> Result<String, Box<dyn Error>> {
+        ensure_trade_account(trade, account)?;
+        let client = IbkrClient::for_account(account)?;
+        let account_id = broker_account_id(account)?;
+        client.prepare_trading_session(Some(account))?;
+        let order_ref = normalize_order_ref(&trade.target);
+        let order_id = client.resolve_live_order_id(account, &order_ref)?;
+        let conid = resolve_conid(&client, &trade.trading_vehicle)?;
+        let payload = build_modify_order(trade, account_id, &conid, &trade.target, new_price)?;
+        let _ = client.post_json_with_replies(
+            &format!("/iserver/account/{account_id}/order/{order_id}"),
+            &payload,
+        )?;
+        Ok(order_ref)
+    }
+
+    fn get_bars(
+        &self,
+        symbol: &str,
+        start: DateTime<Utc>,
+        end: DateTime<Utc>,
+        timeframe: BarTimeframe,
+        account: &Account,
+    ) -> Result<Vec<MarketBar>, Box<dyn Error>> {
+        let client = IbkrClient::for_account(account)?;
+        client.prepare_trading_session(Some(account))?;
+        get_bars(&client, symbol, start, end, timeframe)
+    }
+
+    fn get_latest_quote(
+        &self,
+        symbol: &str,
+        account: &Account,
+    ) -> Result<MarketQuote, Box<dyn Error>> {
+        let client = IbkrClient::for_account(account)?;
+        client.prepare_trading_session(Some(account))?;
+        get_latest_quote(&client, symbol)
+    }
+
+    fn get_latest_trade(
+        &self,
+        symbol: &str,
+        account: &Account,
+    ) -> Result<MarketTradeTick, Box<dyn Error>> {
+        let client = IbkrClient::for_account(account)?;
+        client.prepare_trading_session(Some(account))?;
+        get_latest_trade(&client, symbol)
+    }
+
+    fn fetch_executions(
+        &self,
+        trade: &Trade,
+        account: &Account,
+        after: Option<DateTime<Utc>>,
+    ) -> Result<Vec<model::Execution>, Box<dyn Error>> {
+        let client = IbkrClient::for_account(account)?;
+        client.prepare_trading_session(Some(account))?;
+        fetch_executions(&client, trade, account, after)
+    }
+
+    fn fetch_fee_activities(
+        &self,
+        trade: &Trade,
+        account: &Account,
+        after: Option<DateTime<Utc>>,
+    ) -> Result<Vec<model::FeeActivity>, Box<dyn Error>> {
+        let client = IbkrClient::for_account(account)?;
+        client.prepare_trading_session(Some(account))?;
+        fetch_fee_activities(&client, trade, account, after)
+    }
+}
+
+impl IbkrBroker {
+    /// Store IBKR gateway connection settings for an account.
+    pub fn setup_connection(
+        base_url: &str,
+        allow_insecure_tls: bool,
+        environment: &model::Environment,
+        account: &Account,
+    ) -> Result<ConnectionConfig, Box<dyn Error>> {
+        let config = ConnectionConfig::new(base_url, allow_insecure_tls);
+        let config = config.store(environment, account)?;
+        Ok(config)
+    }
+
+    /// Read the configured IBKR gateway connection for an account.
+    pub fn read_connection(
+        environment: &model::Environment,
+        account: &Account,
+    ) -> Result<ConnectionConfig, Box<dyn Error>> {
+        Ok(ConnectionConfig::read(environment, account)?)
+    }
+
+    /// Delete persisted IBKR gateway settings for an account.
+    pub fn delete_connection(
+        environment: &model::Environment,
+        account: &Account,
+    ) -> Result<(), Box<dyn Error>> {
+        ConnectionConfig::delete(environment, account)?;
+        Ok(())
+    }
+
+    /// Resolve symbol metadata from IBKR contract search.
+    pub fn fetch_contract_metadata(
+        account: &Account,
+        symbol: &str,
+    ) -> Result<ContractMetadata, Box<dyn Error>> {
+        let client = IbkrClient::for_account(account)?;
+        client.prepare_trading_session(Some(account))?;
+        fetch_contract_metadata_with_client(&client, symbol)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{build_bracket_orders, map_live_order, map_trade_status, IbkrBroker};
+    use crate::orders::{map_ibkr_order_status, tracked_order_refs};
+    use crate::parsing::parse_ibkr_datetime;
+    use model::{
+        Account, Currency, Environment, OrderStatus, Status, Trade, TradingVehicleCategory,
+    };
+    use rust_decimal_macros::dec;
+    use serde_json::json;
+
+    fn sample_trade() -> Trade {
+        let mut trade = Trade::default();
+        trade.account_id = Account::default().id;
+        trade.trading_vehicle.symbol = "AAPL".to_string();
+        trade.trading_vehicle.category = TradingVehicleCategory::Stock;
+        trade.entry.unit_price = dec!(100);
+        trade.target.unit_price = dec!(110);
+        trade.safety_stop.unit_price = dec!(95);
+        trade.entry.quantity = 10;
+        trade.target.quantity = 10;
+        trade.safety_stop.quantity = 10;
+        trade.entry.currency = Currency::USD;
+        trade.target.currency = Currency::USD;
+        trade.safety_stop.currency = Currency::USD;
+        trade
+    }
+
+    #[test]
+    fn ibkr_datetime_parser_supports_documented_formats() {
+        assert!(parse_ibkr_datetime("20260318-15:45:00").is_some());
+        assert!(parse_ibkr_datetime("20260318 15:45:00").is_some());
+        assert!(parse_ibkr_datetime("260318154500").is_some());
+    }
+
+    #[test]
+    fn ibkr_order_status_mapping_covers_core_states() {
+        assert_eq!(map_ibkr_order_status("Submitted"), OrderStatus::New);
+        assert_eq!(map_ibkr_order_status("PreSubmitted"), OrderStatus::Held);
+        assert_eq!(map_ibkr_order_status("Filled"), OrderStatus::Filled);
+        assert_eq!(map_ibkr_order_status("Cancelled"), OrderStatus::Canceled);
+        assert_eq!(map_ibkr_order_status("Rejected"), OrderStatus::Rejected);
+    }
+
+    #[test]
+    fn build_bracket_orders_assigns_parent_child_relationships() {
+        let trade = sample_trade();
+        let orders = build_bracket_orders(&trade, "U1234567", "265598").expect("orders");
+        assert_eq!(orders.len(), 3);
+        assert_eq!(orders[0]["cOID"], json!(trade.entry.id.to_string()));
+        assert_eq!(orders[1]["parentId"], json!(trade.entry.id.to_string()));
+        assert_eq!(orders[2]["parentId"], json!(trade.entry.id.to_string()));
+        assert_eq!(orders[1]["cOID"], json!(trade.target.id.to_string()));
+        assert_eq!(orders[2]["cOID"], json!(trade.safety_stop.id.to_string()));
+    }
+
+    #[test]
+    fn map_live_order_translates_filled_quantities_and_prices() {
+        let mut trade = sample_trade();
+        trade.entry.broker_order_id = Some(trade.entry.id.to_string());
+        let live_order = json!({
+            "order_ref": trade.entry.id.to_string(),
+            "status": "Filled",
+            "filledQuantity": "10",
+            "avgPrice": "101.25",
+            "lastExecutionTime": "20260318-15:45:00"
+        });
+
+        let mapped = map_live_order(&trade.entry, &live_order).expect("mapped");
+        assert_eq!(mapped.status, OrderStatus::Filled);
+        assert_eq!(mapped.filled_quantity, 10);
+        assert_eq!(mapped.average_filled_price, Some(dec!(101.25)));
+        assert!(mapped.filled_at.is_some());
+    }
+
+    #[test]
+    fn trade_status_prefers_terminal_exit_orders() {
+        let trade = sample_trade();
+        let mut stop = trade.safety_stop.clone();
+        stop.status = OrderStatus::Filled;
+        assert_eq!(map_trade_status(&trade, &[stop]), Status::ClosedStopLoss);
+    }
+
+    #[test]
+    fn tracked_order_refs_uses_current_broker_refs() {
+        let mut trade = sample_trade();
+        trade.entry.broker_order_id = Some("entry-ref".to_string());
+        let refs = tracked_order_refs(&trade);
+        assert!(refs.contains("entry-ref"));
+        assert!(refs.contains(&trade.target.id.to_string()));
+    }
+
+    #[test]
+    fn connection_helpers_roundtrip_through_public_api() {
+        let account = Account {
+            name: "ibkr-unit".to_string(),
+            environment: Environment::Paper,
+            ..Account::default()
+        };
+        let config = IbkrBroker::setup_connection(
+            "https://localhost:5000/v1/api/",
+            true,
+            &Environment::Paper,
+            &account,
+        );
+        if config.is_ok() {
+            let stored =
+                IbkrBroker::read_connection(&Environment::Paper, &account).expect("stored");
+            assert_eq!(stored.base_url, "https://localhost:5000/v1/api");
+            IbkrBroker::delete_connection(&Environment::Paper, &account).expect("deleted");
+        }
+    }
+}

--- a/ibkr-broker/src/market_data.rs
+++ b/ibkr-broker/src/market_data.rs
@@ -1,0 +1,128 @@
+use crate::client::IbkrClient;
+use crate::contracts::fetch_contract_metadata_with_client;
+use crate::parsing::{
+    decimal_field, parse_epoch_datetime, string_field_optional, timestamp_field, u64_field_optional,
+};
+use chrono::{DateTime, NaiveDateTime, Utc};
+use model::{BarTimeframe, MarketBar, MarketQuote, MarketTradeTick};
+use std::error::Error;
+
+pub(crate) fn get_bars(
+    client: &IbkrClient,
+    symbol: &str,
+    start: DateTime<Utc>,
+    end: DateTime<Utc>,
+    timeframe: BarTimeframe,
+) -> Result<Vec<MarketBar>, Box<dyn Error>> {
+    let conid = fetch_contract_metadata_with_client(client, symbol)?.conid;
+    let response = client.get_json_value(
+        "/iserver/marketdata/history",
+        &[
+            ("conid", conid),
+            ("bar", history_bar(timeframe).to_string()),
+            ("period", history_period(start, end, timeframe)),
+            ("startTime", format_ibkr_datetime(end.naive_utc())),
+            ("outsideRth", "true".to_string()),
+        ],
+    )?;
+    let bars = response
+        .get("data")
+        .and_then(serde_json::Value::as_array)
+        .ok_or("IBKR history response did not include data")?;
+    let mut out = Vec::with_capacity(bars.len());
+    for bar in bars {
+        let Some(time) = parse_epoch_datetime(bar.get("t")) else {
+            continue;
+        };
+        if time < start || time > end {
+            continue;
+        }
+        out.push(MarketBar {
+            time,
+            open: decimal_field(bar, "o")?,
+            high: decimal_field(bar, "h")?,
+            low: decimal_field(bar, "l")?,
+            close: decimal_field(bar, "c")?,
+            volume: u64_field_optional(bar, "v").unwrap_or(0),
+        });
+    }
+    Ok(out)
+}
+
+pub(crate) fn get_latest_quote(
+    client: &IbkrClient,
+    symbol: &str,
+) -> Result<MarketQuote, Box<dyn Error>> {
+    let conid = fetch_contract_metadata_with_client(client, symbol)?.conid;
+    let snapshot = client.snapshot(&conid, &["55", "84", "88", "86", "85"])?;
+    Ok(MarketQuote {
+        symbol: string_field_optional(&snapshot, "55").unwrap_or_else(|| symbol.to_string()),
+        as_of: timestamp_field(&snapshot, "_updated").unwrap_or_else(Utc::now),
+        bid_price: decimal_field(&snapshot, "84")?,
+        bid_size: u64_field_optional(&snapshot, "88").unwrap_or(0),
+        ask_price: decimal_field(&snapshot, "86")?,
+        ask_size: u64_field_optional(&snapshot, "85").unwrap_or(0),
+    })
+}
+
+pub(crate) fn get_latest_trade(
+    client: &IbkrClient,
+    symbol: &str,
+) -> Result<MarketTradeTick, Box<dyn Error>> {
+    let conid = fetch_contract_metadata_with_client(client, symbol)?.conid;
+    let snapshot = client.snapshot(&conid, &["55", "31", "7059"])?;
+    Ok(MarketTradeTick {
+        symbol: string_field_optional(&snapshot, "55").unwrap_or_else(|| symbol.to_string()),
+        as_of: timestamp_field(&snapshot, "_updated").unwrap_or_else(Utc::now),
+        price: decimal_field(&snapshot, "31")?,
+        size: u64_field_optional(&snapshot, "7059").unwrap_or(0),
+    })
+}
+
+fn history_bar(timeframe: BarTimeframe) -> &'static str {
+    match timeframe {
+        BarTimeframe::OneMinute => "1min",
+        BarTimeframe::OneHour => "1h",
+        BarTimeframe::OneDay => "1d",
+    }
+}
+
+pub(crate) fn history_period(
+    start: DateTime<Utc>,
+    end: DateTime<Utc>,
+    timeframe: BarTimeframe,
+) -> String {
+    let duration = end.signed_duration_since(start);
+    match timeframe {
+        BarTimeframe::OneMinute => format!("{}min", duration.num_minutes().max(1)),
+        BarTimeframe::OneHour => format!("{}h", duration.num_hours().max(1)),
+        BarTimeframe::OneDay => format!("{}d", duration.num_days().max(1)),
+    }
+}
+
+pub(crate) fn format_ibkr_datetime(value: NaiveDateTime) -> String {
+    value.format("%Y%m%d-%H:%M:%S").to_string()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::history_period;
+    use chrono::{DateTime, Utc};
+    use model::BarTimeframe;
+
+    #[test]
+    fn history_period_scales_with_requested_timeframe() {
+        let start = DateTime::parse_from_rfc3339("2026-03-18T10:00:00Z")
+            .expect("valid start")
+            .with_timezone(&Utc);
+        let end = DateTime::parse_from_rfc3339("2026-03-18T12:00:00Z")
+            .expect("valid end")
+            .with_timezone(&Utc);
+        assert_eq!(
+            history_period(start, end, BarTimeframe::OneMinute),
+            "120min"
+        );
+        assert_eq!(history_period(start, end, BarTimeframe::OneHour), "2h");
+        assert_eq!(history_period(start, end, BarTimeframe::OneDay), "1d");
+    }
+}

--- a/ibkr-broker/src/orders.rs
+++ b/ibkr-broker/src/orders.rs
@@ -1,0 +1,307 @@
+use crate::contracts::{listing_exchange, sec_type_for_vehicle};
+use crate::parsing::{
+    decimal_field_optional_any, parse_ibkr_datetime, string_field_optional, u64_field_optional_any,
+};
+use chrono::Utc;
+use model::{Order, OrderStatus, Status, TimeInForce, Trade, TradeCategory};
+use rust_decimal::Decimal;
+use serde_json::{json, Value};
+use std::collections::HashSet;
+use std::error::Error;
+
+pub(crate) fn build_bracket_orders(
+    trade: &Trade,
+    account_id: &str,
+    conid: &str,
+) -> Result<Vec<Value>, Box<dyn Error>> {
+    let entry_ref = normalize_order_ref(&trade.entry);
+    let target_ref = normalize_order_ref(&trade.target);
+    let stop_ref = normalize_order_ref(&trade.safety_stop);
+    let listing_exchange = listing_exchange(&trade.trading_vehicle);
+    let symbol = trade.trading_vehicle.symbol.to_uppercase();
+    let sec_type = sec_type_for_vehicle(&trade.trading_vehicle)?;
+    let tif = tif_string(trade.entry.time_in_force);
+    let exit_side = exit_side(trade.category);
+
+    Ok(vec![
+        json!({
+            "acctId": account_id,
+            "conid": conid,
+            "secType": sec_type,
+            "cOID": entry_ref,
+            "referrer": "trust-entry",
+            "orderType": "LMT",
+            "listingExchange": listing_exchange,
+            "outsideRTH": trade.entry.extended_hours,
+            "price": trade.entry.unit_price.to_string(),
+            "side": entry_side(trade.category),
+            "ticker": symbol,
+            "tif": tif,
+            "quantity": trade.entry.quantity,
+        }),
+        json!({
+            "acctId": account_id,
+            "conid": conid,
+            "secType": sec_type,
+            "cOID": target_ref,
+            "parentId": normalize_order_ref(&trade.entry),
+            "referrer": "trust-target",
+            "orderType": "LMT",
+            "listingExchange": listing_exchange,
+            "outsideRTH": trade.target.extended_hours,
+            "price": trade.target.unit_price.to_string(),
+            "side": exit_side,
+            "ticker": symbol,
+            "tif": tif_string(trade.target.time_in_force),
+            "quantity": trade.target.quantity,
+            "isClose": true,
+        }),
+        json!({
+            "acctId": account_id,
+            "conid": conid,
+            "secType": sec_type,
+            "cOID": stop_ref,
+            "parentId": normalize_order_ref(&trade.entry),
+            "referrer": "trust-stop",
+            "orderType": "STP",
+            "listingExchange": listing_exchange,
+            "outsideRTH": trade.safety_stop.extended_hours,
+            "price": trade.safety_stop.unit_price.to_string(),
+            "side": exit_side,
+            "ticker": symbol,
+            "tif": tif_string(trade.safety_stop.time_in_force),
+            "quantity": trade.safety_stop.quantity,
+            "isClose": true,
+        }),
+    ])
+}
+
+pub(crate) fn build_close_order(
+    trade: &Trade,
+    account_id: &str,
+    conid: &str,
+    close_ref: &str,
+) -> Result<Value, Box<dyn Error>> {
+    Ok(json!({
+        "acctId": account_id,
+        "conid": conid,
+        "secType": sec_type_for_vehicle(&trade.trading_vehicle)?,
+        "cOID": close_ref,
+        "referrer": "trust-manual-close",
+        "orderType": "MKT",
+        "listingExchange": listing_exchange(&trade.trading_vehicle),
+        "outsideRTH": trade.target.extended_hours,
+        "side": exit_side(trade.category),
+        "ticker": trade.trading_vehicle.symbol.to_uppercase(),
+        "tif": tif_string(trade.target.time_in_force),
+        "quantity": trade.target.quantity,
+        "isClose": true,
+    }))
+}
+
+pub(crate) fn build_modify_order(
+    trade: &Trade,
+    account_id: &str,
+    conid: &str,
+    order: &Order,
+    new_price: Decimal,
+) -> Result<Value, Box<dyn Error>> {
+    let (order_type, referrer) = if order.id == trade.target.id {
+        ("LMT", "trust-target-modify")
+    } else {
+        ("STP", "trust-stop-modify")
+    };
+
+    Ok(json!({
+        "acctId": account_id,
+        "conid": conid,
+        "secType": sec_type_for_vehicle(&trade.trading_vehicle)?,
+        "cOID": normalize_order_ref(order),
+        "parentId": normalize_order_ref(&trade.entry),
+        "referrer": referrer,
+        "orderType": order_type,
+        "listingExchange": listing_exchange(&trade.trading_vehicle),
+        "outsideRTH": order.extended_hours,
+        "price": new_price.to_string(),
+        "side": exit_side(trade.category),
+        "ticker": trade.trading_vehicle.symbol.to_uppercase(),
+        "tif": tif_string(order.time_in_force),
+        "quantity": order.quantity,
+        "isClose": true,
+    }))
+}
+
+pub(crate) fn find_live_order_by_ref<'a>(
+    orders: &'a [Value],
+    order_ref: &str,
+) -> Option<&'a Value> {
+    orders.iter().find(|order| {
+        string_field_optional(order, "order_ref")
+            .or_else(|| string_field_optional(order, "local_order_id"))
+            .map(|value| value == order_ref)
+            .unwrap_or(false)
+    })
+}
+
+pub(crate) fn map_live_order(base: &Order, live_order: &Value) -> Result<Order, Box<dyn Error>> {
+    let mut order = base.clone();
+    order.broker_order_id = Some(normalize_order_ref(base));
+
+    let status_text = string_field_optional(live_order, "status")
+        .or_else(|| string_field_optional(live_order, "order_status"))
+        .unwrap_or_else(|| "unknown".to_string());
+    order.status = map_ibkr_order_status(&status_text);
+
+    if let Some(filled_quantity) =
+        u64_field_optional_any(live_order, &["filledQuantity", "filled_qty"])
+    {
+        order.filled_quantity = filled_quantity;
+    }
+    if let Some(average_filled_price) =
+        decimal_field_optional_any(live_order, &["avgPrice", "avg_price"])
+    {
+        order.average_filled_price = Some(average_filled_price);
+    }
+    if order.submitted_at.is_none() && order.status != OrderStatus::New {
+        order.submitted_at = Some(Utc::now().naive_utc());
+    }
+
+    let event_time = string_field_optional(live_order, "lastExecutionTime")
+        .as_deref()
+        .and_then(parse_ibkr_datetime);
+    if order.status == OrderStatus::Filled {
+        order.filled_at = event_time
+            .or(order.filled_at)
+            .or(Some(Utc::now().naive_utc()));
+    }
+    if order.status == OrderStatus::Canceled {
+        order.cancelled_at = event_time
+            .or(order.cancelled_at)
+            .or(Some(Utc::now().naive_utc()));
+    }
+
+    Ok(order)
+}
+
+pub(crate) fn map_trade_status(trade: &Trade, updated_orders: &[Order]) -> Status {
+    let entry = apply_order_update(&trade.entry, updated_orders);
+    let target = apply_order_update(&trade.target, updated_orders);
+    let stop = apply_order_update(&trade.safety_stop, updated_orders);
+
+    if stop.status == OrderStatus::Filled {
+        return Status::ClosedStopLoss;
+    }
+    if target.status == OrderStatus::Filled {
+        return Status::ClosedTarget;
+    }
+    if entry.status == OrderStatus::PartiallyFilled {
+        return Status::PartiallyFilled;
+    }
+    if entry.status == OrderStatus::Filled {
+        return Status::Filled;
+    }
+    if entry.status == OrderStatus::Canceled {
+        return Status::Canceled;
+    }
+    if entry.status == OrderStatus::Expired {
+        return Status::Expired;
+    }
+    if entry.status == OrderStatus::Rejected {
+        return Status::Rejected;
+    }
+    if entry.broker_order_id.is_some() || entry.submitted_at.is_some() {
+        return Status::Submitted;
+    }
+    trade.status
+}
+
+fn apply_order_update(base: &Order, updates: &[Order]) -> Order {
+    updates
+        .iter()
+        .find(|candidate| candidate.id == base.id)
+        .cloned()
+        .unwrap_or_else(|| base.clone())
+}
+
+pub(crate) fn map_ibkr_order_status(status: &str) -> OrderStatus {
+    match status.trim().to_ascii_lowercase().as_str() {
+        "submitted" | "pending_submit" | "api_pending" => OrderStatus::New,
+        "presubmitted" | "pre_submitted" | "inactive" => OrderStatus::Held,
+        "partially_filled" => OrderStatus::PartiallyFilled,
+        "filled" => OrderStatus::Filled,
+        "cancelled" | "canceled" | "api_cancelled" => OrderStatus::Canceled,
+        "pending_cancel" => OrderStatus::PendingCancel,
+        "pending_replace" => OrderStatus::PendingReplace,
+        "replaced" => OrderStatus::Replaced,
+        "rejected" => OrderStatus::Rejected,
+        "expired" => OrderStatus::Expired,
+        _ => OrderStatus::Unknown,
+    }
+}
+
+pub(crate) fn entry_side(category: TradeCategory) -> &'static str {
+    match category {
+        TradeCategory::Long => "BUY",
+        TradeCategory::Short => "SELL",
+    }
+}
+
+pub(crate) fn exit_side(category: TradeCategory) -> &'static str {
+    match category {
+        TradeCategory::Long => "SELL",
+        TradeCategory::Short => "BUY",
+    }
+}
+
+pub(crate) fn tif_string(time_in_force: TimeInForce) -> &'static str {
+    match time_in_force {
+        TimeInForce::Day => "DAY",
+        TimeInForce::UntilCanceled => "GTC",
+        TimeInForce::UntilMarketOpen => "OPG",
+        TimeInForce::UntilMarketClose => "CLS",
+    }
+}
+
+pub(crate) fn normalize_order_ref(order: &Order) -> String {
+    order
+        .broker_order_id
+        .clone()
+        .unwrap_or_else(|| order.id.to_string())
+}
+
+pub(crate) fn tracked_order_refs(trade: &Trade) -> HashSet<String> {
+    [
+        normalize_order_ref(&trade.entry),
+        normalize_order_ref(&trade.target),
+        normalize_order_ref(&trade.safety_stop),
+    ]
+    .into_iter()
+    .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{find_live_order_by_ref, normalize_order_ref};
+    use model::Order;
+    use serde_json::json;
+
+    #[test]
+    fn normalize_order_ref_prefers_existing_broker_id() {
+        let mut order = Order::default();
+        order.broker_order_id = Some("ibkr-ref".to_string());
+
+        assert_eq!(normalize_order_ref(&order), "ibkr-ref");
+    }
+
+    #[test]
+    fn find_live_order_by_ref_checks_local_order_id_fallback() {
+        let orders = vec![json!({
+            "local_order_id": "entry-ref",
+            "status": "Submitted"
+        })];
+
+        let found = find_live_order_by_ref(&orders, "entry-ref").expect("order");
+
+        assert_eq!(found["local_order_id"], json!("entry-ref"));
+    }
+}

--- a/ibkr-broker/src/orders.rs
+++ b/ibkr-broker/src/orders.rs
@@ -287,8 +287,10 @@ mod tests {
 
     #[test]
     fn normalize_order_ref_prefers_existing_broker_id() {
-        let mut order = Order::default();
-        order.broker_order_id = Some("ibkr-ref".to_string());
+        let order = Order {
+            broker_order_id: Some("ibkr-ref".to_string()),
+            ..Order::default()
+        };
 
         assert_eq!(normalize_order_ref(&order), "ibkr-ref");
     }

--- a/ibkr-broker/src/parsing.rs
+++ b/ibkr-broker/src/parsing.rs
@@ -1,0 +1,93 @@
+use chrono::{DateTime, NaiveDateTime, Utc};
+use rust_decimal::Decimal;
+use serde_json::Value;
+use std::error::Error;
+
+pub(crate) fn parse_ibkr_datetime(value: &str) -> Option<NaiveDateTime> {
+    for format in ["%Y%m%d-%H:%M:%S", "%Y%m%d %H:%M:%S", "%y%m%d%H%M%S"] {
+        if let Ok(parsed) = NaiveDateTime::parse_from_str(value, format) {
+            return Some(parsed);
+        }
+    }
+    None
+}
+
+pub(crate) fn trade_timestamp(value: &Value) -> Option<NaiveDateTime> {
+    string_field_optional(value, "trade_time")
+        .as_deref()
+        .and_then(parse_ibkr_datetime)
+        .or_else(|| {
+            string_field_optional(value, "date_time")
+                .as_deref()
+                .and_then(parse_ibkr_datetime)
+        })
+        .or_else(|| timestamp_field(value, "_updated").map(|timestamp| timestamp.naive_utc()))
+}
+
+pub(crate) fn timestamp_field(value: &Value, key: &str) -> Option<DateTime<Utc>> {
+    parse_epoch_datetime(value.get(key))
+}
+
+pub(crate) fn parse_epoch_datetime(value: Option<&Value>) -> Option<DateTime<Utc>> {
+    let millis = match value {
+        Some(Value::Number(number)) => number.as_i64()?,
+        Some(Value::String(text)) => text.parse::<i64>().ok()?,
+        _ => return None,
+    };
+    DateTime::<Utc>::from_timestamp_millis(millis)
+}
+
+pub(crate) fn string_field_optional(value: &Value, key: &str) -> Option<String> {
+    match value.get(key) {
+        Some(Value::String(text)) => Some(text.to_string()),
+        Some(Value::Number(number)) => Some(number.to_string()),
+        Some(Value::Bool(flag)) => Some(flag.to_string()),
+        _ => None,
+    }
+}
+
+pub(crate) fn decimal_field(value: &Value, key: &str) -> Result<Decimal, Box<dyn Error>> {
+    decimal_field_optional(value, key)
+        .ok_or_else(|| format!("IBKR payload missing decimal field '{key}'").into())
+}
+
+pub(crate) fn decimal_field_optional(value: &Value, key: &str) -> Option<Decimal> {
+    decimal_from_value(value.get(key))
+}
+
+pub(crate) fn decimal_field_any(value: &Value, keys: &[&str]) -> Result<Decimal, Box<dyn Error>> {
+    decimal_field_optional_any(value, keys)
+        .ok_or_else(|| format!("IBKR payload missing decimal field from {:?}", keys).into())
+}
+
+pub(crate) fn decimal_field_optional_any(value: &Value, keys: &[&str]) -> Option<Decimal> {
+    keys.iter()
+        .find_map(|key| decimal_field_optional(value, key))
+}
+
+fn decimal_from_value(value: Option<&Value>) -> Option<Decimal> {
+    match value {
+        Some(Value::String(text)) => {
+            let normalized = text.replace(',', "");
+            normalized.parse::<Decimal>().ok()
+        }
+        Some(Value::Number(number)) => number.to_string().parse::<Decimal>().ok(),
+        _ => None,
+    }
+}
+
+pub(crate) fn u64_field_optional(value: &Value, key: &str) -> Option<u64> {
+    u64_from_value(value.get(key))
+}
+
+pub(crate) fn u64_field_optional_any(value: &Value, keys: &[&str]) -> Option<u64> {
+    keys.iter().find_map(|key| u64_field_optional(value, key))
+}
+
+fn u64_from_value(value: Option<&Value>) -> Option<u64> {
+    match value {
+        Some(Value::Number(number)) => number.as_u64(),
+        Some(Value::String(text)) => text.replace(',', "").parse::<u64>().ok(),
+        _ => None,
+    }
+}

--- a/ibkr-broker/src/support.rs
+++ b/ibkr-broker/src/support.rs
@@ -1,0 +1,23 @@
+use model::{Account, Trade};
+use std::error::Error;
+
+pub(crate) fn broker_account_id(account: &Account) -> Result<&str, Box<dyn Error>> {
+    account
+        .broker_account_id
+        .as_deref()
+        .filter(|value| !value.trim().is_empty())
+        .ok_or_else(|| {
+            format!(
+                "IBKR account '{}' is missing broker_account_id. Recreate or update the account with the IBKR acctId.",
+                account.name
+            )
+            .into()
+        })
+}
+
+pub(crate) fn ensure_trade_account(trade: &Trade, account: &Account) -> Result<(), Box<dyn Error>> {
+    if trade.account_id == account.id {
+        return Ok(());
+    }
+    Err("Trade account does not match the broker account".into())
+}

--- a/ibkr-broker/tests/http_integration.rs
+++ b/ibkr-broker/tests/http_integration.rs
@@ -1,19 +1,23 @@
-use httpmock::prelude::*;
 use ibkr_broker::IbkrBroker;
 use model::{
     Account, Broker, BrokerKind, Environment, TimeInForce, Trade, TradeCategory,
     TradingVehicleCategory,
 };
 use rust_decimal_macros::dec;
-use serde_json::json;
-use std::sync::{Mutex, OnceLock};
+use serde_json::{json, Value};
+use std::collections::HashMap;
+use std::io::{BufRead, BufReader, Read, Write};
+use std::net::{Ipv4Addr, Shutdown, TcpListener, TcpStream};
+use std::sync::{Arc, Mutex, OnceLock};
+use std::thread::{self, JoinHandle};
+use std::time::Duration;
 
 fn env_lock() -> &'static Mutex<()> {
     static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
     LOCK.get_or_init(|| Mutex::new(()))
 }
 
-fn with_mock_gateway<T>(server: &MockServer, run: impl FnOnce() -> T) -> T {
+fn with_mock_gateway<T>(server: &TestServer, run: impl FnOnce() -> T) -> T {
     let _guard = env_lock()
         .lock()
         .unwrap_or_else(|poisoned| poisoned.into_inner());
@@ -24,6 +28,308 @@ fn with_mock_gateway<T>(server: &MockServer, run: impl FnOnce() -> T) -> T {
     std::env::remove_var("TRUST_IBKR_URL");
     std::env::remove_var("TRUST_IBKR_ALLOW_INSECURE_TLS");
     result
+}
+
+#[derive(Clone, Debug)]
+struct MockHandle {
+    state: Arc<Mutex<MockState>>,
+    expectation_id: usize,
+}
+
+impl MockHandle {
+    fn assert(&self) {
+        assert!(
+            self.hits() > 0,
+            "expected request was not observed: {:?}",
+            self.expectation()
+        );
+    }
+
+    fn hits(&self) -> usize {
+        self.expectation().hits
+    }
+
+    fn expectation(&self) -> MockExpectation {
+        let state = self
+            .state
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        state.expectations[self.expectation_id].clone()
+    }
+}
+
+#[derive(Clone, Debug)]
+struct MockExpectation {
+    method: &'static str,
+    path: &'static str,
+    query: Vec<(&'static str, String)>,
+    body_contains: Vec<String>,
+    response_status: u16,
+    response_body: String,
+    hits: usize,
+}
+
+impl MockExpectation {
+    fn json(method: &'static str, path: &'static str, body: Value) -> Self {
+        Self {
+            method,
+            path,
+            query: Vec::new(),
+            body_contains: Vec::new(),
+            response_status: 200,
+            response_body: body.to_string(),
+            hits: 0,
+        }
+    }
+
+    fn query(mut self, name: &'static str, value: impl Into<String>) -> Self {
+        self.query.push((name, value.into()));
+        self
+    }
+
+    fn body_contains(mut self, value: impl Into<String>) -> Self {
+        self.body_contains.push(value.into());
+        self
+    }
+
+    fn matches(&self, request: &TestRequest) -> bool {
+        if self.method != request.method || self.path != request.path {
+            return false;
+        }
+
+        if self
+            .query
+            .iter()
+            .any(|(name, value)| request.query.get(*name) != Some(value))
+        {
+            return false;
+        }
+
+        !self
+            .body_contains
+            .iter()
+            .any(|needle| !request.body.contains(needle))
+    }
+}
+
+#[derive(Debug)]
+struct MockState {
+    expectations: Vec<MockExpectation>,
+    stop_requested: bool,
+}
+
+#[derive(Debug)]
+struct TestServer {
+    address: String,
+    state: Arc<Mutex<MockState>>,
+    thread: Option<JoinHandle<()>>,
+}
+
+impl TestServer {
+    fn start() -> Self {
+        let listener = TcpListener::bind((Ipv4Addr::LOCALHOST, 0))
+            .unwrap_or_else(|error| panic!("failed to bind test server: {error}"));
+        listener
+            .set_nonblocking(true)
+            .unwrap_or_else(|error| panic!("failed to set nonblocking test server: {error}"));
+        let address = format!(
+            "http://{}",
+            listener
+                .local_addr()
+                .unwrap_or_else(|error| panic!("failed to read test server address: {error}"))
+        );
+        let state = Arc::new(Mutex::new(MockState {
+            expectations: Vec::new(),
+            stop_requested: false,
+        }));
+        let thread_state = Arc::clone(&state);
+
+        let thread = thread::spawn(move || loop {
+            match listener.accept() {
+                Ok((stream, _)) => {
+                    if let Err(error) = handle_connection(stream, &thread_state) {
+                        panic!("test server request failed: {error}");
+                    }
+                }
+                Err(error) if error.kind() == std::io::ErrorKind::WouldBlock => {
+                    if stop_requested(&thread_state) {
+                        break;
+                    }
+                    thread::sleep(Duration::from_millis(10));
+                }
+                Err(error) => panic!("test server accept failed: {error}"),
+            }
+        });
+
+        Self {
+            address,
+            state,
+            thread: Some(thread),
+        }
+    }
+
+    fn base_url(&self) -> &str {
+        &self.address
+    }
+
+    fn expect(&self, expectation: MockExpectation) -> MockHandle {
+        let mut state = self
+            .state
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        let expectation_id = state.expectations.len();
+        state.expectations.push(expectation);
+        MockHandle {
+            state: Arc::clone(&self.state),
+            expectation_id,
+        }
+    }
+}
+
+impl Drop for TestServer {
+    fn drop(&mut self) {
+        {
+            let mut state = self
+                .state
+                .lock()
+                .unwrap_or_else(|poisoned| poisoned.into_inner());
+            state.stop_requested = true;
+        }
+
+        let address = self.address.trim_start_matches("http://");
+        if let Ok(stream) = TcpStream::connect(address) {
+            let _ = stream.shutdown(Shutdown::Both);
+        }
+
+        if let Some(thread) = self.thread.take() {
+            thread
+                .join()
+                .unwrap_or_else(|_| panic!("failed to join test server thread"));
+        }
+    }
+}
+
+#[derive(Debug)]
+struct TestRequest {
+    method: String,
+    path: String,
+    query: HashMap<String, String>,
+    body: String,
+}
+
+fn stop_requested(state: &Arc<Mutex<MockState>>) -> bool {
+    state
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner())
+        .stop_requested
+}
+
+fn handle_connection(
+    mut stream: TcpStream,
+    state: &Arc<Mutex<MockState>>,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let request = match read_request(&stream)? {
+        Some(request) => request,
+        None => return Ok(()),
+    };
+
+    let response = {
+        let mut locked = state
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        if let Some(expectation) = locked
+            .expectations
+            .iter_mut()
+            .find(|expectation| expectation.matches(&request))
+        {
+            expectation.hits += 1;
+            (
+                expectation.response_status,
+                expectation.response_body.clone(),
+            )
+        } else {
+            (
+                500,
+                format!(
+                    "unexpected request: {} {} body={}",
+                    request.method, request.path, request.body
+                ),
+            )
+        }
+    };
+
+    write!(
+        stream,
+        "HTTP/1.1 {} OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
+        response.0,
+        response.1.len(),
+        response.1
+    )?;
+    stream.flush()?;
+    Ok(())
+}
+
+fn read_request(stream: &TcpStream) -> Result<Option<TestRequest>, Box<dyn std::error::Error>> {
+    let mut reader = BufReader::new(stream.try_clone()?);
+    let mut request_line = String::new();
+    if reader.read_line(&mut request_line)? == 0 {
+        return Ok(None);
+    }
+
+    let request_line = request_line.trim_end_matches(['\r', '\n']);
+    if request_line.is_empty() {
+        return Ok(None);
+    }
+
+    let mut parts = request_line.split_whitespace();
+    let Some(method) = parts.next() else {
+        return Ok(None);
+    };
+    let Some(target) = parts.next() else {
+        return Ok(None);
+    };
+
+    let mut content_length = 0usize;
+    loop {
+        let mut header_line = String::new();
+        reader.read_line(&mut header_line)?;
+        let header_line = header_line.trim_end_matches(['\r', '\n']);
+        if header_line.is_empty() {
+            break;
+        }
+
+        if let Some((name, value)) = header_line.split_once(':') {
+            if name.eq_ignore_ascii_case("content-length") {
+                content_length = value.trim().parse::<usize>().unwrap_or_default();
+            }
+        }
+    }
+
+    let mut body = vec![0_u8; content_length];
+    reader.read_exact(&mut body)?;
+    let body = String::from_utf8_lossy(&body).into_owned();
+
+    let (path, query) = split_target(target);
+    Ok(Some(TestRequest {
+        method: method.to_string(),
+        path: path.to_string(),
+        query,
+        body,
+    }))
+}
+
+fn split_target(target: &str) -> (&str, HashMap<String, String>) {
+    let Some((path, raw_query)) = target.split_once('?') else {
+        return (target, HashMap::new());
+    };
+
+    let mut query = HashMap::new();
+    for pair in raw_query.split('&').filter(|pair| !pair.is_empty()) {
+        let (name, value) = pair.split_once('=').unwrap_or((pair, ""));
+        query.insert(name.to_string(), value.to_string());
+    }
+
+    (path, query)
 }
 
 fn account() -> Account {
@@ -56,69 +362,74 @@ fn trade() -> Trade {
     trade
 }
 
-fn mock_session(server: &MockServer) {
-    server.mock(|when, then| {
-        when.method(GET).path("/v1/api/iserver/auth/status");
-        then.status(200)
-            .json_body(json!({ "authenticated": true, "connected": true }));
-    });
-    server.mock(|when, then| {
-        when.method(GET).path("/v1/api/iserver/accounts");
-        then.status(200)
-            .json_body(json!({ "selectedAccount": "U1234567" }));
-    });
-    server.mock(|when, then| {
-        when.method(POST)
-            .path("/v1/api/iserver/account")
-            .body_contains("U1234567");
-        then.status(200).json_body(json!({ "acctId": "U1234567" }));
-    });
+fn mock_session(server: &TestServer) {
+    server.expect(MockExpectation::json(
+        "GET",
+        "/v1/api/iserver/auth/status",
+        json!({ "authenticated": true, "connected": true }),
+    ));
+    server.expect(MockExpectation::json(
+        "GET",
+        "/v1/api/iserver/accounts",
+        json!({ "selectedAccount": "U1234567" }),
+    ));
+    server.expect(
+        MockExpectation::json(
+            "POST",
+            "/v1/api/iserver/account",
+            json!({ "acctId": "U1234567" }),
+        )
+        .body_contains("U1234567"),
+    );
 }
 
-fn mock_contract_search(server: &MockServer) {
-    server.mock(|when, then| {
-        when.method(GET)
-            .path("/v1/api/iserver/secdef/search")
-            .query_param("symbol", "AAPL")
-            .query_param("secType", "STK");
-        then.status(200).json_body(json!([
-            {
-                "conid": "265598",
-                "symbol": "AAPL",
-                "companyName": "Apple Inc",
-                "description": "NASDAQ",
-                "exchange": "SMART",
-                "currency": "USD"
-            }
-        ]));
-    });
+fn mock_contract_search(server: &TestServer) {
+    server.expect(
+        MockExpectation::json(
+            "GET",
+            "/v1/api/iserver/secdef/search",
+            json!([
+                {
+                    "conid": "265598",
+                    "symbol": "AAPL",
+                    "companyName": "Apple Inc",
+                    "description": "NASDAQ",
+                    "exchange": "SMART",
+                    "currency": "USD"
+                }
+            ]),
+        )
+        .query("symbol", "AAPL")
+        .query("secType", "STK"),
+    );
 }
 
 #[test]
 fn submit_trade_posts_bracket_orders_and_returns_local_order_refs() {
-    let server = MockServer::start();
+    let server = TestServer::start();
     mock_session(&server);
     mock_contract_search(&server);
 
     let account = account();
-    let trade = trade();
-    let mut trade = trade;
+    let mut trade = trade();
     trade.account_id = account.id;
-    let submit = server.mock(|when, then| {
-        when.method(POST)
-            .path("/v1/api/iserver/account/U1234567/orders")
-            .body_contains(trade.entry.id.to_string())
-            .body_contains(trade.target.id.to_string())
-            .body_contains(trade.safety_stop.id.to_string())
-            .body_contains("\"parentId\"");
-        then.status(200).json_body(json!([
-            {
-                "order_id": "9001",
-                "local_order_id": trade.entry.id.to_string(),
-                "order_status": "Submitted"
-            }
-        ]));
-    });
+    let submit = server.expect(
+        MockExpectation::json(
+            "POST",
+            "/v1/api/iserver/account/U1234567/orders",
+            json!([
+                {
+                    "order_id": "9001",
+                    "local_order_id": trade.entry.id.to_string(),
+                    "order_status": "Submitted"
+                }
+            ]),
+        )
+        .body_contains(trade.entry.id.to_string())
+        .body_contains(trade.target.id.to_string())
+        .body_contains(trade.safety_stop.id.to_string())
+        .body_contains("\"parentId\""),
+    );
 
     with_mock_gateway(&server, || {
         let broker = IbkrBroker;
@@ -133,33 +444,35 @@ fn submit_trade_posts_bracket_orders_and_returns_local_order_refs() {
 
 #[test]
 fn cancel_trade_resolves_order_id_from_order_ref_before_delete() {
-    let server = MockServer::start();
+    let server = TestServer::start();
     mock_session(&server);
     let mut trade = trade();
     let account = account();
     trade.account_id = account.id;
     trade.entry.broker_order_id = Some(trade.entry.id.to_string());
 
-    let lookup = server.mock(|when, then| {
-        when.method(GET)
-            .path("/v1/api/iserver/account/orders")
-            .query_param("accountId", "U1234567")
-            .query_param("force", "true");
-        then.status(200).json_body(json!({
-            "orders": [
-                {
-                    "orderId": "7001",
-                    "order_ref": trade.entry.id.to_string(),
-                    "status": "Submitted"
-                }
-            ]
-        }));
-    });
-    let delete = server.mock(|when, then| {
-        when.method(DELETE)
-            .path("/v1/api/iserver/account/U1234567/order/7001");
-        then.status(200).json_body(json!({ "ok": true }));
-    });
+    let lookup = server.expect(
+        MockExpectation::json(
+            "GET",
+            "/v1/api/iserver/account/orders",
+            json!({
+                "orders": [
+                    {
+                        "orderId": "7001",
+                        "order_ref": trade.entry.id.to_string(),
+                        "status": "Submitted"
+                    }
+                ]
+            }),
+        )
+        .query("accountId", "U1234567")
+        .query("force", "true"),
+    );
+    let delete = server.expect(MockExpectation::json(
+        "DELETE",
+        "/v1/api/iserver/account/U1234567/order/7001",
+        json!({ "ok": true }),
+    ));
 
     with_mock_gateway(&server, || {
         let broker = IbkrBroker;
@@ -172,7 +485,7 @@ fn cancel_trade_resolves_order_id_from_order_ref_before_delete() {
 
 #[test]
 fn modify_stop_uses_order_ref_for_lookup_and_returns_same_ref() {
-    let server = MockServer::start();
+    let server = TestServer::start();
     mock_session(&server);
     mock_contract_search(&server);
     let mut trade = trade();
@@ -181,35 +494,39 @@ fn modify_stop_uses_order_ref_for_lookup_and_returns_same_ref() {
     trade.entry.broker_order_id = Some(trade.entry.id.to_string());
     trade.safety_stop.broker_order_id = Some(trade.safety_stop.id.to_string());
 
-    let lookup = server.mock(|when, then| {
-        when.method(GET)
-            .path("/v1/api/iserver/account/orders")
-            .query_param("accountId", "U1234567")
-            .query_param("force", "true");
-        then.status(200).json_body(json!({
-            "orders": [
+    let lookup = server.expect(
+        MockExpectation::json(
+            "GET",
+            "/v1/api/iserver/account/orders",
+            json!({
+                "orders": [
+                    {
+                        "orderId": "8001",
+                        "order_ref": trade.safety_stop.id.to_string(),
+                        "status": "Submitted"
+                    }
+                ]
+            }),
+        )
+        .query("accountId", "U1234567")
+        .query("force", "true"),
+    );
+    let modify = server.expect(
+        MockExpectation::json(
+            "POST",
+            "/v1/api/iserver/account/U1234567/order/8001",
+            json!([
                 {
-                    "orderId": "8001",
-                    "order_ref": trade.safety_stop.id.to_string(),
-                    "status": "Submitted"
+                    "order_id": "8001",
+                    "local_order_id": trade.safety_stop.id.to_string(),
+                    "order_status": "Submitted"
                 }
-            ]
-        }));
-    });
-    let modify = server.mock(|when, then| {
-        when.method(POST)
-            .path("/v1/api/iserver/account/U1234567/order/8001")
-            .body_contains(trade.safety_stop.id.to_string())
-            .body_contains(trade.entry.id.to_string())
-            .body_contains("\"price\":\"94.5\"");
-        then.status(200).json_body(json!([
-            {
-                "order_id": "8001",
-                "local_order_id": trade.safety_stop.id.to_string(),
-                "order_status": "Submitted"
-            }
-        ]));
-    });
+            ]),
+        )
+        .body_contains(trade.safety_stop.id.to_string())
+        .body_contains(trade.entry.id.to_string())
+        .body_contains("\"price\":\"94.5\""),
+    );
 
     with_mock_gateway(&server, || {
         let broker = IbkrBroker;
@@ -223,7 +540,7 @@ fn modify_stop_uses_order_ref_for_lookup_and_returns_same_ref() {
 
 #[test]
 fn sync_trade_maps_live_orders_into_trade_status_and_order_updates() {
-    let server = MockServer::start();
+    let server = TestServer::start();
     mock_session(&server);
     let mut trade = trade();
     let account = account();
@@ -232,34 +549,36 @@ fn sync_trade_maps_live_orders_into_trade_status_and_order_updates() {
     trade.target.broker_order_id = Some(trade.target.id.to_string());
     trade.safety_stop.broker_order_id = Some(trade.safety_stop.id.to_string());
 
-    let sync = server.mock(|when, then| {
-        when.method(GET)
-            .path("/v1/api/iserver/account/orders")
-            .query_param("accountId", "U1234567")
-            .query_param("force", "true");
-        then.status(200).json_body(json!({
-            "orders": [
-                {
-                    "orderId": "9100",
-                    "order_ref": trade.entry.id.to_string(),
-                    "status": "Filled",
-                    "filledQuantity": "10",
-                    "avgPrice": "100.25",
-                    "lastExecutionTime": "20260318-15:45:00"
-                },
-                {
-                    "orderId": "9101",
-                    "order_ref": trade.target.id.to_string(),
-                    "status": "PreSubmitted"
-                },
-                {
-                    "orderId": "9102",
-                    "order_ref": trade.safety_stop.id.to_string(),
-                    "status": "PreSubmitted"
-                }
-            ]
-        }));
-    });
+    let sync = server.expect(
+        MockExpectation::json(
+            "GET",
+            "/v1/api/iserver/account/orders",
+            json!({
+                "orders": [
+                    {
+                        "orderId": "9100",
+                        "order_ref": trade.entry.id.to_string(),
+                        "status": "Filled",
+                        "filledQuantity": "10",
+                        "avgPrice": "100.25",
+                        "lastExecutionTime": "20260318-15:45:00"
+                    },
+                    {
+                        "orderId": "9101",
+                        "order_ref": trade.target.id.to_string(),
+                        "status": "PreSubmitted"
+                    },
+                    {
+                        "orderId": "9102",
+                        "order_ref": trade.safety_stop.id.to_string(),
+                        "status": "PreSubmitted"
+                    }
+                ]
+            }),
+        )
+        .query("accountId", "U1234567")
+        .query("force", "true"),
+    );
 
     with_mock_gateway(&server, || {
         let broker = IbkrBroker;
@@ -275,7 +594,7 @@ fn sync_trade_maps_live_orders_into_trade_status_and_order_updates() {
 
 #[test]
 fn market_data_and_execution_endpoints_are_normalized() {
-    let server = MockServer::start();
+    let server = TestServer::start();
     mock_session(&server);
     mock_contract_search(&server);
     let mut trade = trade();
@@ -285,18 +604,19 @@ fn market_data_and_execution_endpoints_are_normalized() {
     trade.target.broker_order_id = Some(trade.target.id.to_string());
     trade.safety_stop.broker_order_id = Some(trade.safety_stop.id.to_string());
 
-    let history = server.mock(|when, then| {
-        when.method(GET)
-            .path("/v1/api/iserver/marketdata/history");
-        then.status(200).json_body(json!({
+    let history = server.expect(MockExpectation::json(
+        "GET",
+        "/v1/api/iserver/marketdata/history",
+        json!({
             "data": [
                 { "o": "100", "h": "101", "l": "99", "c": "100.5", "v": "1000", "t": 1773830400000i64 }
             ]
-        }));
-    });
-    let snapshot = server.mock(|when, then| {
-        when.method(GET).path("/v1/api/iserver/marketdata/snapshot");
-        then.status(200).json_body(json!([
+        }),
+    ));
+    let snapshot = server.expect(MockExpectation::json(
+        "GET",
+        "/v1/api/iserver/marketdata/snapshot",
+        json!([
             {
                 "55": "AAPL",
                 "84": "100.1",
@@ -307,11 +627,12 @@ fn market_data_and_execution_endpoints_are_normalized() {
                 "7059": "25",
                 "_updated": 1773830400000i64
             }
-        ]));
-    });
-    let account_trades = server.mock(|when, then| {
-        when.method(GET).path("/v1/api/iserver/account/trades");
-        then.status(200).json_body(json!([
+        ]),
+    ));
+    let account_trades = server.expect(MockExpectation::json(
+        "GET",
+        "/v1/api/iserver/account/trades",
+        json!([
             {
                 "execution_id": "exec-1",
                 "order_ref": trade.entry.id.to_string(),
@@ -332,8 +653,8 @@ fn market_data_and_execution_endpoints_are_normalized() {
                 "commission": "-0.10",
                 "trade_time": "20260318-15:45:00"
             }
-        ]));
-    });
+        ]),
+    ));
 
     with_mock_gateway(&server, || {
         let broker = IbkrBroker;

--- a/ibkr-broker/tests/http_integration.rs
+++ b/ibkr-broker/tests/http_integration.rs
@@ -37,8 +37,10 @@ fn account() -> Account {
 }
 
 fn trade() -> Trade {
-    let mut trade = Trade::default();
-    trade.category = TradeCategory::Long;
+    let mut trade = Trade {
+        category: TradeCategory::Long,
+        ..Trade::default()
+    };
     trade.trading_vehicle.symbol = "AAPL".to_string();
     trade.trading_vehicle.category = TradingVehicleCategory::Stock;
     trade.trading_vehicle.exchange = Some("SMART".to_string());
@@ -105,9 +107,9 @@ fn submit_trade_posts_bracket_orders_and_returns_local_order_refs() {
     let submit = server.mock(|when, then| {
         when.method(POST)
             .path("/v1/api/iserver/account/U1234567/orders")
-            .body_contains(&trade.entry.id.to_string())
-            .body_contains(&trade.target.id.to_string())
-            .body_contains(&trade.safety_stop.id.to_string())
+            .body_contains(trade.entry.id.to_string())
+            .body_contains(trade.target.id.to_string())
+            .body_contains(trade.safety_stop.id.to_string())
             .body_contains("\"parentId\"");
         then.status(200).json_body(json!([
             {
@@ -197,8 +199,8 @@ fn modify_stop_uses_order_ref_for_lookup_and_returns_same_ref() {
     let modify = server.mock(|when, then| {
         when.method(POST)
             .path("/v1/api/iserver/account/U1234567/order/8001")
-            .body_contains(&trade.safety_stop.id.to_string())
-            .body_contains(&trade.entry.id.to_string())
+            .body_contains(trade.safety_stop.id.to_string())
+            .body_contains(trade.entry.id.to_string())
             .body_contains("\"price\":\"94.5\"");
         then.status(200).json_body(json!([
             {

--- a/ibkr-broker/tests/http_integration.rs
+++ b/ibkr-broker/tests/http_integration.rs
@@ -1,0 +1,373 @@
+use httpmock::prelude::*;
+use ibkr_broker::IbkrBroker;
+use model::{
+    Account, Broker, BrokerKind, Environment, TimeInForce, Trade, TradeCategory,
+    TradingVehicleCategory,
+};
+use rust_decimal_macros::dec;
+use serde_json::json;
+use std::sync::{Mutex, OnceLock};
+
+fn env_lock() -> &'static Mutex<()> {
+    static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+    LOCK.get_or_init(|| Mutex::new(()))
+}
+
+fn with_mock_gateway<T>(server: &MockServer, run: impl FnOnce() -> T) -> T {
+    let _guard = env_lock()
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    let base_url = format!("{}/v1/api", server.base_url());
+    std::env::set_var("TRUST_IBKR_URL", base_url);
+    std::env::set_var("TRUST_IBKR_ALLOW_INSECURE_TLS", "true");
+    let result = run();
+    std::env::remove_var("TRUST_IBKR_URL");
+    std::env::remove_var("TRUST_IBKR_ALLOW_INSECURE_TLS");
+    result
+}
+
+fn account() -> Account {
+    Account {
+        name: "ibkr-main".to_string(),
+        environment: Environment::Paper,
+        broker_kind: BrokerKind::Ibkr,
+        broker_account_id: Some("U1234567".to_string()),
+        ..Account::default()
+    }
+}
+
+fn trade() -> Trade {
+    let mut trade = Trade::default();
+    trade.category = TradeCategory::Long;
+    trade.trading_vehicle.symbol = "AAPL".to_string();
+    trade.trading_vehicle.category = TradingVehicleCategory::Stock;
+    trade.trading_vehicle.exchange = Some("SMART".to_string());
+    trade.entry.quantity = 10;
+    trade.target.quantity = 10;
+    trade.safety_stop.quantity = 10;
+    trade.entry.unit_price = dec!(100);
+    trade.target.unit_price = dec!(110);
+    trade.safety_stop.unit_price = dec!(95);
+    trade.entry.time_in_force = TimeInForce::UntilCanceled;
+    trade.target.time_in_force = TimeInForce::UntilCanceled;
+    trade.safety_stop.time_in_force = TimeInForce::UntilCanceled;
+    trade
+}
+
+fn mock_session(server: &MockServer) {
+    server.mock(|when, then| {
+        when.method(GET).path("/v1/api/iserver/auth/status");
+        then.status(200)
+            .json_body(json!({ "authenticated": true, "connected": true }));
+    });
+    server.mock(|when, then| {
+        when.method(GET).path("/v1/api/iserver/accounts");
+        then.status(200)
+            .json_body(json!({ "selectedAccount": "U1234567" }));
+    });
+    server.mock(|when, then| {
+        when.method(POST)
+            .path("/v1/api/iserver/account")
+            .body_contains("U1234567");
+        then.status(200).json_body(json!({ "acctId": "U1234567" }));
+    });
+}
+
+fn mock_contract_search(server: &MockServer) {
+    server.mock(|when, then| {
+        when.method(GET)
+            .path("/v1/api/iserver/secdef/search")
+            .query_param("symbol", "AAPL")
+            .query_param("secType", "STK");
+        then.status(200).json_body(json!([
+            {
+                "conid": "265598",
+                "symbol": "AAPL",
+                "companyName": "Apple Inc",
+                "description": "NASDAQ",
+                "exchange": "SMART",
+                "currency": "USD"
+            }
+        ]));
+    });
+}
+
+#[test]
+fn submit_trade_posts_bracket_orders_and_returns_local_order_refs() {
+    let server = MockServer::start();
+    mock_session(&server);
+    mock_contract_search(&server);
+
+    let account = account();
+    let trade = trade();
+    let mut trade = trade;
+    trade.account_id = account.id;
+    let submit = server.mock(|when, then| {
+        when.method(POST)
+            .path("/v1/api/iserver/account/U1234567/orders")
+            .body_contains(&trade.entry.id.to_string())
+            .body_contains(&trade.target.id.to_string())
+            .body_contains(&trade.safety_stop.id.to_string())
+            .body_contains("\"parentId\"");
+        then.status(200).json_body(json!([
+            {
+                "order_id": "9001",
+                "local_order_id": trade.entry.id.to_string(),
+                "order_status": "Submitted"
+            }
+        ]));
+    });
+
+    with_mock_gateway(&server, || {
+        let broker = IbkrBroker;
+        let (_, ids) = broker.submit_trade(&trade, &account).unwrap();
+        assert_eq!(ids.entry, trade.entry.id.to_string());
+        assert_eq!(ids.target, trade.target.id.to_string());
+        assert_eq!(ids.stop, trade.safety_stop.id.to_string());
+    });
+
+    submit.assert();
+}
+
+#[test]
+fn cancel_trade_resolves_order_id_from_order_ref_before_delete() {
+    let server = MockServer::start();
+    mock_session(&server);
+    let mut trade = trade();
+    let account = account();
+    trade.account_id = account.id;
+    trade.entry.broker_order_id = Some(trade.entry.id.to_string());
+
+    let lookup = server.mock(|when, then| {
+        when.method(GET)
+            .path("/v1/api/iserver/account/orders")
+            .query_param("accountId", "U1234567")
+            .query_param("force", "true");
+        then.status(200).json_body(json!({
+            "orders": [
+                {
+                    "orderId": "7001",
+                    "order_ref": trade.entry.id.to_string(),
+                    "status": "Submitted"
+                }
+            ]
+        }));
+    });
+    let delete = server.mock(|when, then| {
+        when.method(DELETE)
+            .path("/v1/api/iserver/account/U1234567/order/7001");
+        then.status(200).json_body(json!({ "ok": true }));
+    });
+
+    with_mock_gateway(&server, || {
+        let broker = IbkrBroker;
+        broker.cancel_trade(&trade, &account).unwrap();
+    });
+
+    lookup.assert();
+    delete.assert();
+}
+
+#[test]
+fn modify_stop_uses_order_ref_for_lookup_and_returns_same_ref() {
+    let server = MockServer::start();
+    mock_session(&server);
+    mock_contract_search(&server);
+    let mut trade = trade();
+    let account = account();
+    trade.account_id = account.id;
+    trade.entry.broker_order_id = Some(trade.entry.id.to_string());
+    trade.safety_stop.broker_order_id = Some(trade.safety_stop.id.to_string());
+
+    let lookup = server.mock(|when, then| {
+        when.method(GET)
+            .path("/v1/api/iserver/account/orders")
+            .query_param("accountId", "U1234567")
+            .query_param("force", "true");
+        then.status(200).json_body(json!({
+            "orders": [
+                {
+                    "orderId": "8001",
+                    "order_ref": trade.safety_stop.id.to_string(),
+                    "status": "Submitted"
+                }
+            ]
+        }));
+    });
+    let modify = server.mock(|when, then| {
+        when.method(POST)
+            .path("/v1/api/iserver/account/U1234567/order/8001")
+            .body_contains(&trade.safety_stop.id.to_string())
+            .body_contains(&trade.entry.id.to_string())
+            .body_contains("\"price\":\"94.5\"");
+        then.status(200).json_body(json!([
+            {
+                "order_id": "8001",
+                "local_order_id": trade.safety_stop.id.to_string(),
+                "order_status": "Submitted"
+            }
+        ]));
+    });
+
+    with_mock_gateway(&server, || {
+        let broker = IbkrBroker;
+        let returned = broker.modify_stop(&trade, &account, dec!(94.5)).unwrap();
+        assert_eq!(returned, trade.safety_stop.id.to_string());
+    });
+
+    lookup.assert();
+    modify.assert();
+}
+
+#[test]
+fn sync_trade_maps_live_orders_into_trade_status_and_order_updates() {
+    let server = MockServer::start();
+    mock_session(&server);
+    let mut trade = trade();
+    let account = account();
+    trade.account_id = account.id;
+    trade.entry.broker_order_id = Some(trade.entry.id.to_string());
+    trade.target.broker_order_id = Some(trade.target.id.to_string());
+    trade.safety_stop.broker_order_id = Some(trade.safety_stop.id.to_string());
+
+    let sync = server.mock(|when, then| {
+        when.method(GET)
+            .path("/v1/api/iserver/account/orders")
+            .query_param("accountId", "U1234567")
+            .query_param("force", "true");
+        then.status(200).json_body(json!({
+            "orders": [
+                {
+                    "orderId": "9100",
+                    "order_ref": trade.entry.id.to_string(),
+                    "status": "Filled",
+                    "filledQuantity": "10",
+                    "avgPrice": "100.25",
+                    "lastExecutionTime": "20260318-15:45:00"
+                },
+                {
+                    "orderId": "9101",
+                    "order_ref": trade.target.id.to_string(),
+                    "status": "PreSubmitted"
+                },
+                {
+                    "orderId": "9102",
+                    "order_ref": trade.safety_stop.id.to_string(),
+                    "status": "PreSubmitted"
+                }
+            ]
+        }));
+    });
+
+    with_mock_gateway(&server, || {
+        let broker = IbkrBroker;
+        let (status, updates, _) = broker.sync_trade(&trade, &account).unwrap();
+        assert_eq!(status, model::Status::Filled);
+        assert!(updates
+            .iter()
+            .any(|order| order.id == trade.entry.id && order.status == model::OrderStatus::Filled));
+    });
+
+    sync.assert();
+}
+
+#[test]
+fn market_data_and_execution_endpoints_are_normalized() {
+    let server = MockServer::start();
+    mock_session(&server);
+    mock_contract_search(&server);
+    let mut trade = trade();
+    let account = account();
+    trade.account_id = account.id;
+    trade.entry.broker_order_id = Some(trade.entry.id.to_string());
+    trade.target.broker_order_id = Some(trade.target.id.to_string());
+    trade.safety_stop.broker_order_id = Some(trade.safety_stop.id.to_string());
+
+    let history = server.mock(|when, then| {
+        when.method(GET)
+            .path("/v1/api/iserver/marketdata/history");
+        then.status(200).json_body(json!({
+            "data": [
+                { "o": "100", "h": "101", "l": "99", "c": "100.5", "v": "1000", "t": 1773830400000i64 }
+            ]
+        }));
+    });
+    let snapshot = server.mock(|when, then| {
+        when.method(GET).path("/v1/api/iserver/marketdata/snapshot");
+        then.status(200).json_body(json!([
+            {
+                "55": "AAPL",
+                "84": "100.1",
+                "88": "200",
+                "86": "100.3",
+                "85": "180",
+                "31": "100.2",
+                "7059": "25",
+                "_updated": 1773830400000i64
+            }
+        ]));
+    });
+    let account_trades = server.mock(|when, then| {
+        when.method(GET).path("/v1/api/iserver/account/trades");
+        then.status(200).json_body(json!([
+            {
+                "execution_id": "exec-1",
+                "order_ref": trade.entry.id.to_string(),
+                "symbol": "AAPL",
+                "side": "BUY",
+                "size": "10",
+                "price": "100.25",
+                "commission": "-1.25",
+                "trade_time": "20260318-15:45:00"
+            },
+            {
+                "execution_id": "exec-2",
+                "order_ref": "other-order",
+                "symbol": "MSFT",
+                "side": "BUY",
+                "size": "1",
+                "price": "1",
+                "commission": "-0.10",
+                "trade_time": "20260318-15:45:00"
+            }
+        ]));
+    });
+
+    with_mock_gateway(&server, || {
+        let broker = IbkrBroker;
+        let end = chrono::DateTime::parse_from_rfc3339("2026-03-18T16:00:00Z")
+            .unwrap()
+            .with_timezone(&chrono::Utc);
+        let start = chrono::DateTime::parse_from_rfc3339("2026-03-17T16:00:00Z")
+            .unwrap()
+            .with_timezone(&chrono::Utc);
+
+        let bars = broker
+            .get_bars("AAPL", start, end, model::BarTimeframe::OneDay, &account)
+            .unwrap();
+        assert_eq!(bars.len(), 1);
+
+        let quote = broker.get_latest_quote("AAPL", &account).unwrap();
+        assert_eq!(quote.symbol, "AAPL");
+        assert_eq!(quote.bid_price, dec!(100.1));
+
+        let trade_tick = broker.get_latest_trade("AAPL", &account).unwrap();
+        assert_eq!(trade_tick.price, dec!(100.2));
+
+        let executions = broker.fetch_executions(&trade, &account, None).unwrap();
+        assert_eq!(executions.len(), 1);
+        let expected_order_ref = trade.entry.id.to_string();
+        assert_eq!(
+            executions[0].broker_order_id.as_deref(),
+            Some(expected_order_ref.as_str())
+        );
+
+        let fees = broker.fetch_fee_activities(&trade, &account, None).unwrap();
+        assert_eq!(fees.len(), 1);
+        assert_eq!(fees[0].amount, dec!(1.25));
+    });
+
+    history.assert();
+    assert_eq!(snapshot.hits(), 2);
+    assert_eq!(account_trades.hits(), 2);
+}

--- a/model/src/account.rs
+++ b/model/src/account.rs
@@ -1,4 +1,4 @@
-use crate::currency::Currency;
+use crate::{broker_kind::BrokerKind, currency::Currency};
 use chrono::NaiveDateTime;
 use chrono::Utc;
 use rust_decimal::Decimal;
@@ -63,6 +63,10 @@ pub struct Account {
     pub account_type: AccountType,
     /// Optional parent account for hierarchy
     pub parent_account_id: Option<Uuid>,
+    /// Broker integration associated with this account.
+    pub broker_kind: BrokerKind,
+    /// Broker-native account identifier when required by the integration.
+    pub broker_account_id: Option<String>,
 }
 
 /// AccountBalance entity (read-only)
@@ -135,6 +139,8 @@ impl Default for Account {
             earnings_percentage: Decimal::default(),
             account_type: AccountType::Primary,
             parent_account_id: None,
+            broker_kind: BrokerKind::Alpaca,
+            broker_account_id: None,
         }
     }
 }

--- a/model/src/broker.rs
+++ b/model/src/broker.rs
@@ -1,5 +1,5 @@
 use crate::{
-    Account, BarTimeframe, Execution, FeeActivity, MarketBar, MarketDataChannel,
+    Account, BarTimeframe, BrokerKind, Execution, FeeActivity, MarketBar, MarketDataChannel,
     MarketDataStreamEvent, MarketQuote, MarketTradeTick, Order, Status, Trade,
 };
 use chrono::NaiveDateTime;
@@ -47,15 +47,18 @@ impl Default for BrokerLog {
 #[derive(Debug)]
 pub struct OrderIds {
     /// ID of the stop loss order
-    pub stop: Uuid,
+    pub stop: String,
     /// ID of the entry order
-    pub entry: Uuid,
+    pub entry: String,
     /// ID of the target/take profit order
-    pub target: Uuid,
+    pub target: String,
 }
 
 /// Trait for implementing broker integrations
 pub trait Broker {
+    /// Stable broker identity used for runtime dispatch.
+    fn kind(&self) -> BrokerKind;
+
     /// Submit a new trade to the broker
     fn submit_trade(
         &self,
@@ -90,7 +93,7 @@ pub trait Broker {
         trade: &Trade,
         account: &Account,
         new_stop_price: Decimal,
-    ) -> Result<Uuid, Box<dyn Error>>;
+    ) -> Result<String, Box<dyn Error>>;
 
     /// Modify the target price of an existing trade
     fn modify_target(
@@ -98,7 +101,7 @@ pub trait Broker {
         trade: &Trade,
         account: &Account,
         new_price: Decimal,
-    ) -> Result<Uuid, Box<dyn Error>>;
+    ) -> Result<String, Box<dyn Error>>;
 
     /// Retrieve market bars for a symbol from the broker's market data API (if supported).
     ///

--- a/model/src/broker_kind.rs
+++ b/model/src/broker_kind.rs
@@ -1,0 +1,70 @@
+use std::fmt::{self, Display, Formatter};
+use std::str::FromStr;
+
+/// Supported broker integrations.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum BrokerKind {
+    /// Alpaca broker integration.
+    Alpaca,
+    /// Interactive Brokers integration.
+    Ibkr,
+}
+
+impl BrokerKind {
+    /// Returns all supported broker kinds.
+    pub fn all() -> Vec<Self> {
+        vec![Self::Ibkr, Self::Alpaca]
+    }
+
+    /// Stable lowercase identifier used in persistence and CLI parsing.
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Self::Alpaca => "alpaca",
+            Self::Ibkr => "ibkr",
+        }
+    }
+}
+
+impl Display for BrokerKind {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+/// Error returned when parsing an unsupported broker kind.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct BrokerKindParseError;
+
+impl FromStr for BrokerKind {
+    type Err = BrokerKindParseError;
+
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        match value.trim().to_lowercase().as_str() {
+            "alpaca" => Ok(Self::Alpaca),
+            "ibkr" => Ok(Self::Ibkr),
+            _ => Err(BrokerKindParseError),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{BrokerKind, BrokerKindParseError};
+    use std::str::FromStr;
+
+    #[test]
+    fn broker_kind_roundtrips() {
+        assert_eq!(BrokerKind::from_str("alpaca").unwrap(), BrokerKind::Alpaca);
+        assert_eq!(BrokerKind::from_str("IBKR").unwrap(), BrokerKind::Ibkr);
+        assert_eq!(BrokerKind::Alpaca.to_string(), "alpaca");
+        assert_eq!(BrokerKind::Ibkr.to_string(), "ibkr");
+    }
+
+    #[test]
+    fn broker_kind_rejects_unknown_values() {
+        assert_eq!(
+            BrokerKind::from_str("unknown").unwrap_err(),
+            BrokerKindParseError
+        );
+    }
+}

--- a/model/src/database.rs
+++ b/model/src/database.rs
@@ -1,9 +1,9 @@
 use crate::{
-    Account, AccountBalance, AccountType, BrokerLog, Currency, DistributionExecutionPlan,
-    DistributionHistory, DistributionRules, Environment, Execution, Level, LevelAdjustmentRules,
-    LevelChange, Order, OrderAction, OrderCategory, Rule, RuleLevel, RuleName, Status, Trade,
-    TradeBalance, TradeCategory, TradeGrade, TradingVehicle, TradingVehicleCategory, Transaction,
-    TransactionCategory,
+    Account, AccountBalance, AccountType, BrokerKind, BrokerLog, Currency,
+    DistributionExecutionPlan, DistributionHistory, DistributionRules, Environment, Execution,
+    Level, LevelAdjustmentRules, LevelChange, Order, OrderAction, OrderCategory, Rule, RuleLevel,
+    RuleName, Status, Trade, TradeBalance, TradeCategory, TradeGrade, TradingVehicle,
+    TradingVehicleCategory, Transaction, TransactionCategory,
 };
 use rust_decimal::Decimal;
 use uuid::Uuid;
@@ -137,6 +137,31 @@ pub trait AccountWrite {
             earnings_percentage,
         )
     }
+
+    /// Creates a new account with hierarchy and broker profile metadata.
+    #[allow(clippy::too_many_arguments)]
+    fn create_with_profile(
+        &mut self,
+        name: &str,
+        description: &str,
+        environment: Environment,
+        taxes_percentage: Decimal,
+        earnings_percentage: Decimal,
+        account_type: AccountType,
+        parent_account_id: Option<Uuid>,
+        _broker_kind: BrokerKind,
+        _broker_account_id: Option<&str>,
+    ) -> Result<Account, Box<dyn Error>> {
+        self.create_with_hierarchy(
+            name,
+            description,
+            environment,
+            taxes_percentage,
+            earnings_percentage,
+            account_type,
+            parent_account_id,
+        )
+    }
 }
 
 /// Trait for reading account balance data from the database
@@ -191,7 +216,11 @@ pub trait OrderWrite {
         category: &OrderCategory,
     ) -> Result<Order, Box<dyn Error>>;
     /// Marks an order as submitted with the broker's order ID
-    fn submit_of(&mut self, order: &Order, broker_order_id: Uuid) -> Result<Order, Box<dyn Error>>;
+    fn submit_of(
+        &mut self,
+        order: &Order,
+        broker_order_id: String,
+    ) -> Result<Order, Box<dyn Error>>;
     /// Marks an order as being filled
     fn filling_of(&mut self, order: &Order) -> Result<Order, Box<dyn Error>>;
     /// Marks an order as closed
@@ -203,7 +232,7 @@ pub trait OrderWrite {
         &mut self,
         order: &Order,
         price: Decimal,
-        broker_id: Uuid,
+        broker_id: String,
     ) -> Result<Order, Box<dyn Error>>;
 }
 

--- a/model/src/execution.rs
+++ b/model/src/execution.rs
@@ -108,7 +108,7 @@ pub struct Execution {
     /// Broker execution identifier (must be unique per broker+account).
     pub broker_execution_id: String,
     /// Broker order identifier (if available).
-    pub broker_order_id: Option<Uuid>,
+    pub broker_order_id: Option<String>,
 
     /// Executed symbol (as reported by broker).
     pub symbol: String,
@@ -134,7 +134,7 @@ impl Execution {
         source: ExecutionSource,
         account_id: Uuid,
         broker_execution_id: String,
-        broker_order_id: Option<Uuid>,
+        broker_order_id: Option<String>,
         symbol: String,
         side: ExecutionSide,
         qty: Decimal,

--- a/model/src/fee_activity.rs
+++ b/model/src/fee_activity.rs
@@ -12,7 +12,7 @@ pub struct FeeActivity {
     /// Related account.
     pub account_id: Uuid,
     /// Optional broker order id when provided by the broker.
-    pub broker_order_id: Option<Uuid>,
+    pub broker_order_id: Option<String>,
     /// Optional symbol when provided by the broker.
     pub symbol: Option<String>,
     /// Raw activity type (`FEE`, `PTC`, etc).

--- a/model/src/lib.rs
+++ b/model/src/lib.rs
@@ -34,6 +34,8 @@
 pub mod account;
 /// Broker integration traits and types
 pub mod broker;
+/// Supported broker identities
+pub mod broker_kind;
 /// Currency definitions and operations
 pub mod currency;
 /// Database abstraction layer
@@ -66,6 +68,7 @@ pub mod transaction;
 // Re-export the types from the model crate.
 pub use account::{Account, AccountBalance, AccountHierarchyError, AccountType, Environment};
 pub use broker::{Broker, BrokerLog, OrderIds};
+pub use broker_kind::{BrokerKind, BrokerKindParseError};
 pub use currency::Currency;
 pub use database::{
     AccountBalanceRead, AccountBalanceWrite, AccountRead, AccountWrite, AdvisoryRead,

--- a/model/src/order.rs
+++ b/model/src/order.rs
@@ -16,7 +16,7 @@ pub struct Order {
     pub id: Uuid,
 
     /// The id of the order in the broker
-    pub broker_order_id: Option<Uuid>,
+    pub broker_order_id: Option<String>,
 
     /// When the order was created
     pub created_at: NaiveDateTime,


### PR DESCRIPTION
## Summary
- add broker-neutral account metadata, opaque broker order IDs, and per-account broker routing in core/db/model
- add a new `ibkr-broker` crate for Interactive Brokers Client Portal Gateway trading, sync, execution, fee, and market-data flows
- wire the CLI for broker-aware account creation, key/connection management, and broker-backed trading vehicle imports

## Commits
- `feat(core): add broker-neutral account profiles`
- `feat(ibkr-broker): add client portal adapter`
- `feat(cli): wire broker-aware account flows`

## Verification
- `cargo fmt --all`
- `cargo test -p ibkr-broker`
- `cargo test -p core --lib`
- `cargo test -p trust-cli -- --test-threads=1`
- `cargo test -p trust-cli test_category_to_str_maps_expected_values -- --test-threads=1`
