### PR TITLE
test: add 88 integration tests for transactions, sync, and broker failures

### DIFF
--- a/cli/tests/integration_test.rs
+++ b/cli/tests/integration_test.rs
@@ -1,3 +1,4 @@
 mod integration_test_account;
 mod integration_test_cancel_trade;
 mod integration_test_trade;
+mod integration_test_transactions;

--- a/cli/tests/integration_test_broker_failures.rs
+++ b/cli/tests/integration_test_broker_failures.rs
@@ -1,0 +1,1393 @@
+//! Tests for broker disconnection, failure, and partial-response scenarios.
+//!
+//! These tests verify that the system behaves correctly when the broker:
+//! - Returns errors (network, auth, server)
+//! - Returns partial or inconsistent data
+//! - Provides stale or duplicate responses
+//! - Disconnects mid-operation
+//!
+//! The key invariant is: **trade and account balances must never be corrupted
+//! by broker failures**. The savepoint pattern guarantees this, and these tests
+//! verify it end-to-end.
+
+use chrono::Utc;
+use core::TrustFacade;
+use db_sqlite::SqliteDatabase;
+use model::{
+    Account, Broker, BrokerLog, Currency, DraftTrade, Execution, FeeActivity, Order, OrderIds,
+    OrderStatus, RuleLevel, RuleName, Status, Trade, TradeCategory, TradingVehicleCategory,
+    TransactionCategory,
+};
+use rust_decimal::Decimal;
+use rust_decimal_macros::dec;
+use std::error::Error;
+use std::sync::atomic::{AtomicU32, Ordering};
+use std::sync::Arc;
+use uuid::Uuid;
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+fn new_facade(broker: impl Broker + 'static) -> TrustFacade {
+    TrustFacade::new(
+        Box::new(SqliteDatabase::new_in_memory()),
+        Box::new(broker),
+    )
+}
+
+fn setup_account(trust: &mut TrustFacade, deposit: Decimal) -> Account {
+    trust
+        .create_account(
+            "test",
+            "default",
+            model::Environment::Paper,
+            dec!(20),
+            dec!(10),
+        )
+        .unwrap();
+    let account = trust.search_account("test").unwrap();
+    trust
+        .create_transaction(
+            &account,
+            &TransactionCategory::Deposit,
+            deposit,
+            &Currency::USD,
+        )
+        .unwrap();
+    trust
+        .create_rule(
+            &account,
+            &RuleName::RiskPerMonth(6.0),
+            "risk month",
+            &RuleLevel::Error,
+        )
+        .unwrap();
+    trust
+        .create_rule(
+            &account,
+            &RuleName::RiskPerTrade(2.0),
+            "risk trade",
+            &RuleLevel::Error,
+        )
+        .unwrap();
+    account
+}
+
+fn create_vehicle(trust: &mut TrustFacade, symbol: &str) -> model::TradingVehicle {
+    let isin = format!("US{}", Uuid::new_v4().simple());
+    trust
+        .create_trading_vehicle(symbol, Some(&isin), &TradingVehicleCategory::Stock, "NASDAQ")
+        .unwrap()
+}
+
+fn create_submitted_trade(trust: &mut TrustFacade, account: &Account) -> Trade {
+    let tv = create_vehicle(trust, "TSLA");
+    let draft = DraftTrade {
+        account: account.clone(),
+        trading_vehicle: tv,
+        quantity: 500,
+        currency: Currency::USD,
+        category: TradeCategory::Long,
+        thesis: None,
+        sector: None,
+        asset_class: None,
+        context: None,
+    };
+    trust
+        .create_trade(draft, dec!(38), dec!(40), dec!(50))
+        .unwrap();
+    let trade = trust
+        .search_trades(account.id, Status::New)
+        .unwrap()
+        .pop()
+        .unwrap();
+    trust.fund_trade(&trade).unwrap();
+    let trade = trust
+        .search_trades(account.id, Status::Funded)
+        .unwrap()
+        .pop()
+        .unwrap();
+    trust.submit_trade(&trade).unwrap();
+    trust
+        .search_trades(account.id, Status::Submitted)
+        .unwrap()
+        .pop()
+        .unwrap()
+}
+
+fn now() -> chrono::NaiveDateTime {
+    Utc::now().naive_utc()
+}
+
+// ---------------------------------------------------------------------------
+// Broker implementations that simulate failure scenarios
+// ---------------------------------------------------------------------------
+
+/// Broker that always fails on sync_trade (network error, auth failure, etc.)
+struct SyncFailsBroker {
+    error_message: &'static str,
+}
+
+impl SyncFailsBroker {
+    fn new(msg: &'static str) -> Self {
+        Self {
+            error_message: msg,
+        }
+    }
+}
+
+impl Broker for SyncFailsBroker {
+    fn kind(&self) -> model::BrokerKind {
+        model::BrokerKind::Alpaca
+    }
+    fn submit_trade(
+        &self,
+        _: &Trade,
+        _: &Account,
+    ) -> Result<(BrokerLog, OrderIds), Box<dyn Error>> {
+        Ok((
+            BrokerLog::default(),
+            OrderIds {
+                entry: Uuid::new_v4().to_string(),
+                target: Uuid::new_v4().to_string(),
+                stop: Uuid::new_v4().to_string(),
+            },
+        ))
+    }
+    fn sync_trade(
+        &self,
+        _: &Trade,
+        _: &Account,
+    ) -> Result<(Status, Vec<Order>, BrokerLog), Box<dyn Error>> {
+        Err(self.error_message.into())
+    }
+    fn close_trade(&self, _: &Trade, _: &Account) -> Result<(Order, BrokerLog), Box<dyn Error>> {
+        unimplemented!()
+    }
+    fn cancel_trade(&self, _: &Trade, _: &Account) -> Result<(), Box<dyn Error>> {
+        Ok(())
+    }
+    fn modify_stop(&self, _: &Trade, _: &Account, _: Decimal) -> Result<String, Box<dyn Error>> {
+        unimplemented!()
+    }
+    fn modify_target(
+        &self,
+        _: &Trade,
+        _: &Account,
+        _: Decimal,
+    ) -> Result<String, Box<dyn Error>> {
+        unimplemented!()
+    }
+}
+
+/// Broker where sync_trade succeeds but fetch_executions fails
+struct ExecutionFetchFailsBroker {
+    #[allow(clippy::type_complexity)]
+    sync_fn: Box<dyn Fn(&Trade) -> (Status, Vec<Order>) + Send + Sync>,
+}
+
+impl ExecutionFetchFailsBroker {
+    fn new(sync_fn: impl Fn(&Trade) -> (Status, Vec<Order>) + Send + Sync + 'static) -> Self {
+        Self {
+            sync_fn: Box::new(sync_fn),
+        }
+    }
+}
+
+impl Broker for ExecutionFetchFailsBroker {
+    fn kind(&self) -> model::BrokerKind {
+        model::BrokerKind::Alpaca
+    }
+    fn submit_trade(
+        &self,
+        _: &Trade,
+        _: &Account,
+    ) -> Result<(BrokerLog, OrderIds), Box<dyn Error>> {
+        Ok((
+            BrokerLog::default(),
+            OrderIds {
+                entry: Uuid::new_v4().to_string(),
+                target: Uuid::new_v4().to_string(),
+                stop: Uuid::new_v4().to_string(),
+            },
+        ))
+    }
+    fn sync_trade(
+        &self,
+        trade: &Trade,
+        _: &Account,
+    ) -> Result<(Status, Vec<Order>, BrokerLog), Box<dyn Error>> {
+        let (status, orders) = (self.sync_fn)(trade);
+        Ok((status, orders, BrokerLog::default()))
+    }
+    fn close_trade(&self, _: &Trade, _: &Account) -> Result<(Order, BrokerLog), Box<dyn Error>> {
+        unimplemented!()
+    }
+    fn cancel_trade(&self, _: &Trade, _: &Account) -> Result<(), Box<dyn Error>> {
+        Ok(())
+    }
+    fn modify_stop(&self, _: &Trade, _: &Account, _: Decimal) -> Result<String, Box<dyn Error>> {
+        unimplemented!()
+    }
+    fn modify_target(
+        &self,
+        _: &Trade,
+        _: &Account,
+        _: Decimal,
+    ) -> Result<String, Box<dyn Error>> {
+        unimplemented!()
+    }
+    fn fetch_executions(
+        &self,
+        _: &Trade,
+        _: &Account,
+        _: Option<chrono::DateTime<Utc>>,
+    ) -> Result<Vec<Execution>, Box<dyn Error>> {
+        Err("Connection reset by peer".into())
+    }
+    fn fetch_fee_activities(
+        &self,
+        _: &Trade,
+        _: &Account,
+        _: Option<chrono::DateTime<Utc>>,
+    ) -> Result<Vec<FeeActivity>, Box<dyn Error>> {
+        Err("Connection reset by peer".into())
+    }
+}
+
+/// Broker that fails N times then succeeds
+struct TransientFailureBroker {
+    call_count: Arc<AtomicU32>,
+    failures_before_success: u32,
+    #[allow(clippy::type_complexity)]
+    success_fn: Box<dyn Fn(&Trade) -> (Status, Vec<Order>) + Send + Sync>,
+}
+
+impl TransientFailureBroker {
+    fn new(
+        failures: u32,
+        success_fn: impl Fn(&Trade) -> (Status, Vec<Order>) + Send + Sync + 'static,
+    ) -> Self {
+        Self {
+            call_count: Arc::new(AtomicU32::new(0)),
+            failures_before_success: failures,
+            success_fn: Box::new(success_fn),
+        }
+    }
+}
+
+impl Broker for TransientFailureBroker {
+    fn kind(&self) -> model::BrokerKind {
+        model::BrokerKind::Alpaca
+    }
+    fn submit_trade(
+        &self,
+        _: &Trade,
+        _: &Account,
+    ) -> Result<(BrokerLog, OrderIds), Box<dyn Error>> {
+        Ok((
+            BrokerLog::default(),
+            OrderIds {
+                entry: Uuid::new_v4().to_string(),
+                target: Uuid::new_v4().to_string(),
+                stop: Uuid::new_v4().to_string(),
+            },
+        ))
+    }
+    fn sync_trade(
+        &self,
+        trade: &Trade,
+        _: &Account,
+    ) -> Result<(Status, Vec<Order>, BrokerLog), Box<dyn Error>> {
+        let n = self.call_count.fetch_add(1, Ordering::SeqCst);
+        if n < self.failures_before_success {
+            Err(format!("Transient failure #{}", n + 1).into())
+        } else {
+            let (status, orders) = (self.success_fn)(trade);
+            Ok((status, orders, BrokerLog::default()))
+        }
+    }
+    fn close_trade(&self, _: &Trade, _: &Account) -> Result<(Order, BrokerLog), Box<dyn Error>> {
+        unimplemented!()
+    }
+    fn cancel_trade(&self, _: &Trade, _: &Account) -> Result<(), Box<dyn Error>> {
+        Ok(())
+    }
+    fn modify_stop(&self, _: &Trade, _: &Account, _: Decimal) -> Result<String, Box<dyn Error>> {
+        unimplemented!()
+    }
+    fn modify_target(
+        &self,
+        _: &Trade,
+        _: &Account,
+        _: Decimal,
+    ) -> Result<String, Box<dyn Error>> {
+        unimplemented!()
+    }
+}
+
+/// Broker that returns empty orders (partial data loss)
+struct EmptyOrdersBroker;
+
+impl Broker for EmptyOrdersBroker {
+    fn kind(&self) -> model::BrokerKind {
+        model::BrokerKind::Alpaca
+    }
+    fn submit_trade(
+        &self,
+        _: &Trade,
+        _: &Account,
+    ) -> Result<(BrokerLog, OrderIds), Box<dyn Error>> {
+        Ok((
+            BrokerLog::default(),
+            OrderIds {
+                entry: Uuid::new_v4().to_string(),
+                target: Uuid::new_v4().to_string(),
+                stop: Uuid::new_v4().to_string(),
+            },
+        ))
+    }
+    fn sync_trade(
+        &self,
+        _: &Trade,
+        _: &Account,
+    ) -> Result<(Status, Vec<Order>, BrokerLog), Box<dyn Error>> {
+        // Broker returns Filled status but no order data
+        Ok((Status::Filled, vec![], BrokerLog::default()))
+    }
+    fn close_trade(&self, _: &Trade, _: &Account) -> Result<(Order, BrokerLog), Box<dyn Error>> {
+        unimplemented!()
+    }
+    fn cancel_trade(&self, _: &Trade, _: &Account) -> Result<(), Box<dyn Error>> {
+        Ok(())
+    }
+    fn modify_stop(&self, _: &Trade, _: &Account, _: Decimal) -> Result<String, Box<dyn Error>> {
+        unimplemented!()
+    }
+    fn modify_target(
+        &self,
+        _: &Trade,
+        _: &Account,
+        _: Decimal,
+    ) -> Result<String, Box<dyn Error>> {
+        unimplemented!()
+    }
+}
+
+/// Broker that returns wrong/unknown order IDs
+struct WrongOrderIdBroker;
+
+impl Broker for WrongOrderIdBroker {
+    fn kind(&self) -> model::BrokerKind {
+        model::BrokerKind::Alpaca
+    }
+    fn submit_trade(
+        &self,
+        _: &Trade,
+        _: &Account,
+    ) -> Result<(BrokerLog, OrderIds), Box<dyn Error>> {
+        Ok((
+            BrokerLog::default(),
+            OrderIds {
+                entry: Uuid::new_v4().to_string(),
+                target: Uuid::new_v4().to_string(),
+                stop: Uuid::new_v4().to_string(),
+            },
+        ))
+    }
+    fn sync_trade(
+        &self,
+        _: &Trade,
+        _: &Account,
+    ) -> Result<(Status, Vec<Order>, BrokerLog), Box<dyn Error>> {
+        // Broker returns orders with IDs that don't match any trade orders
+        let fake_entry = Order {
+            id: Uuid::new_v4(), // Wrong ID
+            broker_order_id: Some(Uuid::new_v4().to_string()),
+            filled_quantity: 500,
+            average_filled_price: Some(dec!(40)),
+            status: OrderStatus::Filled,
+            filled_at: Some(now()),
+            ..Default::default()
+        };
+        Ok((Status::Filled, vec![fake_entry], BrokerLog::default()))
+    }
+    fn close_trade(&self, _: &Trade, _: &Account) -> Result<(Order, BrokerLog), Box<dyn Error>> {
+        unimplemented!()
+    }
+    fn cancel_trade(&self, _: &Trade, _: &Account) -> Result<(), Box<dyn Error>> {
+        Ok(())
+    }
+    fn modify_stop(&self, _: &Trade, _: &Account, _: Decimal) -> Result<String, Box<dyn Error>> {
+        unimplemented!()
+    }
+    fn modify_target(
+        &self,
+        _: &Trade,
+        _: &Account,
+        _: Decimal,
+    ) -> Result<String, Box<dyn Error>> {
+        unimplemented!()
+    }
+}
+
+/// Broker that returns duplicate order IDs in sync response
+struct DuplicateOrderIdBroker;
+
+impl Broker for DuplicateOrderIdBroker {
+    fn kind(&self) -> model::BrokerKind {
+        model::BrokerKind::Alpaca
+    }
+    fn submit_trade(
+        &self,
+        _: &Trade,
+        _: &Account,
+    ) -> Result<(BrokerLog, OrderIds), Box<dyn Error>> {
+        Ok((
+            BrokerLog::default(),
+            OrderIds {
+                entry: Uuid::new_v4().to_string(),
+                target: Uuid::new_v4().to_string(),
+                stop: Uuid::new_v4().to_string(),
+            },
+        ))
+    }
+    fn sync_trade(
+        &self,
+        trade: &Trade,
+        _: &Account,
+    ) -> Result<(Status, Vec<Order>, BrokerLog), Box<dyn Error>> {
+        // Return the same order twice (duplicate)
+        let entry = Order {
+            id: trade.entry.id,
+            broker_order_id: Some(Uuid::new_v4().to_string()),
+            status: OrderStatus::Accepted,
+            ..Default::default()
+        };
+        let entry_dup = Order {
+            id: trade.entry.id, // Same ID
+            broker_order_id: Some(Uuid::new_v4().to_string()),
+            status: OrderStatus::Filled,
+            filled_quantity: 500,
+            average_filled_price: Some(dec!(40)),
+            filled_at: Some(now()),
+            ..Default::default()
+        };
+        Ok((
+            Status::Submitted,
+            vec![entry, entry_dup],
+            BrokerLog::default(),
+        ))
+    }
+    fn close_trade(&self, _: &Trade, _: &Account) -> Result<(Order, BrokerLog), Box<dyn Error>> {
+        unimplemented!()
+    }
+    fn cancel_trade(&self, _: &Trade, _: &Account) -> Result<(), Box<dyn Error>> {
+        Ok(())
+    }
+    fn modify_stop(&self, _: &Trade, _: &Account, _: Decimal) -> Result<String, Box<dyn Error>> {
+        unimplemented!()
+    }
+    fn modify_target(
+        &self,
+        _: &Trade,
+        _: &Account,
+        _: Decimal,
+    ) -> Result<String, Box<dyn Error>> {
+        unimplemented!()
+    }
+}
+
+/// Broker that reports conflicting status (e.g. Filled with no filled orders)
+struct StatusMismatchBroker;
+
+impl Broker for StatusMismatchBroker {
+    fn kind(&self) -> model::BrokerKind {
+        model::BrokerKind::Alpaca
+    }
+    fn submit_trade(
+        &self,
+        _: &Trade,
+        _: &Account,
+    ) -> Result<(BrokerLog, OrderIds), Box<dyn Error>> {
+        Ok((
+            BrokerLog::default(),
+            OrderIds {
+                entry: Uuid::new_v4().to_string(),
+                target: Uuid::new_v4().to_string(),
+                stop: Uuid::new_v4().to_string(),
+            },
+        ))
+    }
+    fn sync_trade(
+        &self,
+        trade: &Trade,
+        _: &Account,
+    ) -> Result<(Status, Vec<Order>, BrokerLog), Box<dyn Error>> {
+        // Status says Filled, but entry order is only Accepted (not actually filled)
+        let entry = Order {
+            id: trade.entry.id,
+            broker_order_id: Some(Uuid::new_v4().to_string()),
+            status: OrderStatus::Accepted, // NOT filled
+            ..Default::default()
+        };
+        let target = Order {
+            id: trade.target.id,
+            broker_order_id: Some(Uuid::new_v4().to_string()),
+            status: OrderStatus::Held,
+            ..Default::default()
+        };
+        let stop = Order {
+            id: trade.safety_stop.id,
+            broker_order_id: Some(Uuid::new_v4().to_string()),
+            status: OrderStatus::Held,
+            ..Default::default()
+        };
+        Ok((Status::Filled, vec![entry, target, stop], BrokerLog::default()))
+    }
+    fn close_trade(&self, _: &Trade, _: &Account) -> Result<(Order, BrokerLog), Box<dyn Error>> {
+        unimplemented!()
+    }
+    fn cancel_trade(&self, _: &Trade, _: &Account) -> Result<(), Box<dyn Error>> {
+        Ok(())
+    }
+    fn modify_stop(&self, _: &Trade, _: &Account, _: Decimal) -> Result<String, Box<dyn Error>> {
+        unimplemented!()
+    }
+    fn modify_target(
+        &self,
+        _: &Trade,
+        _: &Account,
+        _: Decimal,
+    ) -> Result<String, Box<dyn Error>> {
+        unimplemented!()
+    }
+}
+
+/// Broker that submits OK but always fails on cancel
+struct CancelFailsBroker;
+
+impl Broker for CancelFailsBroker {
+    fn kind(&self) -> model::BrokerKind {
+        model::BrokerKind::Alpaca
+    }
+    fn submit_trade(
+        &self,
+        _: &Trade,
+        _: &Account,
+    ) -> Result<(BrokerLog, OrderIds), Box<dyn Error>> {
+        Ok((
+            BrokerLog::default(),
+            OrderIds {
+                entry: Uuid::new_v4().to_string(),
+                target: Uuid::new_v4().to_string(),
+                stop: Uuid::new_v4().to_string(),
+            },
+        ))
+    }
+    fn sync_trade(
+        &self,
+        _: &Trade,
+        _: &Account,
+    ) -> Result<(Status, Vec<Order>, BrokerLog), Box<dyn Error>> {
+        unimplemented!()
+    }
+    fn close_trade(&self, _: &Trade, _: &Account) -> Result<(Order, BrokerLog), Box<dyn Error>> {
+        unimplemented!()
+    }
+    fn cancel_trade(&self, _: &Trade, _: &Account) -> Result<(), Box<dyn Error>> {
+        Err("Broker cancel failed: order in transition state".into())
+    }
+    fn modify_stop(&self, _: &Trade, _: &Account, _: Decimal) -> Result<String, Box<dyn Error>> {
+        unimplemented!()
+    }
+    fn modify_target(
+        &self,
+        _: &Trade,
+        _: &Account,
+        _: Decimal,
+    ) -> Result<String, Box<dyn Error>> {
+        unimplemented!()
+    }
+}
+
+/// Broker that fails on submit_trade
+struct SubmitFailsBroker;
+
+impl Broker for SubmitFailsBroker {
+    fn kind(&self) -> model::BrokerKind {
+        model::BrokerKind::Alpaca
+    }
+    fn submit_trade(
+        &self,
+        _: &Trade,
+        _: &Account,
+    ) -> Result<(BrokerLog, OrderIds), Box<dyn Error>> {
+        Err("Market is closed".into())
+    }
+    fn sync_trade(
+        &self,
+        _: &Trade,
+        _: &Account,
+    ) -> Result<(Status, Vec<Order>, BrokerLog), Box<dyn Error>> {
+        unimplemented!()
+    }
+    fn close_trade(&self, _: &Trade, _: &Account) -> Result<(Order, BrokerLog), Box<dyn Error>> {
+        unimplemented!()
+    }
+    fn cancel_trade(&self, _: &Trade, _: &Account) -> Result<(), Box<dyn Error>> {
+        Ok(())
+    }
+    fn modify_stop(&self, _: &Trade, _: &Account, _: Decimal) -> Result<String, Box<dyn Error>> {
+        unimplemented!()
+    }
+    fn modify_target(
+        &self,
+        _: &Trade,
+        _: &Account,
+        _: Decimal,
+    ) -> Result<String, Box<dyn Error>> {
+        unimplemented!()
+    }
+}
+
+// ===========================================================================
+// 1. SYNC FAILURE — Broker API is down / returns error
+//    Verify: trade status unchanged, balance unchanged, no DB corruption
+// ===========================================================================
+
+#[test]
+fn test_sync_network_error_leaves_trade_unchanged() {
+    let mut trust = new_facade(SyncFailsBroker::new("connection timed out"));
+    let account = setup_account(&mut trust, dec!(50000));
+    let trade = create_submitted_trade(&mut trust, &account);
+
+    let result = trust.sync_trade(&trade, &account);
+    assert!(result.is_err());
+
+    // Trade must remain Submitted
+    let trades = trust
+        .search_trades(account.id, Status::Submitted)
+        .unwrap();
+    assert_eq!(trades.len(), 1);
+    assert_eq!(trades[0].id, trade.id);
+
+    // Balance must be unchanged
+    let balance = trust.search_balance(account.id, &Currency::USD).unwrap();
+    assert_eq!(balance.total_balance, dec!(50000));
+    assert_eq!(balance.total_available, dec!(30000)); // 50000 - 20000 funded
+    // total_in_trade = 0 after Funded→Submitted. This is safe because the
+    // risk gatekeeper is total_available (reduced by FundTrade), NOT total_in_trade.
+    // total_in_trade is a display/reporting field — never used in risk decisions.
+    assert_eq!(balance.total_in_trade, dec!(0));
+}
+
+#[test]
+fn test_sync_auth_error_leaves_trade_unchanged() {
+    let mut trust = new_facade(SyncFailsBroker::new("401 Unauthorized"));
+    let account = setup_account(&mut trust, dec!(50000));
+    let trade = create_submitted_trade(&mut trust, &account);
+
+    let result = trust.sync_trade(&trade, &account);
+    assert!(result.is_err());
+
+    let trades = trust
+        .search_trades(account.id, Status::Submitted)
+        .unwrap();
+    assert_eq!(trades.len(), 1);
+
+    let balance = trust.search_balance(account.id, &Currency::USD).unwrap();
+    assert_eq!(balance.total_available, dec!(30000));
+}
+
+#[test]
+fn test_sync_server_error_leaves_trade_unchanged() {
+    let mut trust = new_facade(SyncFailsBroker::new("500 Internal Server Error"));
+    let account = setup_account(&mut trust, dec!(50000));
+    let trade = create_submitted_trade(&mut trust, &account);
+
+    let result = trust.sync_trade(&trade, &account);
+    assert!(result.is_err());
+
+    let balance = trust.search_balance(account.id, &Currency::USD).unwrap();
+    assert_eq!(balance.total_balance, dec!(50000));
+    // total_in_trade = 0 after Funded→Submitted. This is safe because the
+    // risk gatekeeper is total_available (reduced by FundTrade), NOT total_in_trade.
+    // total_in_trade is a display/reporting field — never used in risk decisions.
+    assert_eq!(balance.total_in_trade, dec!(0));
+}
+
+// ===========================================================================
+// 2. EXECUTION/FEE FETCH FAILURE — Sync succeeds but execution feed is down
+//    Verify: trade transitions normally, fees/executions can be retried later
+// ===========================================================================
+
+#[test]
+fn test_execution_fetch_failure_does_not_block_sync() {
+    let broker = ExecutionFetchFailsBroker::new(|trade| {
+        let entry = Order {
+            id: trade.entry.id,
+            broker_order_id: Some(Uuid::new_v4().to_string()),
+            filled_quantity: trade.entry.quantity,
+            average_filled_price: Some(dec!(40)),
+            status: OrderStatus::Filled,
+            filled_at: Some(now()),
+            ..Default::default()
+        };
+        let target = Order {
+            id: trade.target.id,
+            broker_order_id: Some(Uuid::new_v4().to_string()),
+            status: OrderStatus::Accepted,
+            ..Default::default()
+        };
+        let stop = Order {
+            id: trade.safety_stop.id,
+            broker_order_id: Some(Uuid::new_v4().to_string()),
+            status: OrderStatus::Held,
+            ..Default::default()
+        };
+        (Status::Filled, vec![entry, target, stop])
+    });
+    let mut trust = new_facade(broker);
+    let account = setup_account(&mut trust, dec!(50000));
+    let trade = create_submitted_trade(&mut trust, &account);
+
+    // Should succeed despite execution/fee fetch failures (best-effort)
+    let result = trust.sync_trade(&trade, &account);
+    assert!(result.is_ok(), "sync should succeed even when execution fetch fails");
+
+    // Trade should be Filled
+    let filled = trust.search_trades(account.id, Status::Filled).unwrap();
+    assert_eq!(filled.len(), 1);
+
+    // Balance should reflect the fill
+    let balance = trust.search_balance(account.id, &Currency::USD).unwrap();
+    assert_eq!(balance.total_available, dec!(30000)); // No slippage at exact price
+}
+
+#[test]
+fn test_fee_fetch_failure_does_not_block_close() {
+    let broker = ExecutionFetchFailsBroker::new(|trade| {
+        let entry = Order {
+            id: trade.entry.id,
+            broker_order_id: Some(Uuid::new_v4().to_string()),
+            filled_quantity: trade.entry.quantity,
+            average_filled_price: Some(dec!(40)),
+            status: OrderStatus::Filled,
+            filled_at: Some(now()),
+            ..Default::default()
+        };
+        let target = Order {
+            id: trade.target.id,
+            broker_order_id: Some(Uuid::new_v4().to_string()),
+            filled_quantity: trade.entry.quantity,
+            average_filled_price: Some(dec!(50)),
+            status: OrderStatus::Filled,
+            filled_at: Some(now()),
+            ..Default::default()
+        };
+        let stop = Order {
+            id: trade.safety_stop.id,
+            broker_order_id: Some(Uuid::new_v4().to_string()),
+            status: OrderStatus::Canceled,
+            ..Default::default()
+        };
+        (Status::ClosedTarget, vec![entry, target, stop])
+    });
+    let mut trust = new_facade(broker);
+    let account = setup_account(&mut trust, dec!(50000));
+    let trade = create_submitted_trade(&mut trust, &account);
+
+    let result = trust.sync_trade(&trade, &account);
+    assert!(result.is_ok(), "close should succeed even when fee fetch fails");
+
+    let closed = trust
+        .search_trades(account.id, Status::ClosedTarget)
+        .unwrap();
+    assert_eq!(closed.len(), 1);
+    assert_eq!(closed[0].balance.total_performance, dec!(5000));
+}
+
+// ===========================================================================
+// 3. TRANSIENT FAILURE + RETRY — Fails N times then succeeds
+//    Verify: after recovery, balance is correct (no double-counting)
+// ===========================================================================
+
+#[test]
+fn test_transient_failures_then_success_no_corruption() {
+    let broker = TransientFailureBroker::new(3, |trade| {
+        let entry = Order {
+            id: trade.entry.id,
+            broker_order_id: Some(Uuid::new_v4().to_string()),
+            filled_quantity: trade.entry.quantity,
+            average_filled_price: Some(dec!(40)),
+            status: OrderStatus::Filled,
+            filled_at: Some(now()),
+            ..Default::default()
+        };
+        let target = Order {
+            id: trade.target.id,
+            broker_order_id: Some(Uuid::new_v4().to_string()),
+            status: OrderStatus::Accepted,
+            ..Default::default()
+        };
+        let stop = Order {
+            id: trade.safety_stop.id,
+            broker_order_id: Some(Uuid::new_v4().to_string()),
+            status: OrderStatus::Held,
+            ..Default::default()
+        };
+        (Status::Filled, vec![entry, target, stop])
+    });
+
+    let mut trust = new_facade(broker);
+    let account = setup_account(&mut trust, dec!(50000));
+    let trade = create_submitted_trade(&mut trust, &account);
+
+    // First 3 attempts fail
+    for i in 0..3 {
+        let result = trust.sync_trade(&trade, &account);
+        assert!(result.is_err(), "attempt {} should fail", i + 1);
+    }
+
+    // Trade should still be Submitted after all failures
+    let trades = trust
+        .search_trades(account.id, Status::Submitted)
+        .unwrap();
+    assert_eq!(trades.len(), 1);
+    let balance = trust.search_balance(account.id, &Currency::USD).unwrap();
+    // total_in_trade = 0 after Funded→Submitted transition
+    assert_eq!(balance.total_available, dec!(30000)); // Unchanged
+
+    // 4th attempt succeeds
+    let result = trust.sync_trade(&trade, &account);
+    assert!(result.is_ok(), "4th attempt should succeed");
+
+    let filled = trust.search_trades(account.id, Status::Filled).unwrap();
+    assert_eq!(filled.len(), 1);
+
+    let balance = trust.search_balance(account.id, &Currency::USD).unwrap();
+    assert_eq!(balance.total_available, dec!(30000)); // Exact price fill, no slippage
+}
+
+// ===========================================================================
+// 4. EMPTY ORDERS — Broker returns status but no order data
+//    Verify: system rejects inconsistent payload
+// ===========================================================================
+
+#[test]
+fn test_broker_returns_filled_with_no_orders_rejected() {
+    let mut trust = new_facade(EmptyOrdersBroker);
+    let account = setup_account(&mut trust, dec!(50000));
+    let trade = create_submitted_trade(&mut trust, &account);
+
+    // Broker says "Filled" but provides no orders → should be rejected
+    let result = trust.sync_trade(&trade, &account);
+    assert!(
+        result.is_err(),
+        "filled status with no orders should be rejected"
+    );
+
+    // Trade must remain Submitted
+    let trades = trust
+        .search_trades(account.id, Status::Submitted)
+        .unwrap();
+    assert_eq!(trades.len(), 1);
+
+    // Balance unchanged
+    let balance = trust.search_balance(account.id, &Currency::USD).unwrap();
+    assert_eq!(balance.total_available, dec!(30000));
+}
+
+// ===========================================================================
+// 5. WRONG ORDER IDS — Broker returns orders not belonging to trade
+//    Verify: system rejects unknown order IDs
+// ===========================================================================
+
+#[test]
+fn test_broker_returns_wrong_order_ids_rejected() {
+    let mut trust = new_facade(WrongOrderIdBroker);
+    let account = setup_account(&mut trust, dec!(50000));
+    let trade = create_submitted_trade(&mut trust, &account);
+
+    let result = trust.sync_trade(&trade, &account);
+    assert!(
+        result.is_err(),
+        "orders with unknown IDs should be rejected by resolve_orders_for_sync"
+    );
+
+    // Trade and balance unchanged
+    let trades = trust
+        .search_trades(account.id, Status::Submitted)
+        .unwrap();
+    assert_eq!(trades.len(), 1);
+    let balance = trust.search_balance(account.id, &Currency::USD).unwrap();
+    assert_eq!(balance.total_available, dec!(30000));
+}
+
+// ===========================================================================
+// 6. DUPLICATE ORDER IDS — Broker returns same order ID twice
+//    Verify: system rejects duplicate order IDs
+// ===========================================================================
+
+#[test]
+fn test_broker_returns_duplicate_order_ids_rejected() {
+    let mut trust = new_facade(DuplicateOrderIdBroker);
+    let account = setup_account(&mut trust, dec!(50000));
+    let trade = create_submitted_trade(&mut trust, &account);
+
+    let result = trust.sync_trade(&trade, &account);
+    assert!(
+        result.is_err(),
+        "duplicate order IDs should be rejected by resolve_orders_for_sync"
+    );
+
+    // Trade and balance unchanged
+    let trades = trust
+        .search_trades(account.id, Status::Submitted)
+        .unwrap();
+    assert_eq!(trades.len(), 1);
+}
+
+// ===========================================================================
+// 7. STATUS MISMATCH — Broker says Filled but entry is only Accepted
+//    Verify: system rejects via validate_sync_payload
+// ===========================================================================
+
+#[test]
+fn test_status_mismatch_filled_but_entry_not_filled_rejected() {
+    let mut trust = new_facade(StatusMismatchBroker);
+    let account = setup_account(&mut trust, dec!(50000));
+    let trade = create_submitted_trade(&mut trust, &account);
+
+    let result = trust.sync_trade(&trade, &account);
+    assert!(
+        result.is_err(),
+        "Filled status with unfilled entry should be rejected by validate_sync_payload"
+    );
+
+    let trades = trust
+        .search_trades(account.id, Status::Submitted)
+        .unwrap();
+    assert_eq!(trades.len(), 1);
+    let balance = trust.search_balance(account.id, &Currency::USD).unwrap();
+    assert_eq!(balance.total_available, dec!(30000));
+}
+
+// ===========================================================================
+// 8. SUBMIT FAILURE — Market closed or broker rejects order
+//    Verify: trade stays Funded, can be retried or canceled
+// ===========================================================================
+
+#[test]
+fn test_submit_failure_trade_stays_funded() {
+    let mut trust = new_facade(SubmitFailsBroker);
+    let account = setup_account(&mut trust, dec!(50000));
+    let tv = create_vehicle(&mut trust, "TSLA");
+    let draft = DraftTrade {
+        account: account.clone(),
+        trading_vehicle: tv,
+        quantity: 500,
+        currency: Currency::USD,
+        category: TradeCategory::Long,
+        thesis: None,
+        sector: None,
+        asset_class: None,
+        context: None,
+    };
+    trust
+        .create_trade(draft, dec!(38), dec!(40), dec!(50))
+        .unwrap();
+    let trade = trust
+        .search_trades(account.id, Status::New)
+        .unwrap()
+        .pop()
+        .unwrap();
+    trust.fund_trade(&trade).unwrap();
+    let trade = trust
+        .search_trades(account.id, Status::Funded)
+        .unwrap()
+        .pop()
+        .unwrap();
+
+    let result = trust.submit_trade(&trade);
+    assert!(result.is_err(), "submit should fail when market is closed");
+
+    // Trade must remain Funded
+    let funded = trust.search_trades(account.id, Status::Funded).unwrap();
+    assert_eq!(funded.len(), 1);
+
+    // Balance unchanged — funds still in trade (Funded→Submitted never happened)
+    let balance = trust.search_balance(account.id, &Currency::USD).unwrap();
+    assert_eq!(balance.total_available, dec!(30000));
+    assert_eq!(balance.total_in_trade, dec!(20000));
+}
+
+#[test]
+fn test_submit_failure_can_cancel_funded_trade() {
+    let mut trust = new_facade(SubmitFailsBroker);
+    let account = setup_account(&mut trust, dec!(50000));
+    let tv = create_vehicle(&mut trust, "TSLA");
+    let draft = DraftTrade {
+        account: account.clone(),
+        trading_vehicle: tv,
+        quantity: 500,
+        currency: Currency::USD,
+        category: TradeCategory::Long,
+        thesis: None,
+        sector: None,
+        asset_class: None,
+        context: None,
+    };
+    trust
+        .create_trade(draft, dec!(38), dec!(40), dec!(50))
+        .unwrap();
+    let trade = trust
+        .search_trades(account.id, Status::New)
+        .unwrap()
+        .pop()
+        .unwrap();
+    trust.fund_trade(&trade).unwrap();
+    let trade = trust
+        .search_trades(account.id, Status::Funded)
+        .unwrap()
+        .pop()
+        .unwrap();
+
+    // Submit fails
+    let _ = trust.submit_trade(&trade);
+
+    // Should be able to cancel the funded trade and recover funds
+    let funded = trust
+        .search_trades(account.id, Status::Funded)
+        .unwrap()
+        .pop()
+        .unwrap();
+    let (_, account_bal, tx) = trust.cancel_funded_trade(&funded).unwrap();
+
+    assert_eq!(tx.amount, dec!(20000));
+    assert_eq!(account_bal.total_available, dec!(50000)); // Fully restored
+    assert_eq!(account_bal.total_in_trade, dec!(0));
+}
+
+// ===========================================================================
+// 9. REPEATED SYNC FAILURES — Multiple failures must never corrupt state
+// ===========================================================================
+
+#[test]
+fn test_many_sync_failures_no_balance_drift() {
+    let mut trust = new_facade(SyncFailsBroker::new("gateway timeout"));
+    let account = setup_account(&mut trust, dec!(50000));
+    let trade = create_submitted_trade(&mut trust, &account);
+
+    // 100 failed syncs
+    for _ in 0..100 {
+        let _ = trust.sync_trade(&trade, &account);
+    }
+
+    // Balance must be exactly what it was after funding
+    let balance = trust.search_balance(account.id, &Currency::USD).unwrap();
+    assert_eq!(balance.total_balance, dec!(50000));
+    assert_eq!(balance.total_available, dec!(30000));
+    // total_in_trade = 0 after Funded→Submitted. This is safe because the
+    // risk gatekeeper is total_available (reduced by FundTrade), NOT total_in_trade.
+    // total_in_trade is a display/reporting field — never used in risk decisions.
+    assert_eq!(balance.total_in_trade, dec!(0));
+    assert_eq!(balance.taxed, dec!(0));
+
+    // Trade must still be Submitted
+    let trades = trust
+        .search_trades(account.id, Status::Submitted)
+        .unwrap();
+    assert_eq!(trades.len(), 1);
+}
+
+// ===========================================================================
+// 10. CANCEL BROKER FAILURE — Broker rejects cancel
+//     Verify: trade stays Funded in DB
+// ===========================================================================
+
+#[test]
+fn test_broker_cancel_fails_trade_stays_funded() {
+    let mut trust = new_facade(CancelFailsBroker);
+    let account = setup_account(&mut trust, dec!(50000));
+    let tv = create_vehicle(&mut trust, "TSLA");
+    let draft = DraftTrade {
+        account: account.clone(),
+        trading_vehicle: tv,
+        quantity: 500,
+        currency: Currency::USD,
+        category: TradeCategory::Long,
+        thesis: None,
+        sector: None,
+        asset_class: None,
+        context: None,
+    };
+    trust
+        .create_trade(draft, dec!(38), dec!(40), dec!(50))
+        .unwrap();
+    let trade = trust
+        .search_trades(account.id, Status::New)
+        .unwrap()
+        .pop()
+        .unwrap();
+    trust.fund_trade(&trade).unwrap();
+    let funded = trust
+        .search_trades(account.id, Status::Funded)
+        .unwrap()
+        .pop()
+        .unwrap();
+
+    // Cancel attempt should propagate the broker error
+    // Note: cancel_funded_trade calls broker.cancel_trade for submitted trades
+    // For funded trades, it may not call the broker at all (depends on implementation)
+    let result = trust.cancel_funded_trade(&funded);
+    // cancel_funded_trade on a Funded trade shouldn't need broker cancel
+    // It should succeed since the trade was never submitted
+    if result.is_ok() {
+        let balance = trust.search_balance(account.id, &Currency::USD).unwrap();
+        assert_eq!(balance.total_available, dec!(50000));
+    }
+    // Either way, balance must be consistent
+    let balance = trust.search_balance(account.id, &Currency::USD).unwrap();
+    assert_eq!(balance.total_balance, dec!(50000));
+}
+
+// ===========================================================================
+// 11. MULTIPLE TRADES — One fails sync, others unaffected
+// ===========================================================================
+
+#[test]
+fn test_sync_failure_on_one_trade_does_not_affect_others() {
+    // Use TransientFailureBroker: first sync fails, second succeeds
+    let broker = TransientFailureBroker::new(1, |trade| {
+        let entry = Order {
+            id: trade.entry.id,
+            broker_order_id: Some(Uuid::new_v4().to_string()),
+            filled_quantity: trade.entry.quantity,
+            average_filled_price: Some(dec!(40)),
+            status: OrderStatus::Filled,
+            filled_at: Some(now()),
+            ..Default::default()
+        };
+        let target = Order {
+            id: trade.target.id,
+            broker_order_id: Some(Uuid::new_v4().to_string()),
+            status: OrderStatus::Accepted,
+            ..Default::default()
+        };
+        let stop = Order {
+            id: trade.safety_stop.id,
+            broker_order_id: Some(Uuid::new_v4().to_string()),
+            status: OrderStatus::Held,
+            ..Default::default()
+        };
+        (Status::Filled, vec![entry, target, stop])
+    });
+
+    let mut trust = new_facade(broker);
+    let account = setup_account(&mut trust, dec!(100000));
+    let trade = create_submitted_trade(&mut trust, &account);
+
+    // First sync fails
+    let result = trust.sync_trade(&trade, &account);
+    assert!(result.is_err());
+
+    // Second sync succeeds
+    let result = trust.sync_trade(&trade, &account);
+    assert!(result.is_ok());
+
+    let filled = trust.search_trades(account.id, Status::Filled).unwrap();
+    assert_eq!(filled.len(), 1);
+
+    let balance = trust.search_balance(account.id, &Currency::USD).unwrap();
+    // 100000 deposit, 20000 funded, fill at exact price → available = 80000
+    assert_eq!(balance.total_available, dec!(80000));
+}
+
+// ===========================================================================
+// 12. BROKER KIND CONSISTENCY
+// ===========================================================================
+
+#[test]
+fn test_alpaca_broker_kind() {
+    let broker = SyncFailsBroker::new("test");
+    assert_eq!(broker.kind(), model::BrokerKind::Alpaca);
+}
+
+// ===========================================================================
+// 13. SYNC ERROR PRESERVES ERROR CONTEXT
+// ===========================================================================
+
+#[test]
+fn test_sync_error_message_is_preserved() {
+    let mut trust = new_facade(SyncFailsBroker::new("IBKR Client Portal Gateway is not ready"));
+    let account = setup_account(&mut trust, dec!(50000));
+    let trade = create_submitted_trade(&mut trust, &account);
+
+    let result = trust.sync_trade(&trade, &account);
+    assert!(result.is_err());
+    let err_msg = result.unwrap_err().to_string();
+    assert!(
+        err_msg.contains("Gateway is not ready"),
+        "error message should contain original broker error, got: {}",
+        err_msg
+    );
+}
+
+// ===========================================================================
+// 14. RISK INVARIANT — Cannot over-risk via total_in_trade = 0
+//     When a trade transitions Funded→Submitted, total_in_trade goes to 0.
+//     This MUST NOT allow funding more trades than total_available permits.
+//     The gatekeeper is total_available (reduced by FundTrade), not total_in_trade.
+// ===========================================================================
+
+#[test]
+fn test_cannot_over_risk_when_total_in_trade_is_zero() {
+    let mut trust = new_facade(SyncFailsBroker::new("not needed"));
+    let account = setup_account(&mut trust, dec!(50000));
+
+    // Fund and submit trade #1 → uses 20000 of available funds
+    let trade1 = create_submitted_trade(&mut trust, &account);
+
+    // After Funded→Submitted: total_in_trade = 0, total_available = 30000
+    let balance = trust.search_balance(account.id, &Currency::USD).unwrap();
+    assert_eq!(balance.total_in_trade, dec!(0));
+    assert_eq!(balance.total_available, dec!(30000));
+
+    // Try to fund trade #2 that requires 40000 — should fail even though total_in_trade is 0
+    let tv = create_vehicle(&mut trust, "AAPL");
+    let draft = DraftTrade {
+        account: account.clone(),
+        trading_vehicle: tv,
+        quantity: 1000, // 1000 * 40 = 40000 required
+        currency: Currency::USD,
+        category: TradeCategory::Long,
+        thesis: None,
+        sector: None,
+        asset_class: None,
+        context: None,
+    };
+    trust
+        .create_trade(draft, dec!(38), dec!(40), dec!(50))
+        .unwrap();
+    let trades_new = trust.search_trades(account.id, Status::New).unwrap();
+    let trade2 = trades_new
+        .iter()
+        .find(|t| t.id != trade1.id)
+        .unwrap();
+
+    let result = trust.fund_trade(trade2);
+    assert!(
+        result.is_err(),
+        "should NOT be able to fund 40000 when only 30000 is available, \
+         even though total_in_trade is 0"
+    );
+
+    // Balance unchanged
+    let balance = trust.search_balance(account.id, &Currency::USD).unwrap();
+    assert_eq!(balance.total_available, dec!(30000));
+}
+
+#[test]
+fn test_can_fund_second_trade_within_available_balance() {
+    let mut trust = new_facade(SyncFailsBroker::new("not needed"));
+    let account = setup_account(&mut trust, dec!(50000));
+
+    // Fund and submit trade #1 → uses 20000
+    let _trade1 = create_submitted_trade(&mut trust, &account);
+
+    let balance = trust.search_balance(account.id, &Currency::USD).unwrap();
+    assert_eq!(balance.total_available, dec!(30000));
+
+    // Fund trade #2 that requires only 10000 — should succeed
+    let tv = create_vehicle(&mut trust, "GOOG");
+    let draft = DraftTrade {
+        account: account.clone(),
+        trading_vehicle: tv,
+        quantity: 250, // 250 * 40 = 10000 required, within 30000 available
+        currency: Currency::USD,
+        category: TradeCategory::Long,
+        thesis: None,
+        sector: None,
+        asset_class: None,
+        context: None,
+    };
+    trust
+        .create_trade(draft, dec!(38), dec!(40), dec!(50))
+        .unwrap();
+    let new_trades = trust.search_trades(account.id, Status::New).unwrap();
+    assert_eq!(new_trades.len(), 1);
+
+    let result = trust.fund_trade(&new_trades[0]);
+    assert!(
+        result.is_ok(),
+        "should be able to fund 10000 when 30000 is available"
+    );
+
+    let balance = trust.search_balance(account.id, &Currency::USD).unwrap();
+    assert_eq!(balance.total_available, dec!(20000)); // 30000 - 10000
+}
+
+#[test]
+fn test_total_available_is_exact_gatekeeper_for_funding() {
+    let mut trust = new_facade(SyncFailsBroker::new("not needed"));
+    let account = setup_account(&mut trust, dec!(50000));
+
+    // Fund and submit trade #1 → 20000
+    let _trade1 = create_submitted_trade(&mut trust, &account);
+
+    // Fund trade #2 within risk limits: 2% of 30000 = 600 max risk
+    // price_diff = 40-38 = 2, max quantity = 600/2 = 300
+    // Funding = 300 * 40 = 12000
+    let tv = create_vehicle(&mut trust, "MSFT");
+    let draft = DraftTrade {
+        account: account.clone(),
+        trading_vehicle: tv,
+        quantity: 300,
+        currency: Currency::USD,
+        category: TradeCategory::Long,
+        thesis: None,
+        sector: None,
+        asset_class: None,
+        context: None,
+    };
+    trust
+        .create_trade(draft, dec!(38), dec!(40), dec!(50))
+        .unwrap();
+    let new_trades = trust.search_trades(account.id, Status::New).unwrap();
+
+    let result = trust.fund_trade(&new_trades[0]);
+    assert!(
+        result.is_ok(),
+        "should be able to fund within remaining available balance and risk limits"
+    );
+
+    let balance = trust.search_balance(account.id, &Currency::USD).unwrap();
+    assert_eq!(balance.total_available, dec!(18000)); // 30000 - 12000
+
+    // Try to fund another trade that exceeds remaining available
+    let tv = create_vehicle(&mut trust, "AMZN");
+    let draft = DraftTrade {
+        account: account.clone(),
+        trading_vehicle: tv,
+        quantity: 500, // 500 * 40 = 20000, but only 18000 available
+        currency: Currency::USD,
+        category: TradeCategory::Long,
+        thesis: None,
+        sector: None,
+        asset_class: None,
+        context: None,
+    };
+    trust
+        .create_trade(draft, dec!(38), dec!(40), dec!(50))
+        .unwrap();
+    let new_trades = trust.search_trades(account.id, Status::New).unwrap();
+
+    let result = trust.fund_trade(&new_trades[0]);
+    assert!(
+        result.is_err(),
+        "should NOT be able to fund 20000 when only 18000 is available"
+    );
+}

--- a/cli/tests/integration_test_broker_failures.rs
+++ b/cli/tests/integration_test_broker_failures.rs
@@ -30,10 +30,7 @@ use uuid::Uuid;
 // ---------------------------------------------------------------------------
 
 fn new_facade(broker: impl Broker + 'static) -> TrustFacade {
-    TrustFacade::new(
-        Box::new(SqliteDatabase::new_in_memory()),
-        Box::new(broker),
-    )
+    TrustFacade::new(Box::new(SqliteDatabase::new_in_memory()), Box::new(broker))
 }
 
 fn setup_account(trust: &mut TrustFacade, deposit: Decimal) -> Account {
@@ -77,7 +74,12 @@ fn setup_account(trust: &mut TrustFacade, deposit: Decimal) -> Account {
 fn create_vehicle(trust: &mut TrustFacade, symbol: &str) -> model::TradingVehicle {
     let isin = format!("US{}", Uuid::new_v4().simple());
     trust
-        .create_trading_vehicle(symbol, Some(&isin), &TradingVehicleCategory::Stock, "NASDAQ")
+        .create_trading_vehicle(
+            symbol,
+            Some(&isin),
+            &TradingVehicleCategory::Stock,
+            "NASDAQ",
+        )
         .unwrap()
 }
 
@@ -131,9 +133,7 @@ struct SyncFailsBroker {
 
 impl SyncFailsBroker {
     fn new(msg: &'static str) -> Self {
-        Self {
-            error_message: msg,
-        }
+        Self { error_message: msg }
     }
 }
 
@@ -171,12 +171,7 @@ impl Broker for SyncFailsBroker {
     fn modify_stop(&self, _: &Trade, _: &Account, _: Decimal) -> Result<String, Box<dyn Error>> {
         unimplemented!()
     }
-    fn modify_target(
-        &self,
-        _: &Trade,
-        _: &Account,
-        _: Decimal,
-    ) -> Result<String, Box<dyn Error>> {
+    fn modify_target(&self, _: &Trade, _: &Account, _: Decimal) -> Result<String, Box<dyn Error>> {
         unimplemented!()
     }
 }
@@ -230,12 +225,7 @@ impl Broker for ExecutionFetchFailsBroker {
     fn modify_stop(&self, _: &Trade, _: &Account, _: Decimal) -> Result<String, Box<dyn Error>> {
         unimplemented!()
     }
-    fn modify_target(
-        &self,
-        _: &Trade,
-        _: &Account,
-        _: Decimal,
-    ) -> Result<String, Box<dyn Error>> {
+    fn modify_target(&self, _: &Trade, _: &Account, _: Decimal) -> Result<String, Box<dyn Error>> {
         unimplemented!()
     }
     fn fetch_executions(
@@ -317,12 +307,7 @@ impl Broker for TransientFailureBroker {
     fn modify_stop(&self, _: &Trade, _: &Account, _: Decimal) -> Result<String, Box<dyn Error>> {
         unimplemented!()
     }
-    fn modify_target(
-        &self,
-        _: &Trade,
-        _: &Account,
-        _: Decimal,
-    ) -> Result<String, Box<dyn Error>> {
+    fn modify_target(&self, _: &Trade, _: &Account, _: Decimal) -> Result<String, Box<dyn Error>> {
         unimplemented!()
     }
 }
@@ -365,12 +350,7 @@ impl Broker for EmptyOrdersBroker {
     fn modify_stop(&self, _: &Trade, _: &Account, _: Decimal) -> Result<String, Box<dyn Error>> {
         unimplemented!()
     }
-    fn modify_target(
-        &self,
-        _: &Trade,
-        _: &Account,
-        _: Decimal,
-    ) -> Result<String, Box<dyn Error>> {
+    fn modify_target(&self, _: &Trade, _: &Account, _: Decimal) -> Result<String, Box<dyn Error>> {
         unimplemented!()
     }
 }
@@ -422,12 +402,7 @@ impl Broker for WrongOrderIdBroker {
     fn modify_stop(&self, _: &Trade, _: &Account, _: Decimal) -> Result<String, Box<dyn Error>> {
         unimplemented!()
     }
-    fn modify_target(
-        &self,
-        _: &Trade,
-        _: &Account,
-        _: Decimal,
-    ) -> Result<String, Box<dyn Error>> {
+    fn modify_target(&self, _: &Trade, _: &Account, _: Decimal) -> Result<String, Box<dyn Error>> {
         unimplemented!()
     }
 }
@@ -489,12 +464,7 @@ impl Broker for DuplicateOrderIdBroker {
     fn modify_stop(&self, _: &Trade, _: &Account, _: Decimal) -> Result<String, Box<dyn Error>> {
         unimplemented!()
     }
-    fn modify_target(
-        &self,
-        _: &Trade,
-        _: &Account,
-        _: Decimal,
-    ) -> Result<String, Box<dyn Error>> {
+    fn modify_target(&self, _: &Trade, _: &Account, _: Decimal) -> Result<String, Box<dyn Error>> {
         unimplemented!()
     }
 }
@@ -544,7 +514,11 @@ impl Broker for StatusMismatchBroker {
             status: OrderStatus::Held,
             ..Default::default()
         };
-        Ok((Status::Filled, vec![entry, target, stop], BrokerLog::default()))
+        Ok((
+            Status::Filled,
+            vec![entry, target, stop],
+            BrokerLog::default(),
+        ))
     }
     fn close_trade(&self, _: &Trade, _: &Account) -> Result<(Order, BrokerLog), Box<dyn Error>> {
         unimplemented!()
@@ -555,12 +529,7 @@ impl Broker for StatusMismatchBroker {
     fn modify_stop(&self, _: &Trade, _: &Account, _: Decimal) -> Result<String, Box<dyn Error>> {
         unimplemented!()
     }
-    fn modify_target(
-        &self,
-        _: &Trade,
-        _: &Account,
-        _: Decimal,
-    ) -> Result<String, Box<dyn Error>> {
+    fn modify_target(&self, _: &Trade, _: &Account, _: Decimal) -> Result<String, Box<dyn Error>> {
         unimplemented!()
     }
 }
@@ -602,12 +571,7 @@ impl Broker for CancelFailsBroker {
     fn modify_stop(&self, _: &Trade, _: &Account, _: Decimal) -> Result<String, Box<dyn Error>> {
         unimplemented!()
     }
-    fn modify_target(
-        &self,
-        _: &Trade,
-        _: &Account,
-        _: Decimal,
-    ) -> Result<String, Box<dyn Error>> {
+    fn modify_target(&self, _: &Trade, _: &Account, _: Decimal) -> Result<String, Box<dyn Error>> {
         unimplemented!()
     }
 }
@@ -642,12 +606,7 @@ impl Broker for SubmitFailsBroker {
     fn modify_stop(&self, _: &Trade, _: &Account, _: Decimal) -> Result<String, Box<dyn Error>> {
         unimplemented!()
     }
-    fn modify_target(
-        &self,
-        _: &Trade,
-        _: &Account,
-        _: Decimal,
-    ) -> Result<String, Box<dyn Error>> {
+    fn modify_target(&self, _: &Trade, _: &Account, _: Decimal) -> Result<String, Box<dyn Error>> {
         unimplemented!()
     }
 }
@@ -667,9 +626,7 @@ fn test_sync_network_error_leaves_trade_unchanged() {
     assert!(result.is_err());
 
     // Trade must remain Submitted
-    let trades = trust
-        .search_trades(account.id, Status::Submitted)
-        .unwrap();
+    let trades = trust.search_trades(account.id, Status::Submitted).unwrap();
     assert_eq!(trades.len(), 1);
     assert_eq!(trades[0].id, trade.id);
 
@@ -677,9 +634,9 @@ fn test_sync_network_error_leaves_trade_unchanged() {
     let balance = trust.search_balance(account.id, &Currency::USD).unwrap();
     assert_eq!(balance.total_balance, dec!(50000));
     assert_eq!(balance.total_available, dec!(30000)); // 50000 - 20000 funded
-    // total_in_trade = 0 after Funded→Submitted. This is safe because the
-    // risk gatekeeper is total_available (reduced by FundTrade), NOT total_in_trade.
-    // total_in_trade is a display/reporting field — never used in risk decisions.
+                                                      // total_in_trade = 0 after Funded→Submitted. This is safe because the
+                                                      // risk gatekeeper is total_available (reduced by FundTrade), NOT total_in_trade.
+                                                      // total_in_trade is a display/reporting field — never used in risk decisions.
     assert_eq!(balance.total_in_trade, dec!(0));
 }
 
@@ -692,9 +649,7 @@ fn test_sync_auth_error_leaves_trade_unchanged() {
     let result = trust.sync_trade(&trade, &account);
     assert!(result.is_err());
 
-    let trades = trust
-        .search_trades(account.id, Status::Submitted)
-        .unwrap();
+    let trades = trust.search_trades(account.id, Status::Submitted).unwrap();
     assert_eq!(trades.len(), 1);
 
     let balance = trust.search_balance(account.id, &Currency::USD).unwrap();
@@ -755,7 +710,10 @@ fn test_execution_fetch_failure_does_not_block_sync() {
 
     // Should succeed despite execution/fee fetch failures (best-effort)
     let result = trust.sync_trade(&trade, &account);
-    assert!(result.is_ok(), "sync should succeed even when execution fetch fails");
+    assert!(
+        result.is_ok(),
+        "sync should succeed even when execution fetch fails"
+    );
 
     // Trade should be Filled
     let filled = trust.search_trades(account.id, Status::Filled).unwrap();
@@ -800,7 +758,10 @@ fn test_fee_fetch_failure_does_not_block_close() {
     let trade = create_submitted_trade(&mut trust, &account);
 
     let result = trust.sync_trade(&trade, &account);
-    assert!(result.is_ok(), "close should succeed even when fee fetch fails");
+    assert!(
+        result.is_ok(),
+        "close should succeed even when fee fetch fails"
+    );
 
     let closed = trust
         .search_trades(account.id, Status::ClosedTarget)
@@ -852,9 +813,7 @@ fn test_transient_failures_then_success_no_corruption() {
     }
 
     // Trade should still be Submitted after all failures
-    let trades = trust
-        .search_trades(account.id, Status::Submitted)
-        .unwrap();
+    let trades = trust.search_trades(account.id, Status::Submitted).unwrap();
     assert_eq!(trades.len(), 1);
     let balance = trust.search_balance(account.id, &Currency::USD).unwrap();
     // total_in_trade = 0 after Funded→Submitted transition
@@ -890,9 +849,7 @@ fn test_broker_returns_filled_with_no_orders_rejected() {
     );
 
     // Trade must remain Submitted
-    let trades = trust
-        .search_trades(account.id, Status::Submitted)
-        .unwrap();
+    let trades = trust.search_trades(account.id, Status::Submitted).unwrap();
     assert_eq!(trades.len(), 1);
 
     // Balance unchanged
@@ -918,9 +875,7 @@ fn test_broker_returns_wrong_order_ids_rejected() {
     );
 
     // Trade and balance unchanged
-    let trades = trust
-        .search_trades(account.id, Status::Submitted)
-        .unwrap();
+    let trades = trust.search_trades(account.id, Status::Submitted).unwrap();
     assert_eq!(trades.len(), 1);
     let balance = trust.search_balance(account.id, &Currency::USD).unwrap();
     assert_eq!(balance.total_available, dec!(30000));
@@ -944,9 +899,7 @@ fn test_broker_returns_duplicate_order_ids_rejected() {
     );
 
     // Trade and balance unchanged
-    let trades = trust
-        .search_trades(account.id, Status::Submitted)
-        .unwrap();
+    let trades = trust.search_trades(account.id, Status::Submitted).unwrap();
     assert_eq!(trades.len(), 1);
 }
 
@@ -967,9 +920,7 @@ fn test_status_mismatch_filled_but_entry_not_filled_rejected() {
         "Filled status with unfilled entry should be rejected by validate_sync_payload"
     );
 
-    let trades = trust
-        .search_trades(account.id, Status::Submitted)
-        .unwrap();
+    let trades = trust.search_trades(account.id, Status::Submitted).unwrap();
     assert_eq!(trades.len(), 1);
     let balance = trust.search_balance(account.id, &Currency::USD).unwrap();
     assert_eq!(balance.total_available, dec!(30000));
@@ -1097,9 +1048,7 @@ fn test_many_sync_failures_no_balance_drift() {
     assert_eq!(balance.taxed, dec!(0));
 
     // Trade must still be Submitted
-    let trades = trust
-        .search_trades(account.id, Status::Submitted)
-        .unwrap();
+    let trades = trust.search_trades(account.id, Status::Submitted).unwrap();
     assert_eq!(trades.len(), 1);
 }
 
@@ -1222,7 +1171,9 @@ fn test_alpaca_broker_kind() {
 
 #[test]
 fn test_sync_error_message_is_preserved() {
-    let mut trust = new_facade(SyncFailsBroker::new("IBKR Client Portal Gateway is not ready"));
+    let mut trust = new_facade(SyncFailsBroker::new(
+        "IBKR Client Portal Gateway is not ready",
+    ));
     let account = setup_account(&mut trust, dec!(50000));
     let trade = create_submitted_trade(&mut trust, &account);
 
@@ -1273,10 +1224,7 @@ fn test_cannot_over_risk_when_total_in_trade_is_zero() {
         .create_trade(draft, dec!(38), dec!(40), dec!(50))
         .unwrap();
     let trades_new = trust.search_trades(account.id, Status::New).unwrap();
-    let trade2 = trades_new
-        .iter()
-        .find(|t| t.id != trade1.id)
-        .unwrap();
+    let trade2 = trades_new.iter().find(|t| t.id != trade1.id).unwrap();
 
     let result = trust.fund_trade(trade2);
     assert!(

--- a/cli/tests/integration_test_sync_edge_cases.rs
+++ b/cli/tests/integration_test_sync_edge_cases.rs
@@ -1,0 +1,1493 @@
+use chrono::{NaiveDateTime, Utc};
+use core::TrustFacade;
+use db_sqlite::SqliteDatabase;
+use model::{
+    Account, Broker, BrokerLog, Currency, DraftTrade, FeeActivity, Order, OrderIds, OrderStatus,
+    RuleLevel, RuleName, Status, Trade, TradeCategory, TradingVehicleCategory,
+    TransactionCategory,
+};
+use rust_decimal::Decimal;
+use rust_decimal_macros::dec;
+use std::error::Error;
+use std::sync::{Arc, Mutex};
+use uuid::Uuid;
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+fn setup_facade(broker: impl Broker + 'static) -> TrustFacade {
+    TrustFacade::new(
+        Box::new(SqliteDatabase::new_in_memory()),
+        Box::new(broker),
+    )
+}
+
+fn setup_account_with_rules(
+    trust: &mut TrustFacade,
+    deposit: Decimal,
+    risk_per_trade: f32,
+) -> Account {
+    trust
+        .create_account(
+            "test",
+            "default",
+            model::Environment::Paper,
+            dec!(20),
+            dec!(10),
+        )
+        .unwrap();
+    let account = trust.search_account("test").unwrap();
+    trust
+        .create_transaction(
+            &account,
+            &TransactionCategory::Deposit,
+            deposit,
+            &Currency::USD,
+        )
+        .unwrap();
+    trust
+        .create_rule(
+            &account,
+            &RuleName::RiskPerMonth(6.0),
+            "risk month",
+            &RuleLevel::Error,
+        )
+        .unwrap();
+    trust
+        .create_rule(
+            &account,
+            &RuleName::RiskPerTrade(risk_per_trade),
+            "risk trade",
+            &RuleLevel::Error,
+        )
+        .unwrap();
+    account
+}
+
+fn create_vehicle(trust: &mut TrustFacade, symbol: &str) -> model::TradingVehicle {
+    let isin = format!("US{}", Uuid::new_v4().simple());
+    trust
+        .create_trading_vehicle(
+            symbol,
+            Some(&isin),
+            &TradingVehicleCategory::Stock,
+            "NASDAQ",
+        )
+        .unwrap()
+}
+
+fn create_submitted_trade(
+    trust: &mut TrustFacade,
+    account: &Account,
+    symbol: &str,
+    stop: Decimal,
+    entry: Decimal,
+    target: Decimal,
+    quantity: u64,
+) -> Trade {
+    let tv = create_vehicle(trust, symbol);
+    let draft = DraftTrade {
+        account: account.clone(),
+        trading_vehicle: tv,
+        quantity: quantity as i64,
+        currency: Currency::USD,
+        category: TradeCategory::Long,
+        thesis: None,
+        sector: None,
+        asset_class: None,
+        context: None,
+    };
+    trust.create_trade(draft, stop, entry, target).unwrap();
+    let trade = trust
+        .search_trades(account.id, Status::New)
+        .unwrap()
+        .pop()
+        .unwrap();
+    trust.fund_trade(&trade).unwrap();
+    let trade = trust
+        .search_trades(account.id, Status::Funded)
+        .unwrap()
+        .pop()
+        .unwrap();
+    trust.submit_trade(&trade).unwrap();
+    trust
+        .search_trades(account.id, Status::Submitted)
+        .unwrap()
+        .pop()
+        .unwrap()
+}
+
+// ---------------------------------------------------------------------------
+// Stateful broker that supports fee activities and configurable sync responses
+// ---------------------------------------------------------------------------
+
+#[derive(Clone)]
+struct StatefulBroker {
+    state: Arc<Mutex<BrokerState>>,
+}
+
+struct BrokerState {
+    #[allow(clippy::type_complexity)]
+    sync_fn: Box<dyn Fn(&Trade) -> (Status, Vec<Order>) + Send>,
+    fees: Vec<FeeActivity>,
+}
+
+impl StatefulBroker {
+    fn new(sync_fn: impl Fn(&Trade) -> (Status, Vec<Order>) + Send + 'static) -> Self {
+        Self {
+            state: Arc::new(Mutex::new(BrokerState {
+                sync_fn: Box::new(sync_fn),
+                fees: vec![],
+            })),
+        }
+    }
+
+    fn with_fees(
+        sync_fn: impl Fn(&Trade) -> (Status, Vec<Order>) + Send + 'static,
+        fees: Vec<FeeActivity>,
+    ) -> Self {
+        Self {
+            state: Arc::new(Mutex::new(BrokerState {
+                sync_fn: Box::new(sync_fn),
+                fees,
+            })),
+        }
+    }
+}
+
+impl Broker for StatefulBroker {
+    fn kind(&self) -> model::BrokerKind {
+        model::BrokerKind::Alpaca
+    }
+
+    fn submit_trade(
+        &self,
+        _: &Trade,
+        _: &Account,
+    ) -> Result<(BrokerLog, OrderIds), Box<dyn Error>> {
+        Ok((
+            BrokerLog::default(),
+            OrderIds {
+                entry: Uuid::new_v4().to_string(),
+                target: Uuid::new_v4().to_string(),
+                stop: Uuid::new_v4().to_string(),
+            },
+        ))
+    }
+
+    fn sync_trade(
+        &self,
+        trade: &Trade,
+        _: &Account,
+    ) -> Result<(Status, Vec<Order>, BrokerLog), Box<dyn Error>> {
+        let state = self.state.lock().unwrap();
+        let (status, orders) = (state.sync_fn)(trade);
+        Ok((status, orders, BrokerLog::default()))
+    }
+
+    fn close_trade(&self, _: &Trade, _: &Account) -> Result<(Order, BrokerLog), Box<dyn Error>> {
+        unimplemented!()
+    }
+
+    fn cancel_trade(&self, _: &Trade, _: &Account) -> Result<(), Box<dyn Error>> {
+        Ok(())
+    }
+
+    fn modify_stop(&self, _: &Trade, _: &Account, _: Decimal) -> Result<String, Box<dyn Error>> {
+        unimplemented!()
+    }
+
+    fn modify_target(
+        &self,
+        _: &Trade,
+        _: &Account,
+        _: Decimal,
+    ) -> Result<String, Box<dyn Error>> {
+        unimplemented!()
+    }
+
+    fn fetch_fee_activities(
+        &self,
+        _trade: &Trade,
+        _account: &Account,
+        _after: Option<chrono::DateTime<Utc>>,
+    ) -> Result<Vec<FeeActivity>, Box<dyn Error>> {
+        let state = self.state.lock().unwrap();
+        Ok(state.fees.clone())
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Simple NoOp broker
+// ---------------------------------------------------------------------------
+
+struct NoOpBroker;
+impl Broker for NoOpBroker {
+    fn kind(&self) -> model::BrokerKind {
+        model::BrokerKind::Alpaca
+    }
+    fn submit_trade(
+        &self,
+        _: &Trade,
+        _: &Account,
+    ) -> Result<(BrokerLog, OrderIds), Box<dyn Error>> {
+        Ok((
+            BrokerLog::default(),
+            OrderIds {
+                entry: Uuid::new_v4().to_string(),
+                target: Uuid::new_v4().to_string(),
+                stop: Uuid::new_v4().to_string(),
+            },
+        ))
+    }
+    fn sync_trade(
+        &self,
+        _: &Trade,
+        _: &Account,
+    ) -> Result<(Status, Vec<Order>, BrokerLog), Box<dyn Error>> {
+        unimplemented!()
+    }
+    fn close_trade(&self, _: &Trade, _: &Account) -> Result<(Order, BrokerLog), Box<dyn Error>> {
+        unimplemented!()
+    }
+    fn cancel_trade(&self, _: &Trade, _: &Account) -> Result<(), Box<dyn Error>> {
+        unimplemented!()
+    }
+    fn modify_stop(&self, _: &Trade, _: &Account, _: Decimal) -> Result<String, Box<dyn Error>> {
+        unimplemented!()
+    }
+    fn modify_target(
+        &self,
+        _: &Trade,
+        _: &Account,
+        _: Decimal,
+    ) -> Result<String, Box<dyn Error>> {
+        unimplemented!()
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Response helpers
+// ---------------------------------------------------------------------------
+
+fn now() -> NaiveDateTime {
+    Utc::now().naive_utc()
+}
+
+fn make_filled_entry(trade: &Trade, price: Decimal) -> Order {
+    Order {
+        id: trade.entry.id,
+        broker_order_id: Some(Uuid::new_v4().to_string()),
+        filled_quantity: trade.entry.quantity,
+        average_filled_price: Some(price),
+        status: OrderStatus::Filled,
+        filled_at: Some(now()),
+        ..Default::default()
+    }
+}
+
+fn make_filled_target(trade: &Trade, price: Decimal) -> Order {
+    Order {
+        id: trade.target.id,
+        broker_order_id: Some(Uuid::new_v4().to_string()),
+        filled_quantity: trade.entry.quantity,
+        average_filled_price: Some(price),
+        status: OrderStatus::Filled,
+        filled_at: Some(now()),
+        ..Default::default()
+    }
+}
+
+fn make_filled_stop(trade: &Trade, price: Decimal) -> Order {
+    Order {
+        id: trade.safety_stop.id,
+        broker_order_id: Some(Uuid::new_v4().to_string()),
+        filled_quantity: trade.entry.quantity,
+        average_filled_price: Some(price),
+        status: OrderStatus::Filled,
+        filled_at: Some(now()),
+        ..Default::default()
+    }
+}
+
+fn make_canceled_order(trade_order: &Order) -> Order {
+    Order {
+        id: trade_order.id,
+        broker_order_id: Some(Uuid::new_v4().to_string()),
+        status: OrderStatus::Canceled,
+        ..Default::default()
+    }
+}
+
+fn make_held_order(trade_order: &Order) -> Order {
+    Order {
+        id: trade_order.id,
+        broker_order_id: Some(Uuid::new_v4().to_string()),
+        status: OrderStatus::Held,
+        ..Default::default()
+    }
+}
+
+fn make_accepted_order(trade_order: &Order) -> Order {
+    Order {
+        id: trade_order.id,
+        broker_order_id: Some(Uuid::new_v4().to_string()),
+        status: OrderStatus::Accepted,
+        ..Default::default()
+    }
+}
+
+// ===========================================================================
+// 1. SUBMITTED → CLOSED DIRECTLY (single sync fills entry + closes)
+//    This is the "fast path" where broker reports everything in one update.
+// ===========================================================================
+
+#[test]
+fn test_submitted_to_closed_target_in_single_sync() {
+    // Broker reports entry filled AND target filled in one sync call
+    let broker = StatefulBroker::new(|trade| {
+        let entry = make_filled_entry(trade, dec!(40));
+        let target = make_filled_target(trade, dec!(50));
+        let stop = make_canceled_order(&trade.safety_stop);
+        (Status::ClosedTarget, vec![entry, target, stop])
+    });
+    let mut trust = setup_facade(broker);
+    let account = setup_account_with_rules(&mut trust, dec!(50000), 2.0);
+    let trade = create_submitted_trade(
+        &mut trust,
+        &account,
+        "TSLA",
+        dec!(38),
+        dec!(40),
+        dec!(50),
+        500,
+    );
+
+    trust.sync_trade(&trade, &account).unwrap();
+
+    let closed = trust
+        .search_trades(account.id, Status::ClosedTarget)
+        .unwrap();
+    assert_eq!(closed.len(), 1);
+    let closed_trade = &closed[0];
+
+    // Performance = target(50*500) - entry(40*500) = 25000 - 20000 = 5000
+    assert_eq!(closed_trade.balance.total_performance, dec!(5000));
+    assert_eq!(closed_trade.balance.capital_in_market, dec!(0));
+    assert_eq!(closed_trade.balance.capital_out_market, dec!(0));
+
+    let balance = trust.search_balance(account.id, &Currency::USD).unwrap();
+    assert_eq!(balance.total_balance, dec!(55000)); // 50000 + 5000
+    assert_eq!(balance.total_available, dec!(55000));
+    assert_eq!(balance.total_in_trade, dec!(0));
+}
+
+#[test]
+fn test_submitted_to_closed_stop_in_single_sync() {
+    // Broker reports entry filled AND stop filled in one sync call
+    let broker = StatefulBroker::new(|trade| {
+        let entry = make_filled_entry(trade, dec!(40));
+        let stop = make_filled_stop(trade, dec!(38));
+        let target = make_canceled_order(&trade.target);
+        (Status::ClosedStopLoss, vec![entry, stop, target])
+    });
+    let mut trust = setup_facade(broker);
+    let account = setup_account_with_rules(&mut trust, dec!(50000), 2.0);
+    let trade = create_submitted_trade(
+        &mut trust,
+        &account,
+        "TSLA",
+        dec!(38),
+        dec!(40),
+        dec!(50),
+        500,
+    );
+
+    trust.sync_trade(&trade, &account).unwrap();
+
+    let closed = trust
+        .search_trades(account.id, Status::ClosedStopLoss)
+        .unwrap();
+    assert_eq!(closed.len(), 1);
+
+    // Performance = stop(38*500) - entry(40*500) = 19000 - 20000 = -1000
+    assert_eq!(closed[0].balance.total_performance, dec!(-1000));
+
+    let balance = trust.search_balance(account.id, &Currency::USD).unwrap();
+    assert_eq!(balance.total_balance, dec!(49000)); // 50000 - 1000
+    assert_eq!(balance.total_available, dec!(49000));
+    assert_eq!(balance.total_in_trade, dec!(0));
+}
+
+// ===========================================================================
+// 2. IDEMPOTENT RE-SYNC — already-closed trade synced again
+// ===========================================================================
+
+#[test]
+fn test_resync_already_closed_target_is_noop() {
+    let broker = StatefulBroker::new(|trade| {
+        let entry = make_filled_entry(trade, dec!(40));
+        let target = make_filled_target(trade, dec!(50));
+        let stop = make_canceled_order(&trade.safety_stop);
+        (Status::ClosedTarget, vec![entry, target, stop])
+    });
+    let mut trust = setup_facade(broker);
+    let account = setup_account_with_rules(&mut trust, dec!(50000), 2.0);
+    let trade = create_submitted_trade(
+        &mut trust,
+        &account,
+        "TSLA",
+        dec!(38),
+        dec!(40),
+        dec!(50),
+        500,
+    );
+
+    // Sync multiple times
+    for _ in 0..5 {
+        trust.sync_trade(&trade, &account).unwrap();
+    }
+
+    let closed = trust
+        .search_trades(account.id, Status::ClosedTarget)
+        .unwrap();
+    assert_eq!(closed.len(), 1, "no duplicate closed trades");
+
+    let balance = trust.search_balance(account.id, &Currency::USD).unwrap();
+    assert_eq!(balance.total_balance, dec!(55000));
+    assert_eq!(balance.total_available, dec!(55000));
+}
+
+#[test]
+fn test_resync_already_closed_stop_is_noop() {
+    let broker = StatefulBroker::new(|trade| {
+        let entry = make_filled_entry(trade, dec!(40));
+        let stop = make_filled_stop(trade, dec!(38));
+        let target = make_canceled_order(&trade.target);
+        (Status::ClosedStopLoss, vec![entry, stop, target])
+    });
+    let mut trust = setup_facade(broker);
+    let account = setup_account_with_rules(&mut trust, dec!(50000), 2.0);
+    let trade = create_submitted_trade(
+        &mut trust,
+        &account,
+        "TSLA",
+        dec!(38),
+        dec!(40),
+        dec!(50),
+        500,
+    );
+
+    for _ in 0..5 {
+        trust.sync_trade(&trade, &account).unwrap();
+    }
+
+    let closed = trust
+        .search_trades(account.id, Status::ClosedStopLoss)
+        .unwrap();
+    assert_eq!(closed.len(), 1);
+
+    let balance = trust.search_balance(account.id, &Currency::USD).unwrap();
+    assert_eq!(balance.total_balance, dec!(49000));
+}
+
+// ===========================================================================
+// 3. SUBMITTED → SUBMITTED (no fills yet, orders just accepted)
+// ===========================================================================
+
+#[test]
+fn test_sync_submitted_no_fills_is_noop() {
+    let broker = StatefulBroker::new(|trade| {
+        let entry = make_accepted_order(&trade.entry);
+        let target = make_held_order(&trade.target);
+        let stop = make_held_order(&trade.safety_stop);
+        (Status::Submitted, vec![entry, target, stop])
+    });
+    let mut trust = setup_facade(broker);
+    let account = setup_account_with_rules(&mut trust, dec!(50000), 2.0);
+    let trade = create_submitted_trade(
+        &mut trust,
+        &account,
+        "TSLA",
+        dec!(38),
+        dec!(40),
+        dec!(50),
+        500,
+    );
+
+    trust.sync_trade(&trade, &account).unwrap();
+
+    let trades = trust
+        .search_trades(account.id, Status::Submitted)
+        .unwrap();
+    assert_eq!(trades.len(), 1);
+    assert_eq!(trades[0].status, Status::Submitted);
+
+    let balance = trust.search_balance(account.id, &Currency::USD).unwrap();
+    assert_eq!(balance.total_available, dec!(30000)); // Unchanged from funding
+}
+
+// ===========================================================================
+// 4. FEE RECONCILIATION — Broker-reported fees create fee transactions
+// ===========================================================================
+
+#[test]
+fn test_fee_activity_matched_by_broker_order_id() {
+    let entry_broker_id = Uuid::new_v4().to_string();
+    let entry_broker_id_clone = entry_broker_id.clone();
+
+    let broker = StatefulBroker::with_fees(
+        move |trade| {
+            let entry = Order {
+                id: trade.entry.id,
+                broker_order_id: Some(entry_broker_id_clone.clone()),
+                filled_quantity: trade.entry.quantity,
+                average_filled_price: Some(dec!(40)),
+                status: OrderStatus::Filled,
+                filled_at: Some(now()),
+                ..Default::default()
+            };
+            let target = make_accepted_order(&trade.target);
+            let stop = make_held_order(&trade.safety_stop);
+            (Status::Filled, vec![entry, target, stop])
+        },
+        vec![FeeActivity {
+            broker: "alpaca".to_string(),
+            broker_activity_id: "fee-001".to_string(),
+            account_id: Uuid::nil(), // Will be ignored in matching
+            broker_order_id: Some(entry_broker_id.clone()),
+            symbol: Some("TSLA".to_string()),
+            activity_type: "FEE".to_string(),
+            amount: dec!(5.50),
+            occurred_at: now(),
+            raw_json: None,
+        }],
+    );
+
+    let mut trust = setup_facade(broker);
+    let account = setup_account_with_rules(&mut trust, dec!(50000), 2.0);
+    let trade = create_submitted_trade(
+        &mut trust,
+        &account,
+        "TSLA",
+        dec!(38),
+        dec!(40),
+        dec!(50),
+        500,
+    );
+
+    trust.sync_trade(&trade, &account).unwrap();
+
+    // Fee should reduce total_available
+    let balance = trust.search_balance(account.id, &Currency::USD).unwrap();
+    // Without fee: 30000 (from funding). With 5.50 fee: 30000 - 5.50 = 29994.50
+    assert_eq!(balance.total_available, dec!(29994.50));
+
+    // Verify fee transaction exists
+    let txs = trust.get_account_transactions(account.id).unwrap();
+    let fee_txs: Vec<_> = txs
+        .iter()
+        .filter(|t| matches!(t.category, TransactionCategory::FeeOpen(_)))
+        .collect();
+    assert_eq!(fee_txs.len(), 1, "should have exactly one FeeOpen transaction");
+    assert_eq!(fee_txs[0].amount, dec!(5.50));
+}
+
+#[test]
+fn test_fee_activity_matched_by_symbol_and_day_heuristic() {
+    // Fee has no broker_order_id, but matches symbol + day
+    let broker = StatefulBroker::with_fees(
+        |trade| {
+            let entry = Order {
+                id: trade.entry.id,
+                broker_order_id: Some(Uuid::new_v4().to_string()),
+                filled_quantity: trade.entry.quantity,
+                average_filled_price: Some(dec!(40)),
+                status: OrderStatus::Filled,
+                filled_at: Some(now()),
+                ..Default::default()
+            };
+            let target = make_accepted_order(&trade.target);
+            let stop = make_held_order(&trade.safety_stop);
+            (Status::Filled, vec![entry, target, stop])
+        },
+        vec![FeeActivity {
+            broker: "alpaca".to_string(),
+            broker_activity_id: "fee-heuristic-001".to_string(),
+            account_id: Uuid::nil(),
+            broker_order_id: None, // No direct match
+            symbol: Some("TSLA".to_string()),
+            activity_type: "FEE".to_string(),
+            amount: dec!(3.25),
+            occurred_at: now(), // Same day as fill
+            raw_json: None,
+        }],
+    );
+
+    let mut trust = setup_facade(broker);
+    let account = setup_account_with_rules(&mut trust, dec!(50000), 2.0);
+    let trade = create_submitted_trade(
+        &mut trust,
+        &account,
+        "TSLA",
+        dec!(38),
+        dec!(40),
+        dec!(50),
+        500,
+    );
+
+    trust.sync_trade(&trade, &account).unwrap();
+
+    let txs = trust.get_account_transactions(account.id).unwrap();
+    let fee_txs: Vec<_> = txs
+        .iter()
+        .filter(|t| matches!(t.category, TransactionCategory::FeeOpen(_)))
+        .collect();
+    assert_eq!(
+        fee_txs.len(),
+        1,
+        "fee should match via symbol+day heuristic"
+    );
+    assert_eq!(fee_txs[0].amount, dec!(3.25));
+}
+
+#[test]
+fn test_fee_activity_wrong_symbol_not_matched() {
+    let broker = StatefulBroker::with_fees(
+        |trade| {
+            let entry = make_filled_entry(trade, dec!(40));
+            let target = make_accepted_order(&trade.target);
+            let stop = make_held_order(&trade.safety_stop);
+            (Status::Filled, vec![entry, target, stop])
+        },
+        vec![FeeActivity {
+            broker: "alpaca".to_string(),
+            broker_activity_id: "fee-wrong-symbol".to_string(),
+            account_id: Uuid::nil(),
+            broker_order_id: None,
+            symbol: Some("AAPL".to_string()), // Different symbol
+            activity_type: "FEE".to_string(),
+            amount: dec!(10.00),
+            occurred_at: now(),
+            raw_json: None,
+        }],
+    );
+
+    let mut trust = setup_facade(broker);
+    let account = setup_account_with_rules(&mut trust, dec!(50000), 2.0);
+    let trade = create_submitted_trade(
+        &mut trust,
+        &account,
+        "TSLA",
+        dec!(38),
+        dec!(40),
+        dec!(50),
+        500,
+    );
+
+    trust.sync_trade(&trade, &account).unwrap();
+
+    let txs = trust.get_account_transactions(account.id).unwrap();
+    let fee_txs: Vec<_> = txs
+        .iter()
+        .filter(|t| matches!(t.category, TransactionCategory::FeeOpen(_)))
+        .collect();
+    assert_eq!(fee_txs.len(), 0, "fee for wrong symbol should not be matched");
+
+    let balance = trust.search_balance(account.id, &Currency::USD).unwrap();
+    assert_eq!(balance.total_available, dec!(30000)); // No fee deducted
+}
+
+#[test]
+fn test_fee_not_duplicated_on_resync() {
+    let entry_broker_id = Uuid::new_v4().to_string();
+    let entry_broker_id_clone = entry_broker_id.clone();
+
+    let broker = StatefulBroker::with_fees(
+        move |trade| {
+            let entry = Order {
+                id: trade.entry.id,
+                broker_order_id: Some(entry_broker_id_clone.clone()),
+                filled_quantity: trade.entry.quantity,
+                average_filled_price: Some(dec!(40)),
+                status: OrderStatus::Filled,
+                filled_at: Some(now()),
+                ..Default::default()
+            };
+            let target = make_accepted_order(&trade.target);
+            let stop = make_held_order(&trade.safety_stop);
+            (Status::Filled, vec![entry, target, stop])
+        },
+        vec![FeeActivity {
+            broker: "alpaca".to_string(),
+            broker_activity_id: "fee-idempotent".to_string(),
+            account_id: Uuid::nil(),
+            broker_order_id: Some(entry_broker_id),
+            symbol: Some("TSLA".to_string()),
+            activity_type: "FEE".to_string(),
+            amount: dec!(7.00),
+            occurred_at: now(),
+            raw_json: None,
+        }],
+    );
+
+    let mut trust = setup_facade(broker);
+    let account = setup_account_with_rules(&mut trust, dec!(50000), 2.0);
+    let trade = create_submitted_trade(
+        &mut trust,
+        &account,
+        "TSLA",
+        dec!(38),
+        dec!(40),
+        dec!(50),
+        500,
+    );
+
+    // Sync multiple times — fee should only be created once
+    for _ in 0..5 {
+        trust.sync_trade(&trade, &account).unwrap();
+    }
+
+    let txs = trust.get_account_transactions(account.id).unwrap();
+    let fee_txs: Vec<_> = txs
+        .iter()
+        .filter(|t| matches!(t.category, TransactionCategory::FeeOpen(_)))
+        .collect();
+    assert_eq!(fee_txs.len(), 1, "fee should not be duplicated on resync");
+    assert_eq!(fee_txs[0].amount, dec!(7.00));
+
+    let balance = trust.search_balance(account.id, &Currency::USD).unwrap();
+    assert_eq!(balance.total_available, dec!(29993)); // 30000 - 7
+}
+
+// ===========================================================================
+// 5. CLOSING FEE — Fee matched to exit order
+// ===========================================================================
+
+#[test]
+fn test_closing_fee_matched_to_target_order() {
+    let target_broker_id = Uuid::new_v4().to_string();
+    let target_broker_id_clone = target_broker_id.clone();
+
+    let broker = StatefulBroker::with_fees(
+        move |trade| {
+            let entry = make_filled_entry(trade, dec!(40));
+            let target = Order {
+                id: trade.target.id,
+                broker_order_id: Some(target_broker_id_clone.clone()),
+                filled_quantity: trade.entry.quantity,
+                average_filled_price: Some(dec!(50)),
+                status: OrderStatus::Filled,
+                filled_at: Some(now()),
+                ..Default::default()
+            };
+            let stop = make_canceled_order(&trade.safety_stop);
+            (Status::ClosedTarget, vec![entry, target, stop])
+        },
+        vec![FeeActivity {
+            broker: "alpaca".to_string(),
+            broker_activity_id: "fee-close-001".to_string(),
+            account_id: Uuid::nil(),
+            broker_order_id: Some(target_broker_id),
+            symbol: Some("TSLA".to_string()),
+            activity_type: "FEE".to_string(),
+            amount: dec!(4.00),
+            occurred_at: now(),
+            raw_json: None,
+        }],
+    );
+
+    let mut trust = setup_facade(broker);
+    let account = setup_account_with_rules(&mut trust, dec!(50000), 2.0);
+    let trade = create_submitted_trade(
+        &mut trust,
+        &account,
+        "TSLA",
+        dec!(38),
+        dec!(40),
+        dec!(50),
+        500,
+    );
+
+    trust.sync_trade(&trade, &account).unwrap();
+
+    let txs = trust.get_account_transactions(account.id).unwrap();
+    let fee_close_txs: Vec<_> = txs
+        .iter()
+        .filter(|t| matches!(t.category, TransactionCategory::FeeClose(_)))
+        .collect();
+    assert_eq!(fee_close_txs.len(), 1, "should have one FeeClose transaction");
+    assert_eq!(fee_close_txs[0].amount, dec!(4.00));
+
+    let closed = trust
+        .search_trades(account.id, Status::ClosedTarget)
+        .unwrap();
+    // Performance = target(25000) - entry(20000) - fee(4) = 4996
+    assert_eq!(closed[0].balance.total_performance, dec!(4996));
+
+    let balance = trust.search_balance(account.id, &Currency::USD).unwrap();
+    // 50000 + 5000 profit - 4 fee = 54996
+    assert_eq!(balance.total_balance, dec!(54996));
+}
+
+// ===========================================================================
+// 6. SHORT TRADE VALIDATION — Edge cases
+// ===========================================================================
+
+#[test]
+fn test_short_trade_entry_equals_stop_rejected() {
+    // entry == stop means zero risk → should be rejected
+    let mut trust = setup_facade(NoOpBroker);
+    let account = setup_account_with_rules(&mut trust, dec!(50000), 2.0);
+    let tv = create_vehicle(&mut trust, "AAPL");
+
+    let draft = DraftTrade {
+        account: account.clone(),
+        trading_vehicle: tv,
+        quantity: 100,
+        currency: Currency::USD,
+        category: TradeCategory::Short,
+        thesis: None,
+        sector: None,
+        asset_class: None,
+        context: None,
+    };
+
+    // entry=50, stop=50 → price_diff = 0 → rejected
+    let result = trust.create_trade(draft, dec!(50), dec!(50), dec!(40));
+    // Trade creation might succeed but funding should fail
+    if result.is_ok() {
+        let trade = trust
+            .search_trades(account.id, Status::New)
+            .unwrap()
+            .pop()
+            .unwrap();
+        let fund_result = trust.fund_trade(&trade);
+        assert!(
+            fund_result.is_err(),
+            "funding short trade with entry==stop should fail"
+        );
+    }
+}
+
+#[test]
+fn test_short_trade_level_adjustment_skipped() {
+    // Short trades skip level-adjusted quantity validation
+    // This test verifies that a short trade with quantity exceeding level max still funds
+    let mut trust = setup_facade(NoOpBroker);
+    trust
+        .create_account(
+            "test",
+            "default",
+            model::Environment::Paper,
+            dec!(20),
+            dec!(10),
+        )
+        .unwrap();
+    let account = trust.search_account("test").unwrap();
+    trust
+        .create_transaction(
+            &account,
+            &TransactionCategory::Deposit,
+            dec!(100000),
+            &Currency::USD,
+        )
+        .unwrap();
+    // Only risk per trade rule, high enough to allow large trades
+    trust
+        .create_rule(
+            &account,
+            &RuleName::RiskPerTrade(50.0),
+            "high risk",
+            &RuleLevel::Error,
+        )
+        .unwrap();
+
+    let tv = create_vehicle(&mut trust, "TSLA");
+    let draft = DraftTrade {
+        account: account.clone(),
+        trading_vehicle: tv,
+        quantity: 1000,
+        currency: Currency::USD,
+        category: TradeCategory::Short,
+        thesis: None,
+        sector: None,
+        asset_class: None,
+        context: None,
+    };
+
+    // Short trade: entry=50, stop=55, target=40, quantity=1000
+    // Funding = stop * quantity = 55000
+    trust
+        .create_trade(draft, dec!(55), dec!(50), dec!(40))
+        .unwrap();
+    let trade = trust
+        .search_trades(account.id, Status::New)
+        .unwrap()
+        .pop()
+        .unwrap();
+
+    // This should succeed because level validation is skipped for shorts
+    let result = trust.fund_trade(&trade);
+    assert!(
+        result.is_ok(),
+        "short trade should bypass level-adjusted quantity validation"
+    );
+
+    let balance = trust.search_balance(account.id, &Currency::USD).unwrap();
+    assert_eq!(balance.total_available, dec!(45000)); // 100000 - 55000
+}
+
+// ===========================================================================
+// 7. STOP MODIFICATION — Edge cases
+// ===========================================================================
+
+#[test]
+fn test_modify_stop_to_zero_long_trade() {
+    // Long trade: lowering stop increases risk → should be rejected
+    let broker = StatefulBroker::new(|trade| {
+        let entry = make_filled_entry(trade, dec!(40));
+        let target = make_accepted_order(&trade.target);
+        let stop = make_held_order(&trade.safety_stop);
+        (Status::Filled, vec![entry, target, stop])
+    });
+    let mut trust = setup_facade(broker.clone());
+    let account = setup_account_with_rules(&mut trust, dec!(50000), 2.0);
+    let trade = create_submitted_trade(
+        &mut trust,
+        &account,
+        "TSLA",
+        dec!(38),
+        dec!(40),
+        dec!(50),
+        500,
+    );
+
+    trust.sync_trade(&trade, &account).unwrap();
+    let filled = trust
+        .search_trades(account.id, Status::Filled)
+        .unwrap()
+        .pop()
+        .unwrap();
+
+    // Try to modify stop to 0 (way below current 38 → risking more)
+    let result = trust.modify_stop(&filled, &account, dec!(0));
+    assert!(
+        result.is_err(),
+        "lowering stop on long trade should be rejected"
+    );
+}
+
+#[test]
+fn test_modify_stop_not_filled_rejected() {
+    // Can only modify stop on Filled trades
+    let mut trust = setup_facade(NoOpBroker);
+    let account = setup_account_with_rules(&mut trust, dec!(50000), 2.0);
+    let tv = create_vehicle(&mut trust, "TSLA");
+    let draft = DraftTrade {
+        account: account.clone(),
+        trading_vehicle: tv,
+        quantity: 500,
+        currency: Currency::USD,
+        category: TradeCategory::Long,
+        thesis: None,
+        sector: None,
+        asset_class: None,
+        context: None,
+    };
+    trust
+        .create_trade(draft, dec!(38), dec!(40), dec!(50))
+        .unwrap();
+    let trade = trust
+        .search_trades(account.id, Status::New)
+        .unwrap()
+        .pop()
+        .unwrap();
+    trust.fund_trade(&trade).unwrap();
+    let funded = trust
+        .search_trades(account.id, Status::Funded)
+        .unwrap()
+        .pop()
+        .unwrap();
+
+    let result = trust.modify_stop(&funded, &account, dec!(39));
+    assert!(
+        result.is_err(),
+        "modifying stop on funded (not filled) trade should fail"
+    );
+}
+
+// ===========================================================================
+// 8. MULTIPLE TRADES ON SAME SYMBOL — Balance isolation
+// ===========================================================================
+
+#[test]
+fn test_two_trades_same_symbol_independent_lifecycles() {
+    // First trade fills, second stays submitted
+    let call_count = Arc::new(Mutex::new(0u32));
+    let call_count_clone = call_count.clone();
+
+    let broker = StatefulBroker::new(move |trade| {
+        let mut count = call_count_clone.lock().unwrap();
+        *count += 1;
+        // First sync: fill entry
+        let entry = make_filled_entry(trade, dec!(40));
+        let target = make_accepted_order(&trade.target);
+        let stop = make_held_order(&trade.safety_stop);
+        (Status::Filled, vec![entry, target, stop])
+    });
+    let mut trust = setup_facade(broker);
+    let account = setup_account_with_rules(&mut trust, dec!(100000), 2.0);
+
+    let trade1 = create_submitted_trade(
+        &mut trust,
+        &account,
+        "TSLA",
+        dec!(38),
+        dec!(40),
+        dec!(50),
+        500,
+    );
+
+    // Create second trade with different vehicle
+    let _trade2 = create_submitted_trade(
+        &mut trust,
+        &account,
+        "AAPL",
+        dec!(148),
+        dec!(150),
+        dec!(160),
+        200,
+    );
+
+    // Only sync trade1
+    trust.sync_trade(&trade1, &account).unwrap();
+
+    // Trade1 should be Filled
+    let filled = trust.search_trades(account.id, Status::Filled).unwrap();
+    assert_eq!(filled.len(), 1);
+    assert_eq!(filled[0].trading_vehicle.symbol, "TSLA");
+
+    // Trade2 should still be Submitted
+    let submitted = trust
+        .search_trades(account.id, Status::Submitted)
+        .unwrap();
+    assert_eq!(submitted.len(), 1);
+    assert_eq!(submitted[0].trading_vehicle.symbol, "AAPL");
+
+    // Balance should reflect trade states
+    let balance = trust.search_balance(account.id, &Currency::USD).unwrap();
+    // TSLA filled: in_trade reduces by funding and then increases by capital_in_market
+    // AAPL still submitted: in_trade = 0 (submitted releases in_trade delta)
+    // The key point: two independent trades don't corrupt each other's balances
+    assert!(
+        balance.total_in_trade >= dec!(0),
+        "total_in_trade should never be negative"
+    );
+    // Available should account for both trades
+    assert!(
+        balance.total_available < dec!(100000),
+        "available should be less than deposit"
+    );
+}
+
+// ===========================================================================
+// 9. RISK VALIDATION EDGE CASES
+// ===========================================================================
+
+#[test]
+fn test_trade_exceeding_risk_per_trade_rejected() {
+    let mut trust = setup_facade(NoOpBroker);
+    // 2% risk per trade on 10000 = 200 max risk
+    let account = setup_account_with_rules(&mut trust, dec!(10000), 2.0);
+    let tv = create_vehicle(&mut trust, "AAPL");
+
+    let draft = DraftTrade {
+        account: account.clone(),
+        trading_vehicle: tv,
+        quantity: 500, // Risk = (40-38)*500 = 1000, way above 200 limit
+        currency: Currency::USD,
+        category: TradeCategory::Long,
+        thesis: None,
+        sector: None,
+        asset_class: None,
+        context: None,
+    };
+    trust
+        .create_trade(draft, dec!(38), dec!(40), dec!(50))
+        .unwrap();
+    let trade = trust
+        .search_trades(account.id, Status::New)
+        .unwrap()
+        .pop()
+        .unwrap();
+
+    let result = trust.fund_trade(&trade);
+    assert!(result.is_err(), "trade exceeding risk limit should be rejected");
+}
+
+#[test]
+fn test_trade_at_exact_risk_limit_accepted() {
+    let mut trust = setup_facade(NoOpBroker);
+    // 2% risk on 50000 = 1000 max risk
+    // price_diff = 40-38 = 2, quantity = 500, total_risk = 1000
+    let account = setup_account_with_rules(&mut trust, dec!(50000), 2.0);
+    let tv = create_vehicle(&mut trust, "AAPL");
+
+    let draft = DraftTrade {
+        account: account.clone(),
+        trading_vehicle: tv,
+        quantity: 500,
+        currency: Currency::USD,
+        category: TradeCategory::Long,
+        thesis: None,
+        sector: None,
+        asset_class: None,
+        context: None,
+    };
+    trust
+        .create_trade(draft, dec!(38), dec!(40), dec!(50))
+        .unwrap();
+    let trade = trust
+        .search_trades(account.id, Status::New)
+        .unwrap()
+        .pop()
+        .unwrap();
+
+    let result = trust.fund_trade(&trade);
+    assert!(
+        result.is_ok(),
+        "trade at exact risk limit should be accepted"
+    );
+}
+
+#[test]
+fn test_trade_with_zero_quantity_rejected() {
+    let mut trust = setup_facade(NoOpBroker);
+    let account = setup_account_with_rules(&mut trust, dec!(50000), 2.0);
+    let tv = create_vehicle(&mut trust, "AAPL");
+
+    let draft = DraftTrade {
+        account: account.clone(),
+        trading_vehicle: tv,
+        quantity: 0,
+        currency: Currency::USD,
+        category: TradeCategory::Long,
+        thesis: None,
+        sector: None,
+        asset_class: None,
+        context: None,
+    };
+
+    let result = trust.create_trade(draft, dec!(38), dec!(40), dec!(50));
+    // Zero quantity should be rejected either at trade creation or funding
+    if result.is_ok() {
+        let trade = trust
+            .search_trades(account.id, Status::New)
+            .unwrap()
+            .pop()
+            .unwrap();
+        let fund_result = trust.fund_trade(&trade);
+        assert!(
+            fund_result.is_err(),
+            "zero quantity trade should be rejected at funding"
+        );
+    }
+}
+
+// ===========================================================================
+// 10. ENTRY PRICE WORSE THAN EXPECTED — Fill costs more than planned
+// ===========================================================================
+
+#[test]
+fn test_entry_fill_at_higher_price_than_planned_no_refund() {
+    // Entry planned at 40, filled at 40.5 → costs more, no refund
+    // But still within funding (40*500=20000), so 40.5*500=20250 > 20000...
+    // Actually this would exceed funding! Let's verify the behavior.
+    let broker = StatefulBroker::new(|trade| {
+        let entry = make_filled_entry(trade, dec!(40.5));
+        let target = make_accepted_order(&trade.target);
+        let stop = make_held_order(&trade.safety_stop);
+        (Status::Filled, vec![entry, target, stop])
+    });
+    let mut trust = setup_facade(broker);
+    let account = setup_account_with_rules(&mut trust, dec!(50000), 2.0);
+    let trade = create_submitted_trade(
+        &mut trust,
+        &account,
+        "TSLA",
+        dec!(38),
+        dec!(40),
+        dec!(50),
+        500,
+    );
+
+    // Fill at 40.5: total = 40.5 * 500 = 20250, but funding was 40*500=20000
+    // This should fail because fill exceeds funding
+    let result = trust.sync_trade(&trade, &account);
+    assert!(
+        result.is_err(),
+        "fill exceeding funding should be rejected by can_transfer_fill"
+    );
+
+    // Trade should remain Submitted
+    let submitted = trust
+        .search_trades(account.id, Status::Submitted)
+        .unwrap();
+    assert_eq!(submitted.len(), 1);
+}
+
+// ===========================================================================
+// 11. SIBLING ORDER RECONCILIATION — When one exit fills, other is canceled
+// ===========================================================================
+
+#[test]
+fn test_target_fill_cancels_stop_order() {
+    let broker = StatefulBroker::new(|trade| {
+        let entry = make_filled_entry(trade, dec!(40));
+        let target = make_filled_target(trade, dec!(50));
+        let stop = make_canceled_order(&trade.safety_stop);
+        (Status::ClosedTarget, vec![entry, target, stop])
+    });
+    let mut trust = setup_facade(broker);
+    let account = setup_account_with_rules(&mut trust, dec!(50000), 2.0);
+    let trade = create_submitted_trade(
+        &mut trust,
+        &account,
+        "TSLA",
+        dec!(38),
+        dec!(40),
+        dec!(50),
+        500,
+    );
+
+    trust.sync_trade(&trade, &account).unwrap();
+
+    let closed = trust
+        .search_trades(account.id, Status::ClosedTarget)
+        .unwrap()
+        .pop()
+        .unwrap();
+
+    // Stop order should be marked as Canceled
+    assert_eq!(closed.safety_stop.status, OrderStatus::Canceled);
+    // Target should be Filled
+    assert_eq!(closed.target.status, OrderStatus::Filled);
+    // Entry should be Filled
+    assert_eq!(closed.entry.status, OrderStatus::Filled);
+}
+
+#[test]
+fn test_stop_fill_cancels_target_order() {
+    let broker = StatefulBroker::new(|trade| {
+        let entry = make_filled_entry(trade, dec!(40));
+        let stop = make_filled_stop(trade, dec!(38));
+        let target = make_canceled_order(&trade.target);
+        (Status::ClosedStopLoss, vec![entry, stop, target])
+    });
+    let mut trust = setup_facade(broker);
+    let account = setup_account_with_rules(&mut trust, dec!(50000), 2.0);
+    let trade = create_submitted_trade(
+        &mut trust,
+        &account,
+        "TSLA",
+        dec!(38),
+        dec!(40),
+        dec!(50),
+        500,
+    );
+
+    trust.sync_trade(&trade, &account).unwrap();
+
+    let closed = trust
+        .search_trades(account.id, Status::ClosedStopLoss)
+        .unwrap()
+        .pop()
+        .unwrap();
+
+    // Target should be marked as Canceled
+    assert_eq!(closed.target.status, OrderStatus::Canceled);
+    // Stop should be Filled
+    assert_eq!(closed.safety_stop.status, OrderStatus::Filled);
+}
+
+// ===========================================================================
+// 12. TRADE BALANCE CONSERVATION — Verify no money is lost or created
+// ===========================================================================
+
+#[test]
+fn test_profitable_trade_money_conservation() {
+    // Total money in system should always be accounted for:
+    // deposit = account_balance + trade_balance_capital_out_market + open_trade_value
+    let broker = StatefulBroker::new(|trade| {
+        let entry = make_filled_entry(trade, dec!(40));
+        let target = make_filled_target(trade, dec!(50));
+        let stop = make_canceled_order(&trade.safety_stop);
+        (Status::ClosedTarget, vec![entry, target, stop])
+    });
+    let mut trust = setup_facade(broker);
+    let account = setup_account_with_rules(&mut trust, dec!(50000), 2.0);
+    let trade = create_submitted_trade(
+        &mut trust,
+        &account,
+        "TSLA",
+        dec!(38),
+        dec!(40),
+        dec!(50),
+        500,
+    );
+
+    trust.sync_trade(&trade, &account).unwrap();
+
+    let balance = trust.search_balance(account.id, &Currency::USD).unwrap();
+    let closed = trust
+        .search_trades(account.id, Status::ClosedTarget)
+        .unwrap()
+        .pop()
+        .unwrap();
+
+    // After close: all capital should be back in account
+    assert_eq!(closed.balance.capital_in_market, dec!(0));
+    assert_eq!(closed.balance.capital_out_market, dec!(0));
+
+    // Account balance = initial + profit
+    let expected_profit = dec!(5000); // (50-40)*500
+    assert_eq!(balance.total_balance, dec!(50000) + expected_profit);
+    assert_eq!(balance.total_available, balance.total_balance);
+    assert_eq!(balance.total_in_trade, dec!(0));
+}
+
+#[test]
+fn test_losing_trade_money_conservation() {
+    let broker = StatefulBroker::new(|trade| {
+        let entry = make_filled_entry(trade, dec!(40));
+        let stop = make_filled_stop(trade, dec!(36));
+        let target = make_canceled_order(&trade.target);
+        (Status::ClosedStopLoss, vec![entry, stop, target])
+    });
+    let mut trust = setup_facade(broker);
+    let account = setup_account_with_rules(&mut trust, dec!(50000), 2.0);
+    let trade = create_submitted_trade(
+        &mut trust,
+        &account,
+        "TSLA",
+        dec!(38),
+        dec!(40),
+        dec!(50),
+        500,
+    );
+
+    trust.sync_trade(&trade, &account).unwrap();
+
+    let balance = trust.search_balance(account.id, &Currency::USD).unwrap();
+    let closed = trust
+        .search_trades(account.id, Status::ClosedStopLoss)
+        .unwrap()
+        .pop()
+        .unwrap();
+
+    let expected_loss = dec!(2000); // (40-36)*500
+    assert_eq!(closed.balance.total_performance, dec!(0) - expected_loss);
+    assert_eq!(balance.total_balance, dec!(50000) - expected_loss);
+    assert_eq!(balance.total_available, balance.total_balance);
+    assert_eq!(balance.total_in_trade, dec!(0));
+    assert_eq!(closed.balance.capital_in_market, dec!(0));
+    assert_eq!(closed.balance.capital_out_market, dec!(0));
+}
+
+// ===========================================================================
+// 13. SMALL TRADE — Minimum viable amounts
+// ===========================================================================
+
+#[test]
+fn test_single_share_trade_lifecycle() {
+    let broker = StatefulBroker::new(|trade| {
+        let entry = make_filled_entry(trade, dec!(100));
+        let target = make_filled_target(trade, dec!(105));
+        let stop = make_canceled_order(&trade.safety_stop);
+        (Status::ClosedTarget, vec![entry, target, stop])
+    });
+    let mut trust = setup_facade(broker);
+    let account = setup_account_with_rules(&mut trust, dec!(10000), 5.0);
+    // 1 share, entry=100, stop=95, target=105, risk = 5*1 = 5
+    let trade = create_submitted_trade(
+        &mut trust,
+        &account,
+        "AAPL",
+        dec!(95),
+        dec!(100),
+        dec!(105),
+        1,
+    );
+
+    trust.sync_trade(&trade, &account).unwrap();
+
+    let closed = trust
+        .search_trades(account.id, Status::ClosedTarget)
+        .unwrap()
+        .pop()
+        .unwrap();
+
+    assert_eq!(closed.balance.total_performance, dec!(5)); // 105 - 100
+    let balance = trust.search_balance(account.id, &Currency::USD).unwrap();
+    assert_eq!(balance.total_balance, dec!(10005));
+}
+
+// ===========================================================================
+// 14. INSUFFICIENT FUNDS FOR FEE — Fee exceeds available balance
+// ===========================================================================
+
+#[test]
+fn test_fee_exceeding_available_balance_fails() {
+    // Deposit just enough to fund the trade, then fee should fail
+    let entry_broker_id = Uuid::new_v4().to_string();
+    let entry_broker_id_clone = entry_broker_id.clone();
+
+    let broker = StatefulBroker::with_fees(
+        move |trade| {
+            let entry = Order {
+                id: trade.entry.id,
+                broker_order_id: Some(entry_broker_id_clone.clone()),
+                filled_quantity: trade.entry.quantity,
+                average_filled_price: Some(dec!(40)),
+                status: OrderStatus::Filled,
+                filled_at: Some(now()),
+                ..Default::default()
+            };
+            let target = make_accepted_order(&trade.target);
+            let stop = make_held_order(&trade.safety_stop);
+            (Status::Filled, vec![entry, target, stop])
+        },
+        vec![FeeActivity {
+            broker: "alpaca".to_string(),
+            broker_activity_id: "fee-huge".to_string(),
+            account_id: Uuid::nil(),
+            broker_order_id: Some(entry_broker_id),
+            symbol: Some("TSLA".to_string()),
+            activity_type: "FEE".to_string(),
+            amount: dec!(50000), // Huge fee exceeding available balance
+            occurred_at: now(),
+            raw_json: None,
+        }],
+    );
+
+    let mut trust = setup_facade(broker);
+    let account = setup_account_with_rules(&mut trust, dec!(50000), 2.0);
+    let trade = create_submitted_trade(
+        &mut trust,
+        &account,
+        "TSLA",
+        dec!(38),
+        dec!(40),
+        dec!(50),
+        500,
+    );
+
+    // Should fail because fee exceeds available balance
+    let result = trust.sync_trade(&trade, &account);
+    assert!(
+        result.is_err(),
+        "fee exceeding available balance should fail"
+    );
+}

--- a/cli/tests/integration_test_sync_edge_cases.rs
+++ b/cli/tests/integration_test_sync_edge_cases.rs
@@ -3,8 +3,7 @@ use core::TrustFacade;
 use db_sqlite::SqliteDatabase;
 use model::{
     Account, Broker, BrokerLog, Currency, DraftTrade, FeeActivity, Order, OrderIds, OrderStatus,
-    RuleLevel, RuleName, Status, Trade, TradeCategory, TradingVehicleCategory,
-    TransactionCategory,
+    RuleLevel, RuleName, Status, Trade, TradeCategory, TradingVehicleCategory, TransactionCategory,
 };
 use rust_decimal::Decimal;
 use rust_decimal_macros::dec;
@@ -17,10 +16,7 @@ use uuid::Uuid;
 // ---------------------------------------------------------------------------
 
 fn setup_facade(broker: impl Broker + 'static) -> TrustFacade {
-    TrustFacade::new(
-        Box::new(SqliteDatabase::new_in_memory()),
-        Box::new(broker),
-    )
+    TrustFacade::new(Box::new(SqliteDatabase::new_in_memory()), Box::new(broker))
 }
 
 fn setup_account_with_rules(
@@ -198,12 +194,7 @@ impl Broker for StatefulBroker {
         unimplemented!()
     }
 
-    fn modify_target(
-        &self,
-        _: &Trade,
-        _: &Account,
-        _: Decimal,
-    ) -> Result<String, Box<dyn Error>> {
+    fn modify_target(&self, _: &Trade, _: &Account, _: Decimal) -> Result<String, Box<dyn Error>> {
         unimplemented!()
     }
 
@@ -257,12 +248,7 @@ impl Broker for NoOpBroker {
     fn modify_stop(&self, _: &Trade, _: &Account, _: Decimal) -> Result<String, Box<dyn Error>> {
         unimplemented!()
     }
-    fn modify_target(
-        &self,
-        _: &Trade,
-        _: &Account,
-        _: Decimal,
-    ) -> Result<String, Box<dyn Error>> {
+    fn modify_target(&self, _: &Trade, _: &Account, _: Decimal) -> Result<String, Box<dyn Error>> {
         unimplemented!()
     }
 }
@@ -518,9 +504,7 @@ fn test_sync_submitted_no_fills_is_noop() {
 
     trust.sync_trade(&trade, &account).unwrap();
 
-    let trades = trust
-        .search_trades(account.id, Status::Submitted)
-        .unwrap();
+    let trades = trust.search_trades(account.id, Status::Submitted).unwrap();
     assert_eq!(trades.len(), 1);
     assert_eq!(trades[0].status, Status::Submitted);
 
@@ -590,7 +574,11 @@ fn test_fee_activity_matched_by_broker_order_id() {
         .iter()
         .filter(|t| matches!(t.category, TransactionCategory::FeeOpen(_)))
         .collect();
-    assert_eq!(fee_txs.len(), 1, "should have exactly one FeeOpen transaction");
+    assert_eq!(
+        fee_txs.len(),
+        1,
+        "should have exactly one FeeOpen transaction"
+    );
     assert_eq!(fee_txs[0].amount, dec!(5.50));
 }
 
@@ -693,7 +681,11 @@ fn test_fee_activity_wrong_symbol_not_matched() {
         .iter()
         .filter(|t| matches!(t.category, TransactionCategory::FeeOpen(_)))
         .collect();
-    assert_eq!(fee_txs.len(), 0, "fee for wrong symbol should not be matched");
+    assert_eq!(
+        fee_txs.len(),
+        0,
+        "fee for wrong symbol should not be matched"
+    );
 
     let balance = trust.search_balance(account.id, &Currency::USD).unwrap();
     assert_eq!(balance.total_available, dec!(30000)); // No fee deducted
@@ -817,7 +809,11 @@ fn test_closing_fee_matched_to_target_order() {
         .iter()
         .filter(|t| matches!(t.category, TransactionCategory::FeeClose(_)))
         .collect();
-    assert_eq!(fee_close_txs.len(), 1, "should have one FeeClose transaction");
+    assert_eq!(
+        fee_close_txs.len(),
+        1,
+        "should have one FeeClose transaction"
+    );
     assert_eq!(fee_close_txs[0].amount, dec!(4.00));
 
     let closed = trust
@@ -1070,9 +1066,7 @@ fn test_two_trades_same_symbol_independent_lifecycles() {
     assert_eq!(filled[0].trading_vehicle.symbol, "TSLA");
 
     // Trade2 should still be Submitted
-    let submitted = trust
-        .search_trades(account.id, Status::Submitted)
-        .unwrap();
+    let submitted = trust.search_trades(account.id, Status::Submitted).unwrap();
     assert_eq!(submitted.len(), 1);
     assert_eq!(submitted[0].trading_vehicle.symbol, "AAPL");
 
@@ -1124,7 +1118,10 @@ fn test_trade_exceeding_risk_per_trade_rejected() {
         .unwrap();
 
     let result = trust.fund_trade(&trade);
-    assert!(result.is_err(), "trade exceeding risk limit should be rejected");
+    assert!(
+        result.is_err(),
+        "trade exceeding risk limit should be rejected"
+    );
 }
 
 #[test]
@@ -1232,9 +1229,7 @@ fn test_entry_fill_at_higher_price_than_planned_no_refund() {
     );
 
     // Trade should remain Submitted
-    let submitted = trust
-        .search_trades(account.id, Status::Submitted)
-        .unwrap();
+    let submitted = trust.search_trades(account.id, Status::Submitted).unwrap();
     assert_eq!(submitted.len(), 1);
 }
 

--- a/cli/tests/integration_test_transactions.rs
+++ b/cli/tests/integration_test_transactions.rs
@@ -15,10 +15,7 @@ use uuid::Uuid;
 // ---------------------------------------------------------------------------
 
 fn new_facade(broker: impl Broker + 'static) -> TrustFacade {
-    TrustFacade::new(
-        Box::new(SqliteDatabase::new_in_memory()),
-        Box::new(broker),
-    )
+    TrustFacade::new(Box::new(SqliteDatabase::new_in_memory()), Box::new(broker))
 }
 
 fn setup_account(trust: &mut TrustFacade, deposit: Decimal) -> Account {
@@ -138,11 +135,7 @@ impl Broker for NoOpBroker {
     ) -> Result<(Status, Vec<Order>, BrokerLog), Box<dyn Error>> {
         unimplemented!()
     }
-    fn close_trade(
-        &self,
-        _: &Trade,
-        _: &Account,
-    ) -> Result<(Order, BrokerLog), Box<dyn Error>> {
+    fn close_trade(&self, _: &Trade, _: &Account) -> Result<(Order, BrokerLog), Box<dyn Error>> {
         unimplemented!()
     }
     fn cancel_trade(&self, _: &Trade, _: &Account) -> Result<(), Box<dyn Error>> {
@@ -192,11 +185,7 @@ impl Broker for SyncBroker {
         let (status, orders) = (self.response)(trade);
         Ok((status, orders, BrokerLog::default()))
     }
-    fn close_trade(
-        &self,
-        _: &Trade,
-        _: &Account,
-    ) -> Result<(Order, BrokerLog), Box<dyn Error>> {
+    fn close_trade(&self, _: &Trade, _: &Account) -> Result<(Order, BrokerLog), Box<dyn Error>> {
         unimplemented!()
     }
     fn cancel_trade(&self, _: &Trade, _: &Account) -> Result<(), Box<dyn Error>> {
@@ -705,7 +694,10 @@ fn test_profitable_trade_lifecycle_queryable_transaction_count() {
 
     assert_eq!(deposit_count, 1, "exactly one Deposit");
     assert_eq!(fund_count, 1, "exactly one FundTrade");
-    assert_eq!(payment_count, 1, "exactly one PaymentFromTrade (final return)");
+    assert_eq!(
+        payment_count, 1,
+        "exactly one PaymentFromTrade (final return)"
+    );
 }
 
 #[test]
@@ -808,7 +800,10 @@ fn test_withdraw_more_than_available_fails() {
         dec!(1000.01),
         &Currency::USD,
     );
-    assert!(result.is_err(), "withdrawal exceeding available should fail");
+    assert!(
+        result.is_err(),
+        "withdrawal exceeding available should fail"
+    );
 }
 
 #[test]
@@ -1488,7 +1483,9 @@ fn test_accounting_identity_after_funding_trade() {
 #[test]
 fn test_severe_slippage_stop_loss() {
     // Stop planned at 38, but filled at 30.2 — severe slippage for long
-    let mut trust = new_facade(SyncBroker::new(|t| stop_filled_at(t, dec!(39.9), dec!(30.2))));
+    let mut trust = new_facade(SyncBroker::new(|t| {
+        stop_filled_at(t, dec!(39.9), dec!(30.2))
+    }));
     let account = setup_account(&mut trust, dec!(50000));
     let trade = setup_submitted_trade(&mut trust, &account);
 

--- a/cli/tests/integration_test_transactions.rs
+++ b/cli/tests/integration_test_transactions.rs
@@ -1,0 +1,1639 @@
+use chrono::Utc;
+use core::TrustFacade;
+use db_sqlite::SqliteDatabase;
+use model::{
+    Account, Broker, BrokerLog, Currency, DraftTrade, Order, OrderIds, OrderStatus, RuleLevel,
+    RuleName, Status, Trade, TradeCategory, TradingVehicleCategory, TransactionCategory,
+};
+use rust_decimal::Decimal;
+use rust_decimal_macros::dec;
+use std::error::Error;
+use uuid::Uuid;
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+fn new_facade(broker: impl Broker + 'static) -> TrustFacade {
+    TrustFacade::new(
+        Box::new(SqliteDatabase::new_in_memory()),
+        Box::new(broker),
+    )
+}
+
+fn setup_account(trust: &mut TrustFacade, deposit: Decimal) -> Account {
+    trust
+        .create_account(
+            "test",
+            "default",
+            model::Environment::Paper,
+            dec!(20),
+            dec!(10),
+        )
+        .expect("create account");
+    let account = trust.search_account("test").unwrap();
+    trust
+        .create_transaction(
+            &account,
+            &TransactionCategory::Deposit,
+            deposit,
+            &Currency::USD,
+        )
+        .expect("deposit");
+    trust
+        .create_rule(
+            &account,
+            &RuleName::RiskPerMonth(6.0),
+            "risk month",
+            &RuleLevel::Error,
+        )
+        .unwrap();
+    trust
+        .create_rule(
+            &account,
+            &RuleName::RiskPerTrade(2.0),
+            "risk trade",
+            &RuleLevel::Error,
+        )
+        .unwrap();
+    account
+}
+
+fn create_vehicle(trust: &mut TrustFacade, symbol: &str) -> model::TradingVehicle {
+    let isin = format!("US{}", Uuid::new_v4().simple());
+    trust
+        .create_trading_vehicle(
+            symbol,
+            Some(&isin),
+            &TradingVehicleCategory::Stock,
+            "NASDAQ",
+        )
+        .unwrap()
+}
+
+/// Create a long trade through the full lifecycle up to Submitted status.
+/// stop=38, entry=40, target=50, quantity=500
+fn setup_submitted_trade(trust: &mut TrustFacade, account: &Account) -> Trade {
+    let tv = create_vehicle(trust, "TSLA");
+    let draft = DraftTrade {
+        account: account.clone(),
+        trading_vehicle: tv,
+        quantity: 500,
+        currency: Currency::USD,
+        category: TradeCategory::Long,
+        thesis: None,
+        sector: None,
+        asset_class: None,
+        context: None,
+    };
+    trust
+        .create_trade(draft, dec!(38), dec!(40), dec!(50))
+        .unwrap();
+    let trade = trust
+        .search_trades(account.id, Status::New)
+        .unwrap()
+        .pop()
+        .unwrap();
+    trust.fund_trade(&trade).unwrap();
+    let trade = trust
+        .search_trades(account.id, Status::Funded)
+        .unwrap()
+        .pop()
+        .unwrap();
+    trust.submit_trade(&trade).unwrap();
+    trust
+        .search_trades(account.id, Status::Submitted)
+        .unwrap()
+        .pop()
+        .unwrap()
+}
+
+// ---------------------------------------------------------------------------
+// Mock Brokers
+// ---------------------------------------------------------------------------
+
+struct NoOpBroker;
+impl Broker for NoOpBroker {
+    fn kind(&self) -> model::BrokerKind {
+        model::BrokerKind::Alpaca
+    }
+    fn submit_trade(
+        &self,
+        _: &Trade,
+        _: &Account,
+    ) -> Result<(BrokerLog, OrderIds), Box<dyn Error>> {
+        Ok((
+            BrokerLog::default(),
+            OrderIds {
+                entry: Uuid::new_v4().to_string(),
+                target: Uuid::new_v4().to_string(),
+                stop: Uuid::new_v4().to_string(),
+            },
+        ))
+    }
+    fn sync_trade(
+        &self,
+        _: &Trade,
+        _: &Account,
+    ) -> Result<(Status, Vec<Order>, BrokerLog), Box<dyn Error>> {
+        unimplemented!()
+    }
+    fn close_trade(
+        &self,
+        _: &Trade,
+        _: &Account,
+    ) -> Result<(Order, BrokerLog), Box<dyn Error>> {
+        unimplemented!()
+    }
+    fn cancel_trade(&self, _: &Trade, _: &Account) -> Result<(), Box<dyn Error>> {
+        unimplemented!()
+    }
+    fn modify_stop(&self, _: &Trade, _: &Account, _: Decimal) -> Result<String, Box<dyn Error>> {
+        unimplemented!()
+    }
+    fn modify_target(&self, _: &Trade, _: &Account, _: Decimal) -> Result<String, Box<dyn Error>> {
+        unimplemented!()
+    }
+}
+
+struct SyncBroker {
+    response: fn(&Trade) -> (Status, Vec<Order>),
+}
+
+impl SyncBroker {
+    fn new(response: fn(&Trade) -> (Status, Vec<Order>)) -> Self {
+        Self { response }
+    }
+}
+
+impl Broker for SyncBroker {
+    fn kind(&self) -> model::BrokerKind {
+        model::BrokerKind::Alpaca
+    }
+    fn submit_trade(
+        &self,
+        _: &Trade,
+        _: &Account,
+    ) -> Result<(BrokerLog, OrderIds), Box<dyn Error>> {
+        Ok((
+            BrokerLog::default(),
+            OrderIds {
+                entry: Uuid::new_v4().to_string(),
+                target: Uuid::new_v4().to_string(),
+                stop: Uuid::new_v4().to_string(),
+            },
+        ))
+    }
+    fn sync_trade(
+        &self,
+        trade: &Trade,
+        _: &Account,
+    ) -> Result<(Status, Vec<Order>, BrokerLog), Box<dyn Error>> {
+        let (status, orders) = (self.response)(trade);
+        Ok((status, orders, BrokerLog::default()))
+    }
+    fn close_trade(
+        &self,
+        _: &Trade,
+        _: &Account,
+    ) -> Result<(Order, BrokerLog), Box<dyn Error>> {
+        unimplemented!()
+    }
+    fn cancel_trade(&self, _: &Trade, _: &Account) -> Result<(), Box<dyn Error>> {
+        Ok(())
+    }
+    fn modify_stop(&self, _: &Trade, _: &Account, _: Decimal) -> Result<String, Box<dyn Error>> {
+        unimplemented!()
+    }
+    fn modify_target(&self, _: &Trade, _: &Account, _: Decimal) -> Result<String, Box<dyn Error>> {
+        unimplemented!()
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Broker response helpers
+// ---------------------------------------------------------------------------
+
+fn entry_filled_at(trade: &Trade, price: Decimal) -> (Status, Vec<Order>) {
+    let entry = Order {
+        id: trade.entry.id,
+        broker_order_id: Some(Uuid::new_v4().to_string()),
+        filled_quantity: trade.entry.quantity,
+        average_filled_price: Some(price),
+        status: OrderStatus::Filled,
+        filled_at: Some(Utc::now().naive_utc()),
+        ..Default::default()
+    };
+    let target = Order {
+        id: trade.target.id,
+        broker_order_id: Some(Uuid::new_v4().to_string()),
+        status: OrderStatus::Accepted,
+        ..Default::default()
+    };
+    let stop = Order {
+        id: trade.safety_stop.id,
+        broker_order_id: Some(Uuid::new_v4().to_string()),
+        status: OrderStatus::Held,
+        ..Default::default()
+    };
+    (Status::Filled, vec![entry, target, stop])
+}
+
+fn target_filled_at(
+    trade: &Trade,
+    entry_price: Decimal,
+    target_price: Decimal,
+) -> (Status, Vec<Order>) {
+    let entry = Order {
+        id: trade.entry.id,
+        broker_order_id: Some(Uuid::new_v4().to_string()),
+        filled_quantity: trade.entry.quantity,
+        average_filled_price: Some(entry_price),
+        status: OrderStatus::Filled,
+        filled_at: Some(Utc::now().naive_utc()),
+        ..Default::default()
+    };
+    let target = Order {
+        id: trade.target.id,
+        broker_order_id: Some(Uuid::new_v4().to_string()),
+        filled_quantity: trade.entry.quantity,
+        average_filled_price: Some(target_price),
+        status: OrderStatus::Filled,
+        filled_at: Some(Utc::now().naive_utc()),
+        ..Default::default()
+    };
+    let stop = Order {
+        id: trade.safety_stop.id,
+        broker_order_id: Some(Uuid::new_v4().to_string()),
+        status: OrderStatus::Canceled,
+        ..Default::default()
+    };
+    (Status::ClosedTarget, vec![entry, target, stop])
+}
+
+fn stop_filled_at(
+    trade: &Trade,
+    entry_price: Decimal,
+    stop_price: Decimal,
+) -> (Status, Vec<Order>) {
+    let entry = Order {
+        id: trade.entry.id,
+        broker_order_id: Some(Uuid::new_v4().to_string()),
+        filled_quantity: trade.entry.quantity,
+        average_filled_price: Some(entry_price),
+        status: OrderStatus::Filled,
+        filled_at: Some(Utc::now().naive_utc()),
+        ..Default::default()
+    };
+    let target = Order {
+        id: trade.target.id,
+        broker_order_id: Some(Uuid::new_v4().to_string()),
+        status: OrderStatus::Canceled,
+        ..Default::default()
+    };
+    let stop = Order {
+        id: trade.safety_stop.id,
+        broker_order_id: Some(Uuid::new_v4().to_string()),
+        filled_quantity: trade.entry.quantity,
+        average_filled_price: Some(stop_price),
+        status: OrderStatus::Filled,
+        filled_at: Some(Utc::now().naive_utc()),
+        ..Default::default()
+    };
+    (Status::ClosedStopLoss, vec![entry, target, stop])
+}
+
+// ===========================================================================
+// 1. TRANSACTION RECORD ASSERTIONS
+//    Existing tests only check balance outcomes. These tests verify the
+//    actual Transaction records (category, amount, currency, count).
+//
+//    NOTE: get_account_transactions() uses `read_all_trade_transactions_excluding_taxes`
+//    which only returns: deposit, withdrawal, withdrawal_earnings, fee_open,
+//    fee_close, fund_trade, payment_from_trade, payment_earnings.
+//    It EXCLUDES: open_trade, close_target, close_safety_stop,
+//    close_safety_stop_slippage, payment_tax, withdrawal_tax.
+//    We verify excluded categories via balance/trade balance assertions.
+// ===========================================================================
+
+#[test]
+fn test_deposit_creates_correct_transaction_record() {
+    let mut trust = new_facade(NoOpBroker);
+    let account = trust
+        .create_account("acc", "d", model::Environment::Paper, dec!(20), dec!(10))
+        .unwrap();
+    let (tx, balance) = trust
+        .create_transaction(
+            &account,
+            &TransactionCategory::Deposit,
+            dec!(1234.56),
+            &Currency::USD,
+        )
+        .unwrap();
+
+    assert_eq!(tx.category, TransactionCategory::Deposit);
+    assert_eq!(tx.amount, dec!(1234.56));
+    assert_eq!(tx.currency, Currency::USD);
+    assert_eq!(tx.account_id, account.id);
+
+    assert_eq!(balance.total_balance, dec!(1234.56));
+    assert_eq!(balance.total_available, dec!(1234.56));
+    assert_eq!(balance.total_in_trade, dec!(0));
+    assert_eq!(balance.taxed, dec!(0));
+}
+
+#[test]
+fn test_withdrawal_creates_correct_transaction_record() {
+    let mut trust = new_facade(NoOpBroker);
+    let account = trust
+        .create_account("acc", "d", model::Environment::Paper, dec!(20), dec!(10))
+        .unwrap();
+    trust
+        .create_transaction(
+            &account,
+            &TransactionCategory::Deposit,
+            dec!(5000),
+            &Currency::USD,
+        )
+        .unwrap();
+
+    let (tx, balance) = trust
+        .create_transaction(
+            &account,
+            &TransactionCategory::Withdrawal,
+            dec!(1200),
+            &Currency::USD,
+        )
+        .unwrap();
+
+    assert_eq!(tx.category, TransactionCategory::Withdrawal);
+    assert_eq!(tx.amount, dec!(1200));
+    assert_eq!(tx.currency, Currency::USD);
+    assert_eq!(balance.total_balance, dec!(3800));
+    assert_eq!(balance.total_available, dec!(3800));
+}
+
+#[test]
+fn test_fund_trade_creates_fund_trade_transaction_with_correct_amount() {
+    let mut trust = new_facade(NoOpBroker);
+    let account = setup_account(&mut trust, dec!(50000));
+    let tv = create_vehicle(&mut trust, "AAPL");
+
+    let draft = DraftTrade {
+        account: account.clone(),
+        trading_vehicle: tv,
+        quantity: 500,
+        currency: Currency::USD,
+        category: TradeCategory::Long,
+        thesis: None,
+        sector: None,
+        asset_class: None,
+        context: None,
+    };
+    // stop=38, entry=40, target=50 → funding = entry * quantity = 40*500 = 20000
+    trust
+        .create_trade(draft, dec!(38), dec!(40), dec!(50))
+        .unwrap();
+    let trade = trust
+        .search_trades(account.id, Status::New)
+        .unwrap()
+        .pop()
+        .unwrap();
+
+    let (_, tx, _, _) = trust.fund_trade(&trade).unwrap();
+
+    assert_eq!(tx.category, TransactionCategory::FundTrade(trade.id));
+    assert_eq!(tx.amount, dec!(20000));
+    assert_eq!(tx.currency, Currency::USD);
+
+    // Verify balance after funding
+    let balance = trust.search_balance(account.id, &Currency::USD).unwrap();
+    assert_eq!(balance.total_available, dec!(30000)); // 50000 - 20000
+    assert_eq!(balance.total_balance, dec!(50000)); // FundTrade doesn't change total_balance
+    assert_eq!(balance.total_in_trade, dec!(20000));
+}
+
+#[test]
+fn test_cancel_funded_trade_returns_exact_funded_amount() {
+    let mut trust = new_facade(NoOpBroker);
+    let account = setup_account(&mut trust, dec!(50000));
+    let tv = create_vehicle(&mut trust, "AAPL");
+
+    let draft = DraftTrade {
+        account: account.clone(),
+        trading_vehicle: tv,
+        quantity: 500,
+        currency: Currency::USD,
+        category: TradeCategory::Long,
+        thesis: None,
+        sector: None,
+        asset_class: None,
+        context: None,
+    };
+    trust
+        .create_trade(draft, dec!(38), dec!(40), dec!(50))
+        .unwrap();
+    let trade = trust
+        .search_trades(account.id, Status::New)
+        .unwrap()
+        .pop()
+        .unwrap();
+    trust.fund_trade(&trade).unwrap();
+    let trade = trust
+        .search_trades(account.id, Status::Funded)
+        .unwrap()
+        .pop()
+        .unwrap();
+
+    let (trade_bal, account_bal, tx) = trust.cancel_funded_trade(&trade).unwrap();
+
+    // Transaction record
+    assert_eq!(tx.category, TransactionCategory::PaymentFromTrade(trade.id));
+    assert_eq!(tx.amount, dec!(20000)); // Exact funding amount returned
+    assert_eq!(tx.currency, Currency::USD);
+
+    // Account fully restored
+    assert_eq!(account_bal.total_balance, dec!(50000));
+    assert_eq!(account_bal.total_available, dec!(50000));
+    assert_eq!(account_bal.total_in_trade, dec!(0));
+
+    // Trade balance zeroed out
+    assert_eq!(trade_bal.capital_out_market, dec!(0));
+    assert_eq!(trade_bal.capital_in_market, dec!(0));
+    assert_eq!(trade_bal.total_performance, dec!(0));
+}
+
+// ===========================================================================
+// 2. ENTRY FILL WITH SLIPPAGE — Verify via balance and queryable transactions
+// ===========================================================================
+
+#[test]
+fn test_entry_fill_with_slippage_creates_payment_from_trade() {
+    // Entry at 40, filled at 39.9 → slippage refund of 50 (0.1 * 500)
+    let mut trust = new_facade(SyncBroker::new(|t| entry_filled_at(t, dec!(39.9))));
+    let account = setup_account(&mut trust, dec!(50000));
+    let trade = setup_submitted_trade(&mut trust, &account);
+
+    trust.sync_trade(&trade, &account).unwrap();
+
+    // PaymentFromTrade IS included in get_account_transactions
+    let txs = trust.get_account_transactions(account.id).unwrap();
+    let refund_txs: Vec<_> = txs
+        .iter()
+        .filter(|t| matches!(t.category, TransactionCategory::PaymentFromTrade(_)))
+        .collect();
+    assert_eq!(
+        refund_txs.len(),
+        1,
+        "should have one PaymentFromTrade (slippage refund)"
+    );
+    assert_eq!(refund_txs[0].amount, dec!(50)); // (40 - 39.9) * 500
+
+    // Verify balance reflects the refund
+    let balance = trust.search_balance(account.id, &Currency::USD).unwrap();
+    assert_eq!(balance.total_available, dec!(30050)); // 30000 + 50 refund
+
+    // Verify trade balance: capital_in_market should be 19950 (39.9 * 500)
+    let filled_trade = trust
+        .search_trades(account.id, Status::Filled)
+        .unwrap()
+        .pop()
+        .unwrap();
+    assert_eq!(filled_trade.balance.capital_in_market, dec!(19950));
+}
+
+#[test]
+fn test_entry_fill_exact_price_no_slippage_refund() {
+    // Entry at 40, filled at exactly 40 → no PaymentFromTrade
+    let mut trust = new_facade(SyncBroker::new(|t| entry_filled_at(t, dec!(40))));
+    let account = setup_account(&mut trust, dec!(50000));
+    let trade = setup_submitted_trade(&mut trust, &account);
+
+    trust.sync_trade(&trade, &account).unwrap();
+
+    let txs = trust.get_account_transactions(account.id).unwrap();
+    let refund_txs: Vec<_> = txs
+        .iter()
+        .filter(|t| matches!(t.category, TransactionCategory::PaymentFromTrade(_)))
+        .collect();
+    assert_eq!(
+        refund_txs.len(),
+        0,
+        "exact fill should create no slippage refund"
+    );
+
+    let balance = trust.search_balance(account.id, &Currency::USD).unwrap();
+    assert_eq!(balance.total_available, dec!(30000)); // No refund
+    assert_eq!(balance.total_in_trade, dec!(20000));
+
+    // Trade balance: capital_in_market = 40 * 500 = 20000
+    let filled_trade = trust
+        .search_trades(account.id, Status::Filled)
+        .unwrap()
+        .pop()
+        .unwrap();
+    assert_eq!(filled_trade.balance.capital_in_market, dec!(20000));
+    assert_eq!(filled_trade.balance.capital_out_market, dec!(0));
+}
+
+// ===========================================================================
+// 3. TARGET CLOSE — Verify performance and final balances
+// ===========================================================================
+
+#[test]
+fn test_target_close_creates_correct_performance_and_balances() {
+    // Entry at 39.9, target at 52.9 → profit
+    let mut trust = new_facade(SyncBroker::new(|t| {
+        target_filled_at(t, dec!(39.9), dec!(52.9))
+    }));
+    let account = setup_account(&mut trust, dec!(50000));
+    let trade = setup_submitted_trade(&mut trust, &account);
+
+    trust.sync_trade(&trade, &account).unwrap();
+
+    let closed_trade = trust
+        .search_trades(account.id, Status::ClosedTarget)
+        .unwrap()
+        .pop()
+        .unwrap();
+
+    // Trade performance = close(52.9*500) - open(39.9*500) = 26450 - 19950 = 6500
+    assert_eq!(closed_trade.balance.total_performance, dec!(6500));
+    assert_eq!(closed_trade.balance.capital_in_market, dec!(0));
+    assert_eq!(closed_trade.balance.capital_out_market, dec!(0)); // All returned
+
+    // Verify PaymentFromTrade transactions (queryable)
+    let txs = trust.get_account_transactions(account.id).unwrap();
+    let payment_txs: Vec<_> = txs
+        .iter()
+        .filter(|t| matches!(t.category, TransactionCategory::PaymentFromTrade(_)))
+        .collect();
+    // Slippage refund (50) + final return
+    assert!(
+        !payment_txs.is_empty(),
+        "should have PaymentFromTrade transactions"
+    );
+
+    // Verify final account balance
+    let balance = trust.search_balance(account.id, &Currency::USD).unwrap();
+    assert_eq!(balance.total_available, dec!(56500)); // 50000 + 6500 profit
+    assert_eq!(balance.total_balance, dec!(56500));
+    assert_eq!(balance.total_in_trade, dec!(0));
+}
+
+// ===========================================================================
+// 4. STOP LOSS — Verify category via trade balance and account balance
+// ===========================================================================
+
+#[test]
+fn test_stop_filled_at_planned_price_balance_correct() {
+    // Stop planned at 38, filled at exactly 38
+    let mut trust = new_facade(SyncBroker::new(|t| stop_filled_at(t, dec!(39.9), dec!(38))));
+    let account = setup_account(&mut trust, dec!(50000));
+    let trade = setup_submitted_trade(&mut trust, &account);
+
+    trust.sync_trade(&trade, &account).unwrap();
+
+    let closed = trust
+        .search_trades(account.id, Status::ClosedStopLoss)
+        .unwrap()
+        .pop()
+        .unwrap();
+
+    // Performance = stop(38*500) - open(39.9*500) = 19000 - 19950 = -950
+    assert_eq!(closed.balance.total_performance, dec!(-950));
+    assert_eq!(closed.balance.capital_in_market, dec!(0));
+
+    let balance = trust.search_balance(account.id, &Currency::USD).unwrap();
+    // 50000 + slippage_refund(50) - loss(950) = 49100
+    // Wait: entry at 39.9, stop at 38
+    // deposit=50000, fund=20000 → available=30000
+    // fill: open=19950, refund=50 → available=30050
+    // stop: close=19000, return = capital_out_market → available=30050 + returned
+    // After close: total_balance = 50000 - 19950 + 19000 = 49050
+    // But also the slippage refund doesn't go to total_balance (PaymentFromTrade doesn't affect total_balance)
+    // Let me verify by just checking what the test gives us
+    assert_eq!(balance.total_in_trade, dec!(0));
+    // Net P&L = -950, so final balance = 50000 - 950 = 49050
+    assert_eq!(balance.total_balance, dec!(49050));
+}
+
+#[test]
+fn test_stop_filled_below_planned_price_bigger_loss() {
+    // Stop planned at 38, filled at 37 → worse for long
+    let mut trust = new_facade(SyncBroker::new(|t| stop_filled_at(t, dec!(39.9), dec!(37))));
+    let account = setup_account(&mut trust, dec!(50000));
+    let trade = setup_submitted_trade(&mut trust, &account);
+
+    trust.sync_trade(&trade, &account).unwrap();
+
+    let closed = trust
+        .search_trades(account.id, Status::ClosedStopLoss)
+        .unwrap()
+        .pop()
+        .unwrap();
+
+    // Performance = stop(37*500) - open(39.9*500) = 18500 - 19950 = -1450
+    assert_eq!(closed.balance.total_performance, dec!(-1450));
+    assert_eq!(closed.balance.capital_in_market, dec!(0));
+
+    let balance = trust.search_balance(account.id, &Currency::USD).unwrap();
+    // Net P&L = -1450, final balance = 50000 - 1450 = 48550
+    assert_eq!(balance.total_balance, dec!(48550));
+    assert_eq!(balance.total_in_trade, dec!(0));
+}
+
+#[test]
+fn test_stop_filled_above_planned_price_better_than_expected() {
+    // Stop planned at 38, filled at 39 → better fill for long (less loss)
+    // This is the "slippage" category case: total(39*500=19500) > planned(38*500=19000)
+    let mut trust = new_facade(SyncBroker::new(|t| stop_filled_at(t, dec!(39.9), dec!(39))));
+    let account = setup_account(&mut trust, dec!(50000));
+    let trade = setup_submitted_trade(&mut trust, &account);
+
+    trust.sync_trade(&trade, &account).unwrap();
+
+    let closed = trust
+        .search_trades(account.id, Status::ClosedStopLoss)
+        .unwrap()
+        .pop()
+        .unwrap();
+
+    // Performance = stop(39*500) - open(39.9*500) = 19500 - 19950 = -450
+    assert_eq!(closed.balance.total_performance, dec!(-450));
+    assert_eq!(closed.balance.capital_in_market, dec!(0));
+
+    let balance = trust.search_balance(account.id, &Currency::USD).unwrap();
+    // 50000 - 450 = 49550
+    assert_eq!(balance.total_balance, dec!(49550));
+    assert_eq!(balance.total_in_trade, dec!(0));
+}
+
+// ===========================================================================
+// 5. TRANSACTION COUNT INTEGRITY — Verify queryable transactions only
+//    (deposit, withdrawal, fund_trade, payment_from_trade, fee_open, fee_close)
+// ===========================================================================
+
+#[test]
+fn test_profitable_trade_lifecycle_queryable_transaction_count() {
+    // Exact price fill + target close
+    let mut trust = new_facade(SyncBroker::new(|t| target_filled_at(t, dec!(40), dec!(50))));
+    let account = setup_account(&mut trust, dec!(50000));
+    let trade = setup_submitted_trade(&mut trust, &account);
+
+    trust.sync_trade(&trade, &account).unwrap();
+
+    let txs = trust.get_account_transactions(account.id).unwrap();
+
+    // Queryable transactions:
+    // 1. Deposit (setup)
+    // 2. FundTrade (fund_trade)
+    // 3. PaymentFromTrade (final return to account after close)
+    // NOT included: OpenTrade, CloseTarget (excluded by query)
+    let deposit_count = txs
+        .iter()
+        .filter(|t| t.category == TransactionCategory::Deposit)
+        .count();
+    let fund_count = txs
+        .iter()
+        .filter(|t| matches!(t.category, TransactionCategory::FundTrade(_)))
+        .count();
+    let payment_count = txs
+        .iter()
+        .filter(|t| matches!(t.category, TransactionCategory::PaymentFromTrade(_)))
+        .count();
+
+    assert_eq!(deposit_count, 1, "exactly one Deposit");
+    assert_eq!(fund_count, 1, "exactly one FundTrade");
+    assert_eq!(payment_count, 1, "exactly one PaymentFromTrade (final return)");
+}
+
+#[test]
+fn test_profitable_trade_with_slippage_has_two_payments() {
+    // Entry fill with slippage adds an extra PaymentFromTrade
+    let mut trust = new_facade(SyncBroker::new(|t| {
+        target_filled_at(t, dec!(39.9), dec!(52.9))
+    }));
+    let account = setup_account(&mut trust, dec!(50000));
+    let trade = setup_submitted_trade(&mut trust, &account);
+
+    trust.sync_trade(&trade, &account).unwrap();
+
+    let txs = trust.get_account_transactions(account.id).unwrap();
+    let payment_count = txs
+        .iter()
+        .filter(|t| matches!(t.category, TransactionCategory::PaymentFromTrade(_)))
+        .count();
+    assert_eq!(
+        payment_count, 2,
+        "two PaymentFromTrade: slippage refund + final return"
+    );
+}
+
+#[test]
+fn test_losing_trade_lifecycle_queryable_transaction_count() {
+    let mut trust = new_facade(SyncBroker::new(|t| stop_filled_at(t, dec!(40), dec!(38))));
+    let account = setup_account(&mut trust, dec!(50000));
+    let trade = setup_submitted_trade(&mut trust, &account);
+
+    trust.sync_trade(&trade, &account).unwrap();
+
+    let txs = trust.get_account_transactions(account.id).unwrap();
+
+    // Queryable: Deposit, FundTrade, PaymentFromTrade (final return)
+    let fund_count = txs
+        .iter()
+        .filter(|t| matches!(t.category, TransactionCategory::FundTrade(_)))
+        .count();
+    let payment_count = txs
+        .iter()
+        .filter(|t| matches!(t.category, TransactionCategory::PaymentFromTrade(_)))
+        .count();
+
+    assert_eq!(fund_count, 1);
+    assert_eq!(payment_count, 1);
+}
+
+// ===========================================================================
+// 6. EDGE CASES — Withdrawal and deposit boundary conditions
+// ===========================================================================
+
+#[test]
+fn test_withdraw_exact_available_balance() {
+    let mut trust = new_facade(NoOpBroker);
+    let account = trust
+        .create_account("acc", "d", model::Environment::Paper, dec!(20), dec!(10))
+        .unwrap();
+    trust
+        .create_transaction(
+            &account,
+            &TransactionCategory::Deposit,
+            dec!(1000),
+            &Currency::USD,
+        )
+        .unwrap();
+
+    let (tx, balance) = trust
+        .create_transaction(
+            &account,
+            &TransactionCategory::Withdrawal,
+            dec!(1000),
+            &Currency::USD,
+        )
+        .unwrap();
+
+    assert_eq!(tx.amount, dec!(1000));
+    assert_eq!(balance.total_balance, dec!(0));
+    assert_eq!(balance.total_available, dec!(0));
+}
+
+#[test]
+fn test_withdraw_more_than_available_fails() {
+    let mut trust = new_facade(NoOpBroker);
+    let account = trust
+        .create_account("acc", "d", model::Environment::Paper, dec!(20), dec!(10))
+        .unwrap();
+    trust
+        .create_transaction(
+            &account,
+            &TransactionCategory::Deposit,
+            dec!(1000),
+            &Currency::USD,
+        )
+        .unwrap();
+
+    let result = trust.create_transaction(
+        &account,
+        &TransactionCategory::Withdrawal,
+        dec!(1000.01),
+        &Currency::USD,
+    );
+    assert!(result.is_err(), "withdrawal exceeding available should fail");
+}
+
+#[test]
+fn test_withdraw_zero_fails() {
+    let mut trust = new_facade(NoOpBroker);
+    let account = trust
+        .create_account("acc", "d", model::Environment::Paper, dec!(20), dec!(10))
+        .unwrap();
+    trust
+        .create_transaction(
+            &account,
+            &TransactionCategory::Deposit,
+            dec!(1000),
+            &Currency::USD,
+        )
+        .unwrap();
+
+    let result = trust.create_transaction(
+        &account,
+        &TransactionCategory::Withdrawal,
+        dec!(0),
+        &Currency::USD,
+    );
+    assert!(result.is_err(), "zero withdrawal should be rejected");
+}
+
+#[test]
+fn test_withdraw_negative_fails() {
+    let mut trust = new_facade(NoOpBroker);
+    let account = trust
+        .create_account("acc", "d", model::Environment::Paper, dec!(20), dec!(10))
+        .unwrap();
+    trust
+        .create_transaction(
+            &account,
+            &TransactionCategory::Deposit,
+            dec!(1000),
+            &Currency::USD,
+        )
+        .unwrap();
+
+    let result = trust.create_transaction(
+        &account,
+        &TransactionCategory::Withdrawal,
+        dec!(-100),
+        &Currency::USD,
+    );
+    assert!(result.is_err(), "negative withdrawal should be rejected");
+}
+
+#[test]
+fn test_deposit_negative_fails() {
+    let mut trust = new_facade(NoOpBroker);
+    let account = trust
+        .create_account("acc", "d", model::Environment::Paper, dec!(20), dec!(10))
+        .unwrap();
+
+    let result = trust.create_transaction(
+        &account,
+        &TransactionCategory::Deposit,
+        dec!(-100),
+        &Currency::USD,
+    );
+    assert!(result.is_err(), "negative deposit should be rejected");
+}
+
+#[test]
+fn test_deposit_zero_succeeds() {
+    // The validator allows amount >= 0 for deposits (is_sign_negative check)
+    let mut trust = new_facade(NoOpBroker);
+    let account = trust
+        .create_account("acc", "d", model::Environment::Paper, dec!(20), dec!(10))
+        .unwrap();
+
+    let result = trust.create_transaction(
+        &account,
+        &TransactionCategory::Deposit,
+        dec!(0),
+        &Currency::USD,
+    );
+    assert!(
+        result.is_ok(),
+        "zero deposit should be allowed by current validation"
+    );
+}
+
+#[test]
+fn test_manually_creating_fund_trade_transaction_is_rejected() {
+    let mut trust = new_facade(NoOpBroker);
+    let account = trust
+        .create_account("acc", "d", model::Environment::Paper, dec!(20), dec!(10))
+        .unwrap();
+    trust
+        .create_transaction(
+            &account,
+            &TransactionCategory::Deposit,
+            dec!(1000),
+            &Currency::USD,
+        )
+        .unwrap();
+
+    let result = trust.create_transaction(
+        &account,
+        &TransactionCategory::FundTrade(Uuid::new_v4()),
+        dec!(500),
+        &Currency::USD,
+    );
+    assert!(
+        result.is_err(),
+        "manually creating FundTrade should be rejected"
+    );
+}
+
+#[test]
+fn test_manually_creating_open_trade_transaction_is_rejected() {
+    let mut trust = new_facade(NoOpBroker);
+    let account = trust
+        .create_account("acc", "d", model::Environment::Paper, dec!(20), dec!(10))
+        .unwrap();
+    trust
+        .create_transaction(
+            &account,
+            &TransactionCategory::Deposit,
+            dec!(1000),
+            &Currency::USD,
+        )
+        .unwrap();
+
+    let result = trust.create_transaction(
+        &account,
+        &TransactionCategory::OpenTrade(Uuid::new_v4()),
+        dec!(500),
+        &Currency::USD,
+    );
+    assert!(
+        result.is_err(),
+        "manually creating OpenTrade should be rejected"
+    );
+}
+
+#[test]
+fn test_manually_creating_close_target_transaction_is_rejected() {
+    let mut trust = new_facade(NoOpBroker);
+    let account = trust
+        .create_account("acc", "d", model::Environment::Paper, dec!(20), dec!(10))
+        .unwrap();
+
+    let result = trust.create_transaction(
+        &account,
+        &TransactionCategory::CloseTarget(Uuid::new_v4()),
+        dec!(500),
+        &Currency::USD,
+    );
+    assert!(
+        result.is_err(),
+        "manually creating CloseTarget should be rejected"
+    );
+}
+
+// ===========================================================================
+// 7. WITHDRAWAL TAX / EARNINGS — Balance field correctness
+// ===========================================================================
+
+#[test]
+fn test_withdrawal_tax_reduces_total_balance_but_not_total_available() {
+    let mut trust = new_facade(NoOpBroker);
+    let account = trust
+        .create_account("acc", "d", model::Environment::Paper, dec!(20), dec!(10))
+        .unwrap();
+    trust
+        .create_transaction(
+            &account,
+            &TransactionCategory::Deposit,
+            dec!(5000),
+            &Currency::USD,
+        )
+        .unwrap();
+
+    let (tx, balance) = trust
+        .create_transaction(
+            &account,
+            &TransactionCategory::WithdrawalTax,
+            dec!(500),
+            &Currency::USD,
+        )
+        .unwrap();
+
+    assert_eq!(tx.category, TransactionCategory::WithdrawalTax);
+    assert_eq!(tx.amount, dec!(500));
+    // WithdrawalTax: decreases total_balance, does NOT decrease total_available
+    assert_eq!(balance.total_balance, dec!(4500));
+    assert_eq!(balance.total_available, dec!(5000)); // Unchanged
+}
+
+#[test]
+fn test_withdrawal_earnings_reduces_both_total_balance_and_available() {
+    let mut trust = new_facade(NoOpBroker);
+    let account = trust
+        .create_account("acc", "d", model::Environment::Paper, dec!(20), dec!(10))
+        .unwrap();
+    trust
+        .create_transaction(
+            &account,
+            &TransactionCategory::Deposit,
+            dec!(5000),
+            &Currency::USD,
+        )
+        .unwrap();
+
+    let (_, balance) = trust
+        .create_transaction(
+            &account,
+            &TransactionCategory::WithdrawalEarnings,
+            dec!(500),
+            &Currency::USD,
+        )
+        .unwrap();
+
+    // WithdrawalEarnings: decreases both total_balance AND total_available
+    assert_eq!(balance.total_balance, dec!(4500));
+    assert_eq!(balance.total_available, dec!(4500));
+}
+
+// ===========================================================================
+// 8. TRADE BALANCE FIELD VERIFICATION — Full lifecycle
+// ===========================================================================
+
+#[test]
+fn test_trade_balance_after_entry_fill_with_slippage() {
+    let mut trust = new_facade(SyncBroker::new(|t| entry_filled_at(t, dec!(39.9))));
+    let account = setup_account(&mut trust, dec!(50000));
+    let trade = setup_submitted_trade(&mut trust, &account);
+
+    trust.sync_trade(&trade, &account).unwrap();
+
+    let filled_trade = trust
+        .search_trades(account.id, Status::Filled)
+        .unwrap()
+        .pop()
+        .unwrap();
+
+    // Trade balance after fill:
+    // FundTrade: funding=20000, capital_out_market=20000
+    // OpenTrade: capital_in_market=19950, capital_out_market=20000-19950=50
+    // PaymentFromTrade (slippage refund): capital_out_market=50-50=0
+    assert_eq!(filled_trade.balance.funding, dec!(20000));
+    assert_eq!(filled_trade.balance.capital_in_market, dec!(19950));
+    assert_eq!(filled_trade.balance.capital_out_market, dec!(0)); // Slippage refund zeroed it
+    assert_eq!(filled_trade.balance.taxed, dec!(0));
+    assert_eq!(filled_trade.balance.total_performance, dec!(-19950));
+}
+
+#[test]
+fn test_trade_balance_after_exact_entry_fill() {
+    let mut trust = new_facade(SyncBroker::new(|t| entry_filled_at(t, dec!(40))));
+    let account = setup_account(&mut trust, dec!(50000));
+    let trade = setup_submitted_trade(&mut trust, &account);
+
+    trust.sync_trade(&trade, &account).unwrap();
+
+    let filled_trade = trust
+        .search_trades(account.id, Status::Filled)
+        .unwrap()
+        .pop()
+        .unwrap();
+
+    // No slippage refund: capital_out_market = funding - open = 20000 - 20000 = 0
+    assert_eq!(filled_trade.balance.funding, dec!(20000));
+    assert_eq!(filled_trade.balance.capital_in_market, dec!(20000));
+    assert_eq!(filled_trade.balance.capital_out_market, dec!(0));
+    assert_eq!(filled_trade.balance.total_performance, dec!(-20000));
+}
+
+#[test]
+fn test_trade_balance_after_profitable_close() {
+    let mut trust = new_facade(SyncBroker::new(|t| {
+        target_filled_at(t, dec!(39.9), dec!(52.9))
+    }));
+    let account = setup_account(&mut trust, dec!(50000));
+    let trade = setup_submitted_trade(&mut trust, &account);
+
+    trust.sync_trade(&trade, &account).unwrap();
+
+    let closed_trade = trust
+        .search_trades(account.id, Status::ClosedTarget)
+        .unwrap()
+        .pop()
+        .unwrap();
+
+    assert_eq!(closed_trade.balance.capital_in_market, dec!(0));
+    assert_eq!(closed_trade.balance.total_performance, dec!(6500));
+    assert_eq!(closed_trade.balance.capital_out_market, dec!(0));
+}
+
+#[test]
+fn test_trade_balance_after_stop_loss_close() {
+    let mut trust = new_facade(SyncBroker::new(|t| stop_filled_at(t, dec!(39.9), dec!(38))));
+    let account = setup_account(&mut trust, dec!(50000));
+    let trade = setup_submitted_trade(&mut trust, &account);
+
+    trust.sync_trade(&trade, &account).unwrap();
+
+    let closed_trade = trust
+        .search_trades(account.id, Status::ClosedStopLoss)
+        .unwrap()
+        .pop()
+        .unwrap();
+
+    assert_eq!(closed_trade.balance.capital_in_market, dec!(0));
+    // Performance = CloseSafetyStop(19000) - OpenTrade(19950) = -950
+    assert_eq!(closed_trade.balance.total_performance, dec!(-950));
+    assert_eq!(closed_trade.balance.capital_out_market, dec!(0));
+}
+
+// ===========================================================================
+// 9. MULTIPLE TRADES — Verify balance isolation
+// ===========================================================================
+
+#[test]
+fn test_two_trades_funded_simultaneously_correct_balances() {
+    let mut trust = new_facade(NoOpBroker);
+    let account = setup_account(&mut trust, dec!(100000));
+
+    // Create and fund two trades
+    for symbol in &["AAPL", "GOOG"] {
+        let tv = create_vehicle(&mut trust, symbol);
+        let draft = DraftTrade {
+            account: account.clone(),
+            trading_vehicle: tv,
+            quantity: 500,
+            currency: Currency::USD,
+            category: TradeCategory::Long,
+            thesis: None,
+            sector: None,
+            asset_class: None,
+            context: None,
+        };
+        trust
+            .create_trade(draft, dec!(38), dec!(40), dec!(50))
+            .unwrap();
+    }
+
+    let new_trades = trust.search_trades(account.id, Status::New).unwrap();
+    assert_eq!(new_trades.len(), 2);
+
+    // Fund first trade
+    trust.fund_trade(&new_trades[0]).unwrap();
+    let balance = trust.search_balance(account.id, &Currency::USD).unwrap();
+    assert_eq!(balance.total_available, dec!(80000));
+    assert_eq!(balance.total_in_trade, dec!(20000));
+
+    // Fund second trade
+    trust.fund_trade(&new_trades[1]).unwrap();
+    let balance = trust.search_balance(account.id, &Currency::USD).unwrap();
+    assert_eq!(balance.total_available, dec!(60000));
+    assert_eq!(balance.total_in_trade, dec!(40000));
+
+    // Cancel first trade — should restore only its funds
+    let funded = trust.search_trades(account.id, Status::Funded).unwrap();
+    trust.cancel_funded_trade(&funded[0]).unwrap();
+    let balance = trust.search_balance(account.id, &Currency::USD).unwrap();
+    assert_eq!(balance.total_available, dec!(80000));
+    assert_eq!(balance.total_in_trade, dec!(20000));
+}
+
+// ===========================================================================
+// 10. DECIMAL PRECISION
+// ===========================================================================
+
+#[test]
+fn test_deposit_and_withdrawal_with_fractional_cents() {
+    let mut trust = new_facade(NoOpBroker);
+    let account = trust
+        .create_account("acc", "d", model::Environment::Paper, dec!(20), dec!(10))
+        .unwrap();
+
+    trust
+        .create_transaction(
+            &account,
+            &TransactionCategory::Deposit,
+            dec!(0.0001),
+            &Currency::USD,
+        )
+        .unwrap();
+    trust
+        .create_transaction(
+            &account,
+            &TransactionCategory::Deposit,
+            dec!(0.0002),
+            &Currency::USD,
+        )
+        .unwrap();
+    trust
+        .create_transaction(
+            &account,
+            &TransactionCategory::Deposit,
+            dec!(0.0003),
+            &Currency::USD,
+        )
+        .unwrap();
+
+    let balance = trust.search_balance(account.id, &Currency::USD).unwrap();
+    assert_eq!(balance.total_balance, dec!(0.0006));
+    assert_eq!(balance.total_available, dec!(0.0006));
+
+    let (_, balance) = trust
+        .create_transaction(
+            &account,
+            &TransactionCategory::Withdrawal,
+            dec!(0.0006),
+            &Currency::USD,
+        )
+        .unwrap();
+    assert_eq!(balance.total_balance, dec!(0));
+    assert_eq!(balance.total_available, dec!(0));
+}
+
+#[test]
+fn test_large_deposit_amount() {
+    let mut trust = new_facade(NoOpBroker);
+    let account = trust
+        .create_account("acc", "d", model::Environment::Paper, dec!(20), dec!(10))
+        .unwrap();
+
+    let large_amount = dec!(999_999_999.9999);
+    let (tx, balance) = trust
+        .create_transaction(
+            &account,
+            &TransactionCategory::Deposit,
+            large_amount,
+            &Currency::USD,
+        )
+        .unwrap();
+
+    assert_eq!(tx.amount, large_amount);
+    assert_eq!(balance.total_balance, large_amount);
+    assert_eq!(balance.total_available, large_amount);
+}
+
+// ===========================================================================
+// 11. FIRST DEPOSIT AUTO-CREATES BALANCE
+// ===========================================================================
+
+#[test]
+fn test_first_deposit_auto_creates_balance_overview() {
+    let mut trust = new_facade(NoOpBroker);
+    let account = trust
+        .create_account("acc", "d", model::Environment::Paper, dec!(20), dec!(10))
+        .unwrap();
+
+    let (tx, balance) = trust
+        .create_transaction(
+            &account,
+            &TransactionCategory::Deposit,
+            dec!(500),
+            &Currency::USD,
+        )
+        .unwrap();
+
+    assert_eq!(tx.amount, dec!(500));
+    assert_eq!(balance.total_balance, dec!(500));
+    assert_eq!(balance.total_available, dec!(500));
+
+    let queried = trust.search_balance(account.id, &Currency::USD).unwrap();
+    assert_eq!(queried.total_balance, dec!(500));
+}
+
+// ===========================================================================
+// 12. SHORT TRADE — Funding uses stop price (worst case)
+// ===========================================================================
+
+#[test]
+fn test_short_trade_funded_at_stop_price() {
+    let mut trust = new_facade(NoOpBroker);
+    let account = trust
+        .create_account("acc", "d", model::Environment::Paper, dec!(20), dec!(10))
+        .unwrap();
+    trust
+        .create_transaction(
+            &account,
+            &TransactionCategory::Deposit,
+            dec!(10000),
+            &Currency::USD,
+        )
+        .unwrap();
+    trust
+        .create_rule(
+            &account,
+            &RuleName::RiskPerTrade(50.0),
+            "high risk",
+            &RuleLevel::Error,
+        )
+        .unwrap();
+
+    let tv = create_vehicle(&mut trust, "TSLA");
+    let draft = DraftTrade {
+        account: account.clone(),
+        trading_vehicle: tv,
+        quantity: 100,
+        currency: Currency::USD,
+        category: TradeCategory::Short,
+        thesis: None,
+        sector: None,
+        asset_class: None,
+        context: None,
+    };
+
+    // Short trade: entry=50, stop=60 (worst case), target=40
+    trust
+        .create_trade(draft, dec!(60), dec!(50), dec!(40))
+        .unwrap();
+    let trade = trust
+        .search_trades(account.id, Status::New)
+        .unwrap()
+        .pop()
+        .unwrap();
+
+    let (_, tx, _, _) = trust.fund_trade(&trade).unwrap();
+
+    // For short trades, funding should use stop price: 60 * 100 = 6000
+    assert_eq!(
+        tx.amount,
+        dec!(6000),
+        "short trade should fund based on stop (worst case) price"
+    );
+
+    let balance = trust.search_balance(account.id, &Currency::USD).unwrap();
+    assert_eq!(balance.total_available, dec!(4000)); // 10000 - 6000
+}
+
+// ===========================================================================
+// 13. TRANSACTION CURRENCY CONSISTENCY
+// ===========================================================================
+
+#[test]
+fn test_all_queryable_transactions_have_same_currency_as_trade() {
+    let mut trust = new_facade(SyncBroker::new(|t| target_filled_at(t, dec!(40), dec!(50))));
+    let account = setup_account(&mut trust, dec!(50000));
+    let trade = setup_submitted_trade(&mut trust, &account);
+
+    trust.sync_trade(&trade, &account).unwrap();
+
+    let txs = trust.get_account_transactions(account.id).unwrap();
+    for tx in &txs {
+        assert_eq!(
+            tx.currency,
+            Currency::USD,
+            "transaction {:?} has wrong currency",
+            tx.category
+        );
+    }
+}
+
+// ===========================================================================
+// 14. IDEMPOTENCY — Multiple syncs should not create duplicate transactions
+// ===========================================================================
+
+#[test]
+fn test_sync_idempotency_no_duplicate_transactions_on_fill() {
+    let mut trust = new_facade(SyncBroker::new(|t| entry_filled_at(t, dec!(39.9))));
+    let account = setup_account(&mut trust, dec!(50000));
+    let trade = setup_submitted_trade(&mut trust, &account);
+
+    for _ in 0..5 {
+        trust.sync_trade(&trade, &account).unwrap();
+    }
+
+    let txs = trust.get_account_transactions(account.id).unwrap();
+    let refund_count = txs
+        .iter()
+        .filter(|t| matches!(t.category, TransactionCategory::PaymentFromTrade(_)))
+        .count();
+    assert_eq!(
+        refund_count, 1,
+        "multiple syncs should not duplicate slippage refund"
+    );
+
+    let balance = trust.search_balance(account.id, &Currency::USD).unwrap();
+    assert_eq!(balance.total_available, dec!(30050));
+}
+
+#[test]
+fn test_sync_idempotency_no_duplicate_transactions_on_close() {
+    let mut trust = new_facade(SyncBroker::new(|t| {
+        target_filled_at(t, dec!(39.9), dec!(52.9))
+    }));
+    let account = setup_account(&mut trust, dec!(50000));
+    let trade = setup_submitted_trade(&mut trust, &account);
+
+    for _ in 0..5 {
+        trust.sync_trade(&trade, &account).unwrap();
+    }
+
+    let txs = trust.get_account_transactions(account.id).unwrap();
+    let payment_count = txs
+        .iter()
+        .filter(|t| matches!(t.category, TransactionCategory::PaymentFromTrade(_)))
+        .count();
+    // 2 PaymentFromTrade: slippage refund + final return (not duplicated)
+    assert_eq!(
+        payment_count, 2,
+        "multiple syncs should not duplicate PaymentFromTrade"
+    );
+
+    let balance = trust.search_balance(account.id, &Currency::USD).unwrap();
+    assert_eq!(balance.total_available, dec!(56500));
+    assert_eq!(balance.total_balance, dec!(56500));
+}
+
+// ===========================================================================
+// 15. BALANCE ACCOUNTING IDENTITY
+// ===========================================================================
+
+#[test]
+fn test_accounting_identity_after_deposit() {
+    let mut trust = new_facade(NoOpBroker);
+    let account = trust
+        .create_account("acc", "d", model::Environment::Paper, dec!(20), dec!(10))
+        .unwrap();
+
+    for amount in [dec!(100), dec!(250.50), dec!(0.01)] {
+        trust
+            .create_transaction(
+                &account,
+                &TransactionCategory::Deposit,
+                amount,
+                &Currency::USD,
+            )
+            .unwrap();
+    }
+
+    let balance = trust.search_balance(account.id, &Currency::USD).unwrap();
+    assert_eq!(balance.total_balance, balance.total_available);
+    assert_eq!(balance.total_in_trade, dec!(0));
+}
+
+#[test]
+fn test_accounting_identity_after_funding_trade() {
+    let mut trust = new_facade(NoOpBroker);
+    let account = setup_account(&mut trust, dec!(50000));
+    let tv = create_vehicle(&mut trust, "TSLA");
+
+    let draft = DraftTrade {
+        account: account.clone(),
+        trading_vehicle: tv,
+        quantity: 500,
+        currency: Currency::USD,
+        category: TradeCategory::Long,
+        thesis: None,
+        sector: None,
+        asset_class: None,
+        context: None,
+    };
+    trust
+        .create_trade(draft, dec!(38), dec!(40), dec!(50))
+        .unwrap();
+    let trade = trust
+        .search_trades(account.id, Status::New)
+        .unwrap()
+        .pop()
+        .unwrap();
+    trust.fund_trade(&trade).unwrap();
+
+    let balance = trust.search_balance(account.id, &Currency::USD).unwrap();
+    assert_eq!(balance.total_balance, dec!(50000));
+    assert_eq!(
+        balance.total_available + balance.total_in_trade,
+        balance.total_balance,
+        "accounting identity: total_available + total_in_trade = total_balance"
+    );
+}
+
+// ===========================================================================
+// 16. SEVERE SLIPPAGE STOP LOSS
+// ===========================================================================
+
+#[test]
+fn test_severe_slippage_stop_loss() {
+    // Stop planned at 38, but filled at 30.2 — severe slippage for long
+    let mut trust = new_facade(SyncBroker::new(|t| stop_filled_at(t, dec!(39.9), dec!(30.2))));
+    let account = setup_account(&mut trust, dec!(50000));
+    let trade = setup_submitted_trade(&mut trust, &account);
+
+    trust.sync_trade(&trade, &account).unwrap();
+
+    let closed_trade = trust
+        .search_trades(account.id, Status::ClosedStopLoss)
+        .unwrap()
+        .pop()
+        .unwrap();
+
+    // Performance = stop(30.2*500=15100) - open(39.9*500=19950) = -4850
+    assert_eq!(closed_trade.balance.total_performance, dec!(-4850));
+
+    let balance = trust.search_balance(account.id, &Currency::USD).unwrap();
+    // 50000 - open(19950) + slippage_refund(50) + stop_return(15100) = 45200
+    // But total_balance = initial - open + close = 50000 - 19950 + 15100 = 45150
+    assert_eq!(balance.total_balance, dec!(45150));
+    assert_eq!(balance.total_in_trade, dec!(0));
+}
+
+// ===========================================================================
+// 17. PROFITABLE/LOSING TRADE ENDING BALANCE VERIFICATION
+// ===========================================================================
+
+#[test]
+fn test_profitable_trade_final_balance_matches_deposit_plus_profit() {
+    // Entry at 40, target at 60 → profit = (60-40)*500 = 10000
+    let mut trust = new_facade(SyncBroker::new(|t| target_filled_at(t, dec!(40), dec!(60))));
+    let account = setup_account(&mut trust, dec!(50000));
+    let trade = setup_submitted_trade(&mut trust, &account);
+
+    trust.sync_trade(&trade, &account).unwrap();
+
+    let balance = trust.search_balance(account.id, &Currency::USD).unwrap();
+    assert_eq!(balance.total_balance, dec!(60000)); // 50000 + 10000
+    assert_eq!(balance.total_available, dec!(60000));
+    assert_eq!(balance.total_in_trade, dec!(0));
+}
+
+#[test]
+fn test_losing_trade_final_balance_matches_deposit_minus_loss() {
+    // Entry at 40, stop at 37 → loss = (40-37)*500 = 1500
+    let mut trust = new_facade(SyncBroker::new(|t| stop_filled_at(t, dec!(40), dec!(37))));
+    let account = setup_account(&mut trust, dec!(50000));
+    let trade = setup_submitted_trade(&mut trust, &account);
+
+    trust.sync_trade(&trade, &account).unwrap();
+
+    let balance = trust.search_balance(account.id, &Currency::USD).unwrap();
+    assert_eq!(balance.total_balance, dec!(48500)); // 50000 - 1500
+    assert_eq!(balance.total_available, dec!(48500));
+    assert_eq!(balance.total_in_trade, dec!(0));
+}
+
+// ===========================================================================
+// 18. WITHDRAW WHILE TRADE IS FUNDED — Available balance should be reduced
+// ===========================================================================
+
+#[test]
+fn test_cannot_withdraw_funds_locked_in_trade() {
+    let mut trust = new_facade(NoOpBroker);
+    let account = setup_account(&mut trust, dec!(50000));
+    let tv = create_vehicle(&mut trust, "TSLA");
+
+    let draft = DraftTrade {
+        account: account.clone(),
+        trading_vehicle: tv,
+        quantity: 500,
+        currency: Currency::USD,
+        category: TradeCategory::Long,
+        thesis: None,
+        sector: None,
+        asset_class: None,
+        context: None,
+    };
+    trust
+        .create_trade(draft, dec!(38), dec!(40), dec!(50))
+        .unwrap();
+    let trade = trust
+        .search_trades(account.id, Status::New)
+        .unwrap()
+        .pop()
+        .unwrap();
+    trust.fund_trade(&trade).unwrap();
+
+    // Available is now 30000 (50000 - 20000 in trade)
+    let balance = trust.search_balance(account.id, &Currency::USD).unwrap();
+    assert_eq!(balance.total_available, dec!(30000));
+
+    // Should succeed: withdraw up to available
+    trust
+        .create_transaction(
+            &account,
+            &TransactionCategory::Withdrawal,
+            dec!(30000),
+            &Currency::USD,
+        )
+        .unwrap();
+
+    // Should fail: nothing left to withdraw
+    let result = trust.create_transaction(
+        &account,
+        &TransactionCategory::Withdrawal,
+        dec!(1),
+        &Currency::USD,
+    );
+    assert!(
+        result.is_err(),
+        "should not be able to withdraw funds locked in trade"
+    );
+}
+
+// ===========================================================================
+// 19. MULTIPLE DEPOSITS/WITHDRAWALS RUNNING BALANCE
+// ===========================================================================
+
+#[test]
+fn test_running_balance_after_many_operations() {
+    let mut trust = new_facade(NoOpBroker);
+    let account = trust
+        .create_account("acc", "d", model::Environment::Paper, dec!(20), dec!(10))
+        .unwrap();
+
+    let ops: Vec<(TransactionCategory, Decimal)> = vec![
+        (TransactionCategory::Deposit, dec!(10000)),
+        (TransactionCategory::Withdrawal, dec!(500)),
+        (TransactionCategory::Deposit, dec!(250.75)),
+        (TransactionCategory::Withdrawal, dec!(1000.25)),
+        (TransactionCategory::Deposit, dec!(3000)),
+        (TransactionCategory::Withdrawal, dec!(7500)),
+    ];
+
+    // Expected: 10000 - 500 + 250.75 - 1000.25 + 3000 - 7500 = 4250.50
+    for (cat, amount) in &ops {
+        trust
+            .create_transaction(&account, cat, *amount, &Currency::USD)
+            .unwrap();
+    }
+
+    let balance = trust.search_balance(account.id, &Currency::USD).unwrap();
+    assert_eq!(balance.total_balance, dec!(4250.50));
+    assert_eq!(balance.total_available, dec!(4250.50));
+
+    // Verify transaction count
+    let txs = trust.get_account_transactions(account.id).unwrap();
+    assert_eq!(txs.len(), 6);
+}


### PR DESCRIPTION
## Summary

- **43 tests** in `integration_test_transactions.rs` — Transaction record assertions (category, amount, currency), slippage refund verification, balance projection per transaction type, decimal precision, short trade funding, accounting identity invariants
- **25 tests** in `integration_test_sync_edge_cases.rs` — Submitted→Closed single-sync path, fee reconciliation (broker_order_id + symbol+day heuristic), fee idempotency on resync, sibling order cancellation, stop modification guards, risk validation boundaries, money conservation proofs
- **20 tests** in `integration_test_broker_failures.rs` — Network/auth/server errors leave trade+balance unchanged, execution/fee fetch failures don't block sync (best-effort), transient failure recovery without double-counting, empty/wrong/duplicate order rejection, status mismatch detection, submit failure recovery, 100-consecutive-failure stress test, risk invariant proof (total_available is the gatekeeper, not total_in_trade)

## Key findings during development
- `get_account_transactions()` intentionally excludes `OpenTrade`, `CloseTarget`, `CloseSafetyStop`, `CloseSafetyStopSlippage` from its query — verified and documented in tests
- `total_in_trade` transitions to 0 on Funded→Submitted but this is safe: `total_available` (reduced by FundTrade) is the actual risk gatekeeper. New tests explicitly prove you cannot over-risk via this state
- Fee reconciliation uses delta-based approach (allocated - existing), making it naturally idempotent on resync

## Test plan
- [x] All 88 new tests pass (`cargo test -p trust-cli -- --test-threads=1`)
- [x] All 65 existing integration tests still pass
- [x] Clippy clean (`-D warnings`) on all 3 new test files
- [x] No changes to production code — tests only

🤖 Generated with [Claude Code](https://claude.com/claude-code)