### PR TITLE
fix(core): close security regression bugs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -497,7 +497,6 @@ dependencies = [
  "rand_core 0.6.4",
  "rust_decimal",
  "rust_decimal_macros",
- "sha2",
  "thiserror 1.0.69",
  "tracing",
  "trust-model",
@@ -2245,17 +2244,6 @@ name = "sha1"
 version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
-dependencies = [
- "cfg-if",
- "cpufeatures 0.2.17",
- "digest",
-]
-
-[[package]]
-name = "sha2"
-version = "0.10.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
  "cpufeatures 0.2.17",

--- a/cli/src/dispatcher.rs
+++ b/cli/src/dispatcher.rs
@@ -400,7 +400,22 @@ impl ArgDispatcher {
     }
 
     fn is_valid_protected_keyword(expected: &str, provided: &str) -> bool {
-        provided == expected
+        if expected.is_empty() || provided.is_empty() {
+            return false;
+        }
+
+        let expected_bytes = expected.as_bytes();
+        let provided_bytes = provided.as_bytes();
+        let max_len = expected_bytes.len().max(provided_bytes.len());
+        let mut diff = expected_bytes.len() ^ provided_bytes.len();
+
+        for index in 0..max_len {
+            let expected_byte = expected_bytes.get(index).copied().unwrap_or_default();
+            let provided_byte = provided_bytes.get(index).copied().unwrap_or_default();
+            diff |= usize::from(expected_byte ^ provided_byte);
+        }
+
+        diff == 0
     }
 
     pub fn new_sqlite() -> Self {
@@ -1037,7 +1052,15 @@ impl ArgDispatcher {
             ));
         }
 
-        self.trust.authorize_protected_mutation();
+        self.trust
+            .authorize_protected_mutation(provided, &expected)
+            .map_err(|_| {
+                Self::report_error(
+                    format,
+                    "protected_keyword_invalid",
+                    format!("Invalid protected keyword for {operation}."),
+                )
+            })?;
         Ok(())
     }
 

--- a/cli/tests/integration_test_bug_hunt.rs
+++ b/cli/tests/integration_test_bug_hunt.rs
@@ -1410,7 +1410,9 @@ fn bug_046_protected_authorization_consumed_once() {
     let mut trust = TrustFacade::new(Box::new(db), Box::new(NoOpBroker));
     trust.enable_protected_mode();
 
-    trust.authorize_protected_mutation();
+    trust
+        .authorize_protected_mutation("secret", "secret")
+        .unwrap();
     trust
         .create_account("test", "test", Environment::Paper, dec!(20), dec!(10))
         .unwrap();
@@ -1428,7 +1430,9 @@ fn bug_047_protected_authorization_consumed_on_failure() {
     let db = SqliteDatabase::new_in_memory();
     let mut trust = TrustFacade::new(Box::new(db), Box::new(NoOpBroker));
     trust.enable_protected_mode();
-    trust.authorize_protected_mutation();
+    trust
+        .authorize_protected_mutation("secret", "secret")
+        .unwrap();
 
     // Create first account
     trust
@@ -1436,7 +1440,9 @@ fn bug_047_protected_authorization_consumed_on_failure() {
         .unwrap();
 
     // Authorization is consumed. Authorize again.
-    trust.authorize_protected_mutation();
+    trust
+        .authorize_protected_mutation("secret", "secret")
+        .unwrap();
 
     let account = trust.search_account("test").unwrap();
     // Try an operation that will fail (e.g., deposit into non-existent currency balance record issue)

--- a/cli/tests/integration_test_level.rs
+++ b/cli/tests/integration_test_level.rs
@@ -321,7 +321,9 @@ fn test_core_protected_mode_blocks_level_mutation_without_authorization() {
 #[test]
 fn test_core_protected_mode_allows_single_authorized_level_mutation() {
     let mut trust = create_protected_trust();
-    trust.authorize_protected_mutation();
+    trust
+        .authorize_protected_mutation("secret", "secret")
+        .unwrap();
     let account = trust
         .create_account(
             "level-core-authorized",
@@ -332,7 +334,9 @@ fn test_core_protected_mode_allows_single_authorized_level_mutation() {
         )
         .expect("authorized account create");
 
-    trust.authorize_protected_mutation();
+    trust
+        .authorize_protected_mutation("secret", "secret")
+        .unwrap();
     let changed = trust.change_level(account.id, 2, "risk control", LevelTrigger::ManualReview);
     assert!(changed.is_ok(), "authorized level mutation should succeed");
 
@@ -390,7 +394,9 @@ fn test_funding_rejects_quantity_above_level_adjusted_limit() {
 #[test]
 fn test_level_adjustment_rules_update_requires_authorization_in_protected_mode() {
     let mut trust = create_protected_trust();
-    trust.authorize_protected_mutation();
+    trust
+        .authorize_protected_mutation("secret", "secret")
+        .unwrap();
     let account = trust
         .create_account(
             "level-rules-protected",
@@ -408,7 +414,9 @@ fn test_level_adjustment_rules_update_requires_authorization_in_protected_mode()
         "rules mutation should require explicit authorization"
     );
 
-    trust.authorize_protected_mutation();
+    trust
+        .authorize_protected_mutation("secret", "secret")
+        .unwrap();
     let with_auth = trust.set_level_adjustment_rules(account.id, &rules);
     assert!(
         with_auth.is_ok(),

--- a/cli/tests/integration_test_transactions.rs
+++ b/cli/tests/integration_test_transactions.rs
@@ -871,8 +871,7 @@ fn test_deposit_negative_fails() {
 }
 
 #[test]
-fn test_deposit_zero_succeeds() {
-    // The validator allows amount >= 0 for deposits (is_sign_negative check)
+fn test_deposit_zero_fails() {
     let mut trust = new_facade(NoOpBroker);
     let account = trust
         .create_account("acc", "d", model::Environment::Paper, dec!(20), dec!(10))
@@ -884,10 +883,7 @@ fn test_deposit_zero_succeeds() {
         dec!(0),
         &Currency::USD,
     );
-    assert!(
-        result.is_ok(),
-        "zero deposit should be allowed by current validation"
-    );
+    assert!(result.is_err(), "zero deposit should be rejected");
 }
 
 #[test]

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -18,7 +18,6 @@ uuid = {workspace = true}
 chrono = {workspace = true}
 thiserror = {workspace = true}
 tracing = {workspace = true}
-sha2 = {workspace = true}
 argon2 = {workspace = true}
 password-hash = {workspace = true}
 rand_core = {workspace = true}

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -290,6 +290,25 @@ impl std::fmt::Debug for TrustFacade {
     }
 }
 
+fn protected_keyword_matches(expected: &str, provided: &str) -> bool {
+    if expected.is_empty() || provided.is_empty() {
+        return false;
+    }
+
+    let expected_bytes = expected.as_bytes();
+    let provided_bytes = provided.as_bytes();
+    let max_len = expected_bytes.len().max(provided_bytes.len());
+    let mut diff = expected_bytes.len() ^ provided_bytes.len();
+
+    for index in 0..max_len {
+        let expected_byte = expected_bytes.get(index).copied().unwrap_or_default();
+        let provided_byte = provided_bytes.get(index).copied().unwrap_or_default();
+        diff |= usize::from(expected_byte ^ provided_byte);
+    }
+
+    diff == 0
+}
+
 /// Trust is the main entry point for interacting with the core library.
 /// It is a facade that provides a simple interface for interacting with the
 /// core library.
@@ -320,9 +339,20 @@ impl TrustFacade {
         self.protected_mode = true;
     }
 
-    /// Authorizes exactly one protected mutation operation.
-    pub fn authorize_protected_mutation(&mut self) {
+    /// Authorizes exactly one protected mutation operation with the protected keyword.
+    pub fn authorize_protected_mutation(
+        &mut self,
+        provided_keyword: &str,
+        expected_keyword: &str,
+    ) -> Result<(), Box<dyn std::error::Error>> {
+        if !self.protected_mode {
+            return Ok(());
+        }
+        if !protected_keyword_matches(expected_keyword, provided_keyword) {
+            return Err("Protected mutation authorization failed".into());
+        }
         self.protected_authorized = true;
+        Ok(())
     }
 
     fn consume_protected_authorization(

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -56,7 +56,6 @@ use model::{
 use rand_core::OsRng;
 use rust_decimal::Decimal;
 use rust_decimal_macros::dec;
-use sha2::{Digest, Sha256};
 use uuid::Uuid;
 use {
     services::leveling::{
@@ -2009,20 +2008,8 @@ fn verify_distribution_password(
             .verify_password(password.as_bytes(), &parsed)
             .is_ok())
     } else {
-        Ok(hash_distribution_password_legacy_sha256(password)? == stored_hash)
+        Ok(false)
     }
-}
-
-fn hash_distribution_password_legacy_sha256(
-    password: &str,
-) -> Result<String, Box<dyn std::error::Error>> {
-    if password.trim().len() < 8 {
-        return Err("Distribution password must be at least 8 characters".into());
-    }
-    let mut hasher = Sha256::new();
-    hasher.update(password.as_bytes());
-    let digest = hasher.finalize();
-    Ok(format!("{digest:x}"))
 }
 
 #[cfg(test)]
@@ -2320,17 +2307,18 @@ mod tests {
     #[test]
     fn distribution_password_hashes_verify_and_reject_weak_inputs() {
         assert!(hash_distribution_password("short").is_err());
-        assert!(hash_distribution_password_legacy_sha256("short").is_err());
 
         let password = "correct horse battery staple";
         let argon_hash = hash_distribution_password(password).unwrap();
+        let second_argon_hash = hash_distribution_password(password).unwrap();
         assert!(argon_hash.starts_with("$argon2"));
+        assert!(second_argon_hash.starts_with("$argon2"));
+        assert_ne!(argon_hash, second_argon_hash);
         assert!(verify_distribution_password(password, &argon_hash).unwrap());
         assert!(!verify_distribution_password("wrong password", &argon_hash).unwrap());
 
-        let legacy_hash = hash_distribution_password_legacy_sha256(password).unwrap();
-        assert!(verify_distribution_password(password, &legacy_hash).unwrap());
-        assert!(!verify_distribution_password("wrong password", &legacy_hash).unwrap());
+        let legacy_sha256_hash = "cbe6beb26479b568e48058e254b7c50b8d0fef2bd635a0f024ee3f80d1a7084d";
+        assert!(!verify_distribution_password(password, legacy_sha256_hash).unwrap());
         assert!(!verify_distribution_password(password, "$argon2id$invalid").unwrap());
     }
 

--- a/core/src/security_tests.rs
+++ b/core/src/security_tests.rs
@@ -292,28 +292,19 @@ mod tests {
     /// that hashing the same password twice produces DIFFERENT results
     /// (which Argon2 does, but SHA-256 doesn't).
     #[test]
-    #[should_panic]
     fn password_hash_should_be_salted() {
-        use sha2::{Digest, Sha256};
-
         let password = "my_secure_password";
-
-        // Reproduce the legacy hashing logic from core/src/lib.rs:1977-1987
-        let hash = |p: &str| {
-            let mut h = Sha256::new();
-            h.update(p.as_bytes());
-            format!("{:x}", h.finalize())
-        };
-
-        let h1 = hash(password);
-        let h2 = hash(password);
+        let h1 = crate::hash_distribution_password(password).unwrap();
+        let h2 = crate::hash_distribution_password(password).unwrap();
 
         // CORRECT behavior: hashing same password twice should produce
-        // different results (salted).  Legacy SHA-256 fails this.
+        // different results (salted).
         assert_ne!(
             h1, h2,
-            "Password hash should be salted — same input must produce different output"
+            "Password hash should be salted - same input must produce different output"
         );
+        assert!(h1.starts_with("$argon2"));
+        assert!(h2.starts_with("$argon2"));
     }
 
     // ===============================================================

--- a/core/src/security_tests.rs
+++ b/core/src/security_tests.rs
@@ -1,10 +1,7 @@
 //! Security and correctness tests for Trust core.
 //!
-//! Each test asserts the **correct** behavior.  Since the bugs are unfixed,
-//! the correct assertion fails — so tests are marked `#[should_panic]`.
-//!
-//! When you fix a bug, its test will stop panicking and the `#[should_panic]`
-//! will cause a test failure — that's your signal to remove the annotation.
+//! Each test asserts the expected fixed behavior directly so these regressions
+//! fail loudly if any of the security guarantees are weakened.
 
 #[cfg(test)]
 #[allow(
@@ -89,13 +86,11 @@ mod tests {
     }
 
     // ===============================================================
-    // 1. PROTECTED MODE BYPASS — no password required
+    // 1. PROTECTED MODE BYPASS - no password required
     // ===============================================================
 
-    /// Protected mutations should require a password.  Currently
-    /// `authorize_protected_mutation()` needs no credentials at all.
+    /// Protected mutations should require valid credentials.
     #[test]
-    #[should_panic]
     fn protected_mode_should_require_password() {
         use crate::TrustFacade;
         use model::{Currency, Environment, TransactionCategory};
@@ -108,8 +103,10 @@ mod tests {
             .unwrap();
 
         facade.enable_protected_mode();
-        // Call authorize without any password — this should fail but doesn't.
-        facade.authorize_protected_mutation();
+        assert!(
+            facade.authorize_protected_mutation("", "").is_err(),
+            "Blank protected credentials should be rejected"
+        );
 
         let result = facade.create_transaction(
             &account,
@@ -125,7 +122,6 @@ mod tests {
     }
 
     /// Confirm that without calling authorize, operations are blocked.
-    /// (This is already correct behavior — no should_panic needed.)
     #[test]
     fn protected_mode_blocks_without_authorize() {
         use crate::TrustFacade;
@@ -151,7 +147,6 @@ mod tests {
 
     /// Re-authorization should require credentials each time.
     #[test]
-    #[should_panic]
     fn protected_mode_re_authorization_should_require_credentials() {
         use crate::TrustFacade;
         use model::{Currency, Environment, TransactionCategory};
@@ -165,16 +160,21 @@ mod tests {
 
         facade.enable_protected_mode();
 
-        // Second authorization without credentials should fail.
-        facade.authorize_protected_mutation();
+        facade
+            .authorize_protected_mutation("correct-secret", "correct-secret")
+            .unwrap();
         let _ = facade.create_transaction(
             &account,
             &TransactionCategory::Deposit,
             dec!(10),
             &Currency::USD,
         );
-        // Now try again — should require credentials again.
-        facade.authorize_protected_mutation();
+        assert!(
+            facade
+                .authorize_protected_mutation("wrong-secret", "correct-secret")
+                .is_err(),
+            "Re-authorization should reject invalid credentials"
+        );
         let result = facade.create_transaction(
             &account,
             &TransactionCategory::Deposit,

--- a/core/src/security_tests.rs
+++ b/core/src/security_tests.rs
@@ -194,7 +194,6 @@ mod tests {
     /// A zero-amount deposit should be rejected like all other zero-amount
     /// financial operations.
     #[test]
-    #[should_panic]
     fn zero_amount_deposit_should_be_rejected() {
         use model::{AccountBalance, AccountBalanceRead, Currency};
         use uuid::Uuid;
@@ -237,7 +236,6 @@ mod tests {
     /// When a non-Filled trade attempts stop modification, the error
     /// should be TradeNotFilled regardless of the price.
     #[test]
-    #[should_panic]
     fn modify_stop_should_check_status_before_price_for_long() {
         use crate::validators::trade::{can_modify_stop, TradeValidationErrorCode};
         use model::TradeCategory;
@@ -263,7 +261,6 @@ mod tests {
 
     /// Same for Short trades.
     #[test]
-    #[should_panic]
     fn modify_stop_should_check_status_before_price_for_short() {
         use crate::validators::trade::{can_modify_stop, TradeValidationErrorCode};
         use model::TradeCategory;

--- a/core/src/validators/trade.rs
+++ b/core/src/validators/trade.rs
@@ -64,6 +64,16 @@ pub fn can_cancel_submitted(trade: &Trade) -> TradeValidationResult {
 }
 
 pub fn can_modify_stop(trade: &Trade, new_price_stop: Decimal) -> TradeValidationResult {
+    if trade.status != Status::Filled {
+        return Err(Box::new(TradeValidationError {
+            code: TradeValidationErrorCode::TradeNotFilled,
+            message: format!(
+                "Trade with id {} is not filled, cannot be modified",
+                trade.id
+            ),
+        }));
+    }
+
     if trade.category == TradeCategory::Long && trade.safety_stop.unit_price > new_price_stop
         || trade.category == TradeCategory::Short && trade.safety_stop.unit_price < new_price_stop
     {
@@ -76,16 +86,7 @@ pub fn can_modify_stop(trade: &Trade, new_price_stop: Decimal) -> TradeValidatio
         }));
     }
 
-    match trade.status {
-        Status::Filled => Ok(()),
-        _ => Err(Box::new(TradeValidationError {
-            code: TradeValidationErrorCode::TradeNotFilled,
-            message: format!(
-                "Trade with id {} is not filled, cannot be modified",
-                trade.id
-            ),
-        })),
-    }
+    Ok(())
 }
 
 pub fn can_modify_target(trade: &Trade) -> TradeValidationResult {
@@ -249,8 +250,35 @@ mod tests {
             status: Status::Canceled,
             ..Default::default()
         };
-        let result = can_modify_stop(&trade, dec!(10));
-        assert!(result.is_err());
+        let error = can_modify_stop(&trade, dec!(10)).unwrap_err();
+        assert_eq!(error.code, TradeValidationErrorCode::TradeNotFilled);
+    }
+
+    #[test]
+    fn test_validate_modify_stop_not_filled_prioritizes_status_over_price() {
+        let long_trade = Trade {
+            status: Status::Submitted,
+            category: TradeCategory::Long,
+            safety_stop: model::Order {
+                unit_price: dec!(10),
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+        let long_error = can_modify_stop(&long_trade, dec!(9)).unwrap_err();
+        assert_eq!(long_error.code, TradeValidationErrorCode::TradeNotFilled);
+
+        let short_trade = Trade {
+            status: Status::Submitted,
+            category: TradeCategory::Short,
+            safety_stop: model::Order {
+                unit_price: dec!(10),
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+        let short_error = can_modify_stop(&short_trade, dec!(11)).unwrap_err();
+        assert_eq!(short_error.code, TradeValidationErrorCode::TradeNotFilled);
     }
 
     #[test]

--- a/core/src/validators/transaction.rs
+++ b/core/src/validators/transaction.rs
@@ -80,7 +80,7 @@ pub fn can_transfer_deposit(
     account_id: Uuid,
     database: &mut dyn AccountBalanceRead,
 ) -> TransactionValidationResult {
-    if amount.is_sign_negative() {
+    if amount <= dec!(0) {
         Err(Box::new(TransactionValidationError {
             code: TransactionValidationErrorCode::AmountOfDepositMustBePositive,
             message: "Amount of deposit must be positive".to_string(),
@@ -392,7 +392,7 @@ mod tests {
         };
 
         assert!(
-            can_transfer_deposit(dec!(0), &currency, account_id, &mut existing_balance).is_ok()
+            can_transfer_deposit(dec!(1), &currency, account_id, &mut existing_balance).is_ok()
         );
 
         let mut missing_balance = BalanceReadStub { balance: None };
@@ -410,6 +410,20 @@ mod tests {
             }),
         };
         let error = can_transfer_deposit(dec!(-1), &currency, account_id, &mut existing_balance)
+            .unwrap_err();
+        assert_eq!(
+            error.code,
+            TransactionValidationErrorCode::AmountOfDepositMustBePositive
+        );
+
+        let mut existing_balance = BalanceReadStub {
+            balance: Some(AccountBalance {
+                account_id,
+                currency,
+                ..Default::default()
+            }),
+        };
+        let error = can_transfer_deposit(dec!(0), &currency, account_id, &mut existing_balance)
             .unwrap_err();
         assert_eq!(
             error.code,


### PR DESCRIPTION
## Summary

- Require protected mutations to authorize with matching non-empty credentials instead of a bare facade toggle.
- Reject zero-value deposits and preserve `TradeNotFilled` as the first error for stop modifications on non-filled trades.
- Remove legacy unsalted SHA-256 distribution password verification; distribution passwords now verify only Argon2 hashes.
- Refresh stale CLI/core regression expectations so the bug tests assert fixed behavior directly.

## Issue audit

Fixed in this branch:
- Fixes #117
- Fixes #119
- Fixes #120
- Fixes #121

Already covered by existing passing regression suites on this branch baseline:
- Fixes #118
- Fixes #122
- Fixes #123
- Fixes #124
- Fixes #125
- Fixes #126
- Fixes #127
- Fixes #128

Closes the aggregate security audit:
- Fixes #130

Open issues #95-#116 and #129 are enhancements/documentation rather than confirmed bugs, so they are intentionally left open.

## Local verification

- `cargo test -p core --lib security_tests -- --test-threads=1`
- `cargo test -p core --lib`
- `cargo test -p trust-cli --test integration_test_level -- --test-threads=1`
- `cargo test -p trust-cli --test integration_test_bug_hunt -- --test-threads=1`
- `cargo test -p trust-cli --test integration_test test_deposit_zero_fails -- --test-threads=1`
- `cargo test --locked --all-features --workspace`
- `cargo test --locked --no-default-features --workspace`
- `make ci-fast`
