### PR TITLE
feat(advisor): add advisor crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9,6 +9,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
+name = "advisor"
+version = "0.3.5"
+dependencies = [
+ "keyring",
+ "reqwest",
+ "thiserror 1.0.69",
+ "trust-model",
+]
+
+[[package]]
 name = "ahash"
 version = "0.7.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -488,6 +498,7 @@ dependencies = [
 name = "core"
 version = "0.3.5"
 dependencies = [
+ "advisor",
  "argon2",
  "chrono",
  "db-sqlite",
@@ -2717,6 +2728,7 @@ dependencies = [
 name = "trust-cli"
 version = "0.3.5"
 dependencies = [
+ "advisor",
  "alpaca-broker",
  "broker-sync",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,14 @@
 [workspace]
-members = ["model", "db-sqlite", "core", "cli", "alpaca-broker", "ibkr-broker", "broker-sync"]
+members = [
+    "model",
+    "db-sqlite",
+    "core",
+    "cli",
+    "alpaca-broker",
+    "ibkr-broker",
+    "broker-sync",
+    "advisor",
+]
 resolver = "2"
 
 [workspace.package]
@@ -36,6 +45,7 @@ shellexpand = "3.1.1"
 keyring = { version = "3.6.3", features = ["apple-native", "windows-native", "sync-secret-service"] }
 serde_json = "1.0.149"
 thiserror = "1.0.69"
+reqwest = { version = "0.12.24", default-features = false, features = ["blocking", "cookies", "json", "native-tls"] }
 sha2 = "0.10.9"
 argon2 = "0.5.3"
 password-hash = "0.5.0"

--- a/advisor/Cargo.toml
+++ b/advisor/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "advisor"
+version = { workspace = true }
+edition = "2021"
+license = "GPL-3.0-only"
+
+[dependencies]
+model = { package = "trust-model", path = "../model", version = "0.3.2" }
+keyring = { workspace = true }
+reqwest = { workspace = true }
+thiserror = { workspace = true }

--- a/advisor/src/catalyst.rs
+++ b/advisor/src/catalyst.rs
@@ -1,0 +1,48 @@
+use crate::AdvisorError;
+
+/// Request for future calendar catalyst scanning.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct CatalystScanRequest {
+    /// Symbols to scan for upcoming events.
+    pub symbols: Vec<String>,
+}
+
+/// Calendar event returned by future catalyst scanning.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CatalystEvent {
+    /// Event symbol.
+    pub symbol: String,
+    /// Human-readable event type.
+    pub event_type: String,
+    /// Human-readable event date or timestamp.
+    pub event_time: String,
+}
+
+/// Stub catalyst scanner.
+#[derive(Debug, Clone, Default)]
+pub struct CatalystScanner;
+
+impl CatalystScanner {
+    /// Return a deliberate stub error until catalyst scanning is implemented.
+    pub fn scan(&self, _request: &CatalystScanRequest) -> Result<Vec<CatalystEvent>, AdvisorError> {
+        Err(AdvisorError::NotImplemented {
+            feature: "catalyst",
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn catalyst_scanner_is_explicit_stub() {
+        let request = CatalystScanRequest {
+            symbols: vec!["AAPL".to_string()],
+        };
+
+        let error = CatalystScanner.scan(&request).unwrap_err();
+
+        assert!(error.to_string().contains("catalyst"));
+    }
+}

--- a/advisor/src/config.rs
+++ b/advisor/src/config.rs
@@ -1,0 +1,298 @@
+use crate::error::AdvisorError;
+use keyring::Entry;
+use std::fmt::{self, Display, Formatter};
+use std::str::FromStr;
+
+const SERVICE: &str = "trust-advisor";
+const CALENDAR_API_KEY: &str = "calendar_api_key";
+const CLAUDE_API_KEY: &str = "claude_api_key";
+const CALENDAR_PROVIDER: &str = "calendar_provider";
+
+/// Calendar data provider used by catalyst scanning.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub enum CalendarProvider {
+    /// Financial Modeling Prep calendar endpoint.
+    Fmp,
+    /// Polygon.io calendar endpoint.
+    Polygon,
+    /// Calendar-driven features are disabled.
+    #[default]
+    None,
+}
+
+impl CalendarProvider {
+    /// Stable storage key for the provider.
+    pub fn as_str(self) -> &'static str {
+        match self {
+            CalendarProvider::Fmp => "fmp",
+            CalendarProvider::Polygon => "polygon",
+            CalendarProvider::None => "none",
+        }
+    }
+}
+
+impl Display for CalendarProvider {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+impl FromStr for CalendarProvider {
+    type Err = AdvisorError;
+
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        match value.trim().to_ascii_lowercase().as_str() {
+            "fmp" | "financial-modeling-prep" | "financialmodelingprep" => Ok(Self::Fmp),
+            "polygon" | "polygon.io" => Ok(Self::Polygon),
+            "none" | "off" | "disabled" => Ok(Self::None),
+            _ => Err(AdvisorError::InvalidCalendarProvider {
+                value: value.to_string(),
+            }),
+        }
+    }
+}
+
+/// Redacted advisor configuration status.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AdvisorConfig {
+    /// Configured calendar provider.
+    pub calendar_provider: CalendarProvider,
+    /// Whether a calendar API key is present.
+    pub calendar_api_key_configured: bool,
+    /// Whether a Claude API key is present.
+    pub claude_api_key_configured: bool,
+}
+
+impl AdvisorConfig {
+    /// Read advisor configuration status from the system keychain.
+    pub fn read() -> Result<Self, AdvisorError> {
+        let store = KeychainSecretStore;
+        read_with_store(&store)
+    }
+
+    /// Human-safe display value for calendar API key state.
+    pub fn calendar_api_key_display(&self) -> &'static str {
+        redacted_key_state(self.calendar_api_key_configured)
+    }
+
+    /// Human-safe display value for Claude API key state.
+    pub fn claude_api_key_display(&self) -> &'static str {
+        redacted_key_state(self.claude_api_key_configured)
+    }
+}
+
+impl Default for AdvisorConfig {
+    fn default() -> Self {
+        Self {
+            calendar_provider: CalendarProvider::None,
+            calendar_api_key_configured: false,
+            claude_api_key_configured: false,
+        }
+    }
+}
+
+/// Partial advisor configuration update.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct AdvisorConfigUpdate {
+    /// Calendar provider to persist.
+    pub calendar_provider: Option<CalendarProvider>,
+    /// Calendar API key to persist.
+    pub calendar_api_key: Option<String>,
+    /// Claude API key to persist.
+    pub claude_api_key: Option<String>,
+}
+
+impl AdvisorConfigUpdate {
+    /// Returns true when the update contains no changes.
+    pub fn is_empty(&self) -> bool {
+        self.calendar_provider.is_none()
+            && self.calendar_api_key.is_none()
+            && self.claude_api_key.is_none()
+    }
+
+    /// Persist this update to the system keychain and return redacted status.
+    pub fn apply(&self) -> Result<AdvisorConfig, AdvisorError> {
+        let store = KeychainSecretStore;
+        apply_update_with_store(&store, self)
+    }
+}
+
+trait SecretStore {
+    fn read(&self, name: &'static str) -> Result<Option<String>, AdvisorError>;
+    fn write(&self, name: &'static str, value: &str) -> Result<(), AdvisorError>;
+}
+
+#[derive(Debug, Clone, Copy)]
+struct KeychainSecretStore;
+
+impl SecretStore for KeychainSecretStore {
+    fn read(&self, name: &'static str) -> Result<Option<String>, AdvisorError> {
+        let entry = Entry::new(SERVICE, name)?;
+        match entry.get_password() {
+            Ok(value) => Ok(Some(value)),
+            Err(keyring::Error::NoEntry) => Ok(None),
+            Err(error) => Err(error.into()),
+        }
+    }
+
+    fn write(&self, name: &'static str, value: &str) -> Result<(), AdvisorError> {
+        let entry = Entry::new(SERVICE, name)?;
+        entry.set_password(value)?;
+        Ok(())
+    }
+}
+
+fn apply_update_with_store(
+    store: &dyn SecretStore,
+    update: &AdvisorConfigUpdate,
+) -> Result<AdvisorConfig, AdvisorError> {
+    if let Some(provider) = update.calendar_provider {
+        store.write(CALENDAR_PROVIDER, provider.as_str())?;
+    }
+    if let Some(key) = update.calendar_api_key.as_deref() {
+        store_secret(store, CALENDAR_API_KEY, key, "calendar_api_key")?;
+    }
+    if let Some(key) = update.claude_api_key.as_deref() {
+        store_secret(store, CLAUDE_API_KEY, key, "claude_api_key")?;
+    }
+    read_with_store(store)
+}
+
+fn read_with_store(store: &dyn SecretStore) -> Result<AdvisorConfig, AdvisorError> {
+    let provider = match store.read(CALENDAR_PROVIDER)? {
+        Some(value) => CalendarProvider::from_str(&value)?,
+        None => CalendarProvider::None,
+    };
+    Ok(AdvisorConfig {
+        calendar_provider: provider,
+        calendar_api_key_configured: has_nonblank_secret(store, CALENDAR_API_KEY)?,
+        claude_api_key_configured: has_nonblank_secret(store, CLAUDE_API_KEY)?,
+    })
+}
+
+fn store_secret(
+    store: &dyn SecretStore,
+    name: &'static str,
+    value: &str,
+    field: &'static str,
+) -> Result<(), AdvisorError> {
+    let trimmed = value.trim();
+    if trimmed.is_empty() {
+        return Err(AdvisorError::BlankValue { field });
+    }
+    store.write(name, trimmed)
+}
+
+fn has_nonblank_secret(store: &dyn SecretStore, name: &'static str) -> Result<bool, AdvisorError> {
+    Ok(store
+        .read(name)?
+        .map(|value| !value.trim().is_empty())
+        .unwrap_or(false))
+}
+
+fn redacted_key_state(is_configured: bool) -> &'static str {
+    if is_configured {
+        "[REDACTED]"
+    } else {
+        "missing"
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::HashMap;
+    use std::sync::Mutex;
+
+    #[derive(Default)]
+    struct MemorySecretStore {
+        values: Mutex<HashMap<&'static str, String>>,
+    }
+
+    impl SecretStore for MemorySecretStore {
+        fn read(&self, name: &'static str) -> Result<Option<String>, AdvisorError> {
+            let values = self.values.lock().unwrap();
+            Ok(values.get(name).cloned())
+        }
+
+        fn write(&self, name: &'static str, value: &str) -> Result<(), AdvisorError> {
+            let mut values = self.values.lock().unwrap();
+            values.insert(name, value.to_string());
+            Ok(())
+        }
+    }
+
+    #[test]
+    fn calendar_provider_display_and_parse_roundtrip() {
+        for provider in [
+            CalendarProvider::Fmp,
+            CalendarProvider::Polygon,
+            CalendarProvider::None,
+        ] {
+            let parsed = CalendarProvider::from_str(provider.as_str()).unwrap();
+            assert_eq!(parsed, provider);
+            assert_eq!(provider.to_string(), provider.as_str());
+        }
+        assert_eq!(
+            CalendarProvider::from_str("FMP").unwrap(),
+            CalendarProvider::Fmp
+        );
+        assert_eq!(
+            CalendarProvider::from_str("polygon.io").unwrap(),
+            CalendarProvider::Polygon
+        );
+        assert!(CalendarProvider::from_str("unknown").is_err());
+    }
+
+    #[test]
+    fn advisor_config_update_stores_redacted_status() {
+        let store = MemorySecretStore::default();
+        let update = AdvisorConfigUpdate {
+            calendar_provider: Some(CalendarProvider::Polygon),
+            calendar_api_key: Some(" calendar-secret ".to_string()),
+            claude_api_key: Some("claude-secret".to_string()),
+        };
+
+        let config = apply_update_with_store(&store, &update).unwrap();
+
+        assert_eq!(config.calendar_provider, CalendarProvider::Polygon);
+        assert!(config.calendar_api_key_configured);
+        assert!(config.claude_api_key_configured);
+        assert_eq!(config.calendar_api_key_display(), "[REDACTED]");
+        assert_eq!(config.claude_api_key_display(), "[REDACTED]");
+        assert_eq!(
+            store.read(CALENDAR_API_KEY).unwrap(),
+            Some("calendar-secret".to_string())
+        );
+    }
+
+    #[test]
+    fn read_with_store_defaults_missing_values() {
+        let store = MemorySecretStore::default();
+
+        let config = read_with_store(&store).unwrap();
+
+        assert_eq!(config, AdvisorConfig::default());
+        assert_eq!(config.calendar_api_key_display(), "missing");
+        assert_eq!(config.claude_api_key_display(), "missing");
+    }
+
+    #[test]
+    fn update_rejects_blank_secrets_and_bad_provider_rows() {
+        let store = MemorySecretStore::default();
+        let update = AdvisorConfigUpdate {
+            calendar_api_key: Some(" \t ".to_string()),
+            ..AdvisorConfigUpdate::default()
+        };
+        assert!(apply_update_with_store(&store, &update)
+            .unwrap_err()
+            .to_string()
+            .contains("calendar_api_key"));
+
+        store.write(CALENDAR_PROVIDER, "bad-provider").unwrap();
+        assert!(read_with_store(&store)
+            .unwrap_err()
+            .to_string()
+            .contains("unsupported calendar provider"));
+    }
+}

--- a/advisor/src/correlation.rs
+++ b/advisor/src/correlation.rs
@@ -1,0 +1,54 @@
+use crate::AdvisorError;
+
+/// Request for future correlation analysis.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct CorrelationRequest {
+    /// Primary symbol under review.
+    pub symbol: String,
+    /// Symbols already represented in the account portfolio.
+    pub portfolio_symbols: Vec<String>,
+}
+
+/// Result returned by future correlation analysis.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CorrelationAdvisory {
+    /// Primary symbol under review.
+    pub symbol: String,
+    /// Advisory severity label.
+    pub level: String,
+    /// Human-readable explanation.
+    pub reason: String,
+}
+
+/// Stub correlation analyzer.
+#[derive(Debug, Clone, Default)]
+pub struct CorrelationAnalyzer;
+
+impl CorrelationAnalyzer {
+    /// Return a deliberate stub error until correlation analysis is implemented.
+    pub fn analyze(
+        &self,
+        _request: &CorrelationRequest,
+    ) -> Result<CorrelationAdvisory, AdvisorError> {
+        Err(AdvisorError::NotImplemented {
+            feature: "correlation",
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn correlation_analyzer_is_explicit_stub() {
+        let request = CorrelationRequest {
+            symbol: "AAPL".to_string(),
+            portfolio_symbols: vec!["MSFT".to_string()],
+        };
+
+        let error = CorrelationAnalyzer.analyze(&request).unwrap_err();
+
+        assert!(error.to_string().contains("correlation"));
+    }
+}

--- a/advisor/src/error.rs
+++ b/advisor/src/error.rs
@@ -1,0 +1,42 @@
+use thiserror::Error;
+
+/// Error type for advisor crate configuration and stub advisory features.
+#[derive(Debug, Error)]
+pub enum AdvisorError {
+    /// A required secret or configuration value was blank.
+    #[error("{field} cannot be blank")]
+    BlankValue {
+        /// Field name that failed validation.
+        field: &'static str,
+    },
+    /// A calendar provider string could not be parsed.
+    #[error("unsupported calendar provider '{value}'")]
+    InvalidCalendarProvider {
+        /// Raw provider value supplied by the caller.
+        value: String,
+    },
+    /// The system keychain could not be read or written.
+    #[error("advisor keychain error: {0}")]
+    Keychain(String),
+    /// HTTP client setup or execution failed.
+    #[error("advisor HTTP error: {0}")]
+    Http(String),
+    /// The requested advisor feature is intentionally not implemented yet.
+    #[error("{feature} advisory is not implemented yet")]
+    NotImplemented {
+        /// Stub feature name.
+        feature: &'static str,
+    },
+}
+
+impl From<keyring::Error> for AdvisorError {
+    fn from(value: keyring::Error) -> Self {
+        AdvisorError::Keychain(value.to_string())
+    }
+}
+
+impl From<reqwest::Error> for AdvisorError {
+    fn from(value: reqwest::Error) -> Self {
+        AdvisorError::Http(value.to_string())
+    }
+}

--- a/advisor/src/lib.rs
+++ b/advisor/src/lib.rs
@@ -1,0 +1,83 @@
+//! AI-powered advisory integration scaffolding for Trust.
+//!
+//! This crate owns external advisory configuration and future HTTP-backed
+//! advisory features. The catalyst, correlation, and regime modules are stubs
+//! until their issue-specific implementations land.
+
+#![deny(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::indexing_slicing,
+    clippy::panic,
+    clippy::float_arithmetic,
+    clippy::arithmetic_side_effects,
+    clippy::cast_precision_loss,
+    clippy::cast_possible_truncation,
+    clippy::cast_sign_loss,
+    clippy::cognitive_complexity,
+    clippy::too_many_lines
+)]
+#![cfg_attr(test, allow(clippy::unwrap_used, clippy::expect_used))]
+#![warn(missing_docs, rust_2018_idioms, missing_debug_implementations)]
+
+/// Catalyst-calendar advisory scaffolding.
+pub mod catalyst;
+/// Keychain-backed advisor configuration.
+pub mod config;
+/// Correlation advisory scaffolding.
+pub mod correlation;
+/// Advisor crate error types.
+pub mod error;
+/// Market-regime advisory scaffolding.
+pub mod regime;
+
+pub use config::{AdvisorConfig, AdvisorConfigUpdate, CalendarProvider};
+pub use error::AdvisorError;
+
+/// Entry point for future external advisory integrations.
+#[derive(Debug)]
+pub struct Advisor {
+    config: AdvisorConfig,
+    client: reqwest::blocking::Client,
+}
+
+impl Advisor {
+    /// Build an advisor client from an explicit redacted configuration status.
+    pub fn new(config: AdvisorConfig) -> Result<Self, AdvisorError> {
+        let client = reqwest::blocking::Client::builder().build()?;
+        Ok(Self { config, client })
+    }
+
+    /// Build an advisor client from keychain-backed configuration.
+    pub fn from_keychain() -> Result<Self, AdvisorError> {
+        Self::new(AdvisorConfig::read()?)
+    }
+
+    /// Return the redacted configuration currently attached to this advisor.
+    pub fn config(&self) -> &AdvisorConfig {
+        &self.config
+    }
+
+    /// Return the shared HTTP client for future advisory modules.
+    pub fn http_client(&self) -> &reqwest::blocking::Client {
+        &self.client
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn advisor_builds_from_explicit_config() {
+        let config = AdvisorConfig {
+            calendar_provider: CalendarProvider::Fmp,
+            calendar_api_key_configured: true,
+            claude_api_key_configured: false,
+        };
+
+        let advisor = Advisor::new(config.clone()).unwrap();
+
+        assert_eq!(advisor.config(), &config);
+    }
+}

--- a/advisor/src/regime.rs
+++ b/advisor/src/regime.rs
@@ -1,0 +1,46 @@
+use crate::AdvisorError;
+
+/// Request for future market-regime filtering.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct RegimeRequest {
+    /// Symbol or market index to evaluate.
+    pub symbol: String,
+}
+
+/// Result returned by future market-regime filtering.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RegimeAdvisory {
+    /// Symbol or market index that was evaluated.
+    pub symbol: String,
+    /// Regime label.
+    pub regime: String,
+    /// Human-readable explanation.
+    pub reason: String,
+}
+
+/// Stub market-regime filter.
+#[derive(Debug, Clone, Default)]
+pub struct RegimeFilter;
+
+impl RegimeFilter {
+    /// Return a deliberate stub error until regime filtering is implemented.
+    pub fn evaluate(&self, _request: &RegimeRequest) -> Result<RegimeAdvisory, AdvisorError> {
+        Err(AdvisorError::NotImplemented { feature: "regime" })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn regime_filter_is_explicit_stub() {
+        let request = RegimeRequest {
+            symbol: "SPY".to_string(),
+        };
+
+        let error = RegimeFilter.evaluate(&request).unwrap_err();
+
+        assert!(error.to_string().contains("regime"));
+    }
+}

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -22,6 +22,7 @@ alpaca-broker = { path = "../alpaca-broker", version = "0.3.2" }
 ibkr-broker = { path = "../ibkr-broker", version = "0.3.2" }
 db-sqlite = { path = "../db-sqlite", version = "0.3.2" }
 broker-sync = { path = "../broker-sync", version = "0.3.2" }
+advisor = { path = "../advisor", version = "0.3.2" }
 
 clap = {workspace = true}
 dialoguer = {workspace = true}

--- a/cli/src/commands/advisor_command.rs
+++ b/cli/src/commands/advisor_command.rs
@@ -1,4 +1,4 @@
-use clap::{Arg, Command};
+use clap::{Arg, ArgAction, Command};
 
 pub struct AdvisorCommandBuilder {
     command: Command,
@@ -22,35 +22,59 @@ impl AdvisorCommandBuilder {
     pub fn configure(mut self) -> Self {
         self.subcommands.push(
             Command::new("configure")
-                .about("Configure advisory thresholds for an account")
+                .about("Configure advisory thresholds or external advisor providers")
                 .arg(
                     Arg::new("account")
                         .long("account")
                         .value_name("ACCOUNT_ID")
-                        .required(true),
+                        .required(false),
                 )
                 .arg(
                     Arg::new("sector-limit")
                         .long("sector-limit")
                         .value_name("PERCENT")
-                        .required(true),
+                        .required(false),
                 )
                 .arg(
                     Arg::new("asset-class-limit")
                         .long("asset-class-limit")
                         .value_name("PERCENT")
-                        .required(true),
+                        .required(false),
                 )
                 .arg(
                     Arg::new("single-position-limit")
                         .long("single-position-limit")
                         .value_name("PERCENT")
-                        .required(true),
+                        .required(false),
                 )
                 .arg(
                     Arg::new("confirm-protected")
                         .long("confirm-protected")
                         .value_name("KEYWORD")
+                        .required(false),
+                )
+                .arg(
+                    Arg::new("calendar-provider")
+                        .long("calendar-provider")
+                        .value_name("PROVIDER")
+                        .required(false),
+                )
+                .arg(
+                    Arg::new("calendar-api-key")
+                        .long("calendar-api-key")
+                        .value_name("KEY")
+                        .required(false),
+                )
+                .arg(
+                    Arg::new("claude-api-key")
+                        .long("claude-api-key")
+                        .value_name("KEY")
+                        .required(false),
+                )
+                .arg(
+                    Arg::new("show")
+                        .long("show")
+                        .action(ArgAction::SetTrue)
                         .required(false),
                 ),
         );
@@ -104,7 +128,7 @@ mod tests {
     #[test]
     fn configure_parses() {
         let cmd = AdvisorCommandBuilder::new().configure().build();
-        let result = cmd.try_get_matches_from([
+        let thresholds = cmd.clone().try_get_matches_from([
             "advisor",
             "configure",
             "--account",
@@ -116,7 +140,18 @@ mod tests {
             "--single-position-limit",
             "15",
         ]);
-        assert!(result.is_ok());
+        assert!(thresholds.is_ok());
+
+        let provider = cmd.try_get_matches_from([
+            "advisor",
+            "configure",
+            "--calendar-provider",
+            "fmp",
+            "--calendar-api-key",
+            "secret",
+            "--show",
+        ]);
+        assert!(provider.is_ok());
     }
 
     #[test]

--- a/cli/src/dispatcher.rs
+++ b/cli/src/dispatcher.rs
@@ -30,6 +30,7 @@ use crate::dialogs::{
 use crate::dialogs::{RuleDialogBuilder, RuleRemoveDialogBuilder};
 use crate::protected_keyword;
 use crate::trading_vehicle_import;
+use advisor::{AdvisorConfig, AdvisorConfigUpdate, CalendarProvider};
 use alpaca_broker::AlpacaBroker;
 use chrono::{DateTime, Datelike, Days, NaiveDate, Utc};
 use clap::ArgMatches;
@@ -132,6 +133,59 @@ impl Display for CliError {
 }
 
 impl std::error::Error for CliError {}
+
+fn advisor_provider_config_requested(matches: &ArgMatches) -> bool {
+    bool_arg_present(matches, "show")
+        || string_arg_present(matches, "calendar-provider")
+        || string_arg_present(matches, "calendar-api-key")
+        || string_arg_present(matches, "claude-api-key")
+}
+
+fn advisor_threshold_config_requested(matches: &ArgMatches) -> bool {
+    string_arg_present(matches, "account")
+        || string_arg_present(matches, "sector-limit")
+        || string_arg_present(matches, "asset-class-limit")
+        || string_arg_present(matches, "single-position-limit")
+        || string_arg_present(matches, "confirm-protected")
+}
+
+fn string_arg_present(matches: &ArgMatches, key: &str) -> bool {
+    matches.try_get_one::<String>(key).ok().flatten().is_some()
+}
+
+fn bool_arg_present(matches: &ArgMatches, key: &str) -> bool {
+    matches
+        .try_get_one::<bool>(key)
+        .ok()
+        .flatten()
+        .copied()
+        .unwrap_or(false)
+}
+
+fn advisor_config_update_from_matches(
+    matches: &ArgMatches,
+) -> Result<AdvisorConfigUpdate, CliError> {
+    let calendar_provider = matches
+        .get_one::<String>("calendar-provider")
+        .map(|value| {
+            CalendarProvider::from_str(value)
+                .map_err(|e| CliError::new("invalid_calendar_provider", e.to_string()))
+        })
+        .transpose()?;
+
+    Ok(AdvisorConfigUpdate {
+        calendar_provider,
+        calendar_api_key: matches.get_one::<String>("calendar-api-key").cloned(),
+        claude_api_key: matches.get_one::<String>("claude-api-key").cloned(),
+    })
+}
+
+fn print_advisor_provider_config(config: &AdvisorConfig) {
+    println!("Advisor configuration:");
+    println!("Calendar provider: {}", config.calendar_provider);
+    println!("Calendar API key: {}", config.calendar_api_key_display());
+    println!("Claude API key: {}", config.claude_api_key_display());
+}
 
 pub struct ArgDispatcher {
     trust: TrustFacade,
@@ -7667,21 +7721,32 @@ impl ArgDispatcher {
     }
 
     fn advisor_configure(&mut self, sub_matches: &ArgMatches) -> Result<(), CliError> {
-        self.ensure_protected_keyword(sub_matches, ReportOutputFormat::Text, "advisor configure")?;
-        let account_id = Uuid::parse_str(sub_matches.get_one::<String>("account").unwrap())
-            .map_err(|_| CliError::new("invalid_uuid", "Invalid --account UUID"))?;
+        let provider_mode = advisor_provider_config_requested(sub_matches);
+        let threshold_mode = advisor_threshold_config_requested(sub_matches);
+        if provider_mode && threshold_mode {
+            return Err(CliError::new(
+                "advisor_configure_mode_conflict",
+                "Advisor provider keys and concentration thresholds must be configured separately",
+            ));
+        }
+        if provider_mode {
+            return Self::advisor_provider_configure(sub_matches);
+        }
+        self.advisor_thresholds_configure(sub_matches)
+    }
+
+    fn advisor_thresholds_configure(&mut self, sub_matches: &ArgMatches) -> Result<(), CliError> {
+        let account_id = Self::parse_uuid_arg(sub_matches, "account", ReportOutputFormat::Text)?;
         let sector_limit =
-            Decimal::from_str_exact(sub_matches.get_one::<String>("sector-limit").unwrap())
-                .map_err(|_| CliError::new("invalid_decimal", "Invalid --sector-limit"))?;
+            Self::parse_decimal_arg(sub_matches, "sector-limit", ReportOutputFormat::Text)?;
         let asset_class_limit =
-            Decimal::from_str_exact(sub_matches.get_one::<String>("asset-class-limit").unwrap())
-                .map_err(|_| CliError::new("invalid_decimal", "Invalid --asset-class-limit"))?;
-        let single_position_limit = Decimal::from_str_exact(
-            sub_matches
-                .get_one::<String>("single-position-limit")
-                .unwrap(),
-        )
-        .map_err(|_| CliError::new("invalid_decimal", "Invalid --single-position-limit"))?;
+            Self::parse_decimal_arg(sub_matches, "asset-class-limit", ReportOutputFormat::Text)?;
+        let single_position_limit = Self::parse_decimal_arg(
+            sub_matches,
+            "single-position-limit",
+            ReportOutputFormat::Text,
+        )?;
+        self.ensure_protected_keyword(sub_matches, ReportOutputFormat::Text, "advisor configure")?;
 
         self.trust
             .configure_advisory_thresholds(
@@ -7694,6 +7759,26 @@ impl ArgDispatcher {
             )
             .map_err(|e| CliError::new("advisor_configure_failed", e.to_string()))?;
         println!("Advisor thresholds configured for account {account_id}");
+        Ok(())
+    }
+
+    fn advisor_provider_configure(sub_matches: &ArgMatches) -> Result<(), CliError> {
+        let update = advisor_config_update_from_matches(sub_matches)?;
+        if !update.is_empty() {
+            update
+                .apply()
+                .map_err(|e| CliError::new("advisor_configure_failed", e.to_string()))?;
+        }
+        if sub_matches.get_flag("show") || update.is_empty() {
+            let config = AdvisorConfig::read()
+                .map_err(|e| CliError::new("advisor_configure_failed", e.to_string()))?;
+            print_advisor_provider_config(&config);
+        } else {
+            let config = AdvisorConfig::read()
+                .map_err(|e| CliError::new("advisor_configure_failed", e.to_string()))?;
+            println!("Advisor provider configuration updated.");
+            print_advisor_provider_config(&config);
+        }
         Ok(())
     }
 
@@ -8466,6 +8551,14 @@ mod tests {
             .arg(Arg::new("sector-limit").long("sector-limit"))
             .arg(Arg::new("asset-class-limit").long("asset-class-limit"))
             .arg(Arg::new("single-position-limit").long("single-position-limit"))
+            .arg(Arg::new("calendar-provider").long("calendar-provider"))
+            .arg(Arg::new("calendar-api-key").long("calendar-api-key"))
+            .arg(Arg::new("claude-api-key").long("claude-api-key"))
+            .arg(
+                Arg::new("show")
+                    .long("show")
+                    .action(clap::ArgAction::SetTrue),
+            )
             .get_matches_from(argv)
     }
 
@@ -13548,6 +13641,31 @@ mod tests {
             .advisor_configure(&bad_decimal)
             .expect_err("invalid decimal should fail");
         assert!(error.to_string().contains("invalid_decimal"));
+
+        let bad_provider = advisor_configure_matches(&["--calendar-provider", "bad"]);
+        let error = dispatcher
+            .advisor_configure(&bad_provider)
+            .expect_err("invalid provider should fail");
+        assert!(error.to_string().contains("invalid_calendar_provider"));
+
+        let mixed_modes = advisor_configure_matches(&[
+            "--calendar-api-key",
+            "secret",
+            "--account",
+            &account.id.to_string(),
+            "--sector-limit",
+            "40",
+            "--asset-class-limit",
+            "40",
+            "--single-position-limit",
+            "25",
+        ]);
+        let error = dispatcher
+            .advisor_configure(&mixed_modes)
+            .expect_err("mixed config modes should fail");
+        assert!(error
+            .to_string()
+            .contains("advisor_configure_mode_conflict"));
 
         let check_bad_decimal = advisor_check_matches(&[
             "--account",

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -21,6 +21,7 @@ tracing = {workspace = true}
 argon2 = {workspace = true}
 password-hash = {workspace = true}
 rand_core = {workspace = true}
+advisor = { path = "../advisor", version = "0.3.2", optional = true }
 
 [dev-dependencies]
 db-sqlite = { path = "../db-sqlite", version = "0.3.2" }

--- a/ibkr-broker/Cargo.toml
+++ b/ibkr-broker/Cargo.toml
@@ -9,7 +9,7 @@ model = { package = "trust-model", path = "../model", version = "0.3.2" }
 chrono = { workspace = true }
 rust_decimal = { workspace = true }
 serde_json = { workspace = true }
-reqwest = { version = "0.12.24", default-features = false, features = ["blocking", "cookies", "json", "native-tls"] }
+reqwest = { workspace = true }
 keyring = { workspace = true }
 
 [dev-dependencies]


### PR DESCRIPTION
## Summary
- add a new `advisor` workspace crate with strict financial lints, keychain-backed configuration, redacted status reporting, and stub catalyst/correlation/regime modules
- wire `advisor` into the workspace, CLI, and optional core dependency surface
- extend `trust advisor configure` with provider-key mode for `--calendar-api-key`, `--claude-api-key`, `--calendar-provider`, and `--show` while preserving existing concentration-threshold configuration

Closes #109

## Verification
- cargo test -p advisor
- cargo test -p trust-cli advisor -- --test-threads=1
- cargo build
- make ci-fast
- cargo test --locked --all-features --workspace
- cargo test --locked --no-default-features --workspace

## Notes
- Provider keys are stored under the `trust-advisor` keychain service as `calendar_api_key`, `claude_api_key`, and `calendar_provider`.
- Stub modules intentionally return `AdvisorError::NotImplemented` until the follow-up feature issues implement the actual advisory logic.