### PR TITLE
feat(advisor): add catalyst calendar scan

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12,10 +12,13 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 name = "advisor"
 version = "0.3.5"
 dependencies = [
+ "chrono",
  "keyring",
  "reqwest",
+ "serde_json",
  "thiserror 1.0.69",
  "trust-model",
+ "uuid",
 ]
 
 [[package]]

--- a/advisor/Cargo.toml
+++ b/advisor/Cargo.toml
@@ -6,6 +6,9 @@ license = "GPL-3.0-only"
 
 [dependencies]
 model = { package = "trust-model", path = "../model", version = "0.3.2" }
+chrono = { workspace = true }
 keyring = { workspace = true }
 reqwest = { workspace = true }
+serde_json = { workspace = true }
 thiserror = { workspace = true }
+uuid = { workspace = true }

--- a/advisor/src/catalyst.rs
+++ b/advisor/src/catalyst.rs
@@ -1,48 +1,746 @@
+use crate::config::{CalendarCredentials, CalendarProvider};
 use crate::AdvisorError;
+use chrono::{NaiveDate, Utc};
+use model::{TradeEvent, TradeEventSeverity, TradeEventSource, TradeEventType, WriteTradeEventDB};
+use reqwest::blocking::Client;
+use reqwest::Url;
+use serde_json::Value;
+use uuid::Uuid;
 
-/// Request for future calendar catalyst scanning.
-#[derive(Debug, Clone, Default, PartialEq, Eq)]
-pub struct CatalystScanRequest {
-    /// Symbols to scan for upcoming events.
-    pub symbols: Vec<String>,
-}
+const FMP_BASE_URL: &str = "https://financialmodelingprep.com";
+const POLYGON_BASE_URL: &str = "https://api.polygon.io";
 
-/// Calendar event returned by future catalyst scanning.
+/// Request for calendar-backed catalyst scanning.
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub struct CatalystEvent {
-    /// Event symbol.
+pub struct CatalystScanRequest {
+    /// Trade that owns the persisted catalyst events.
+    pub trade_id: Uuid,
+    /// Symbol to scan for calendar events.
     pub symbol: String,
-    /// Human-readable event type.
-    pub event_type: String,
-    /// Human-readable event date or timestamp.
-    pub event_time: String,
+    /// Inclusive start date for the expected hold window.
+    pub start_date: NaiveDate,
+    /// Inclusive end date for the expected hold window.
+    pub end_date: NaiveDate,
 }
 
-/// Stub catalyst scanner.
-#[derive(Debug, Clone, Default)]
-pub struct CatalystScanner;
+impl CatalystScanRequest {
+    /// Build a catalyst scan request.
+    pub fn new(
+        trade_id: Uuid,
+        symbol: impl Into<String>,
+        start_date: NaiveDate,
+        end_date: NaiveDate,
+    ) -> Self {
+        Self {
+            trade_id,
+            symbol: symbol.into(),
+            start_date,
+            end_date,
+        }
+    }
+}
+
+/// Calendar catalyst scan output.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct CatalystScanResult {
+    /// Events returned by the calendar API and persisted to storage.
+    pub events: Vec<TradeEvent>,
+    /// Non-fatal warning explaining why scanning was skipped.
+    pub warning: Option<String>,
+}
+
+impl CatalystScanResult {
+    fn skipped(warning: impl Into<String>) -> Self {
+        Self {
+            events: Vec::new(),
+            warning: Some(warning.into()),
+        }
+    }
+}
+
+/// Calendar API-backed catalyst scanner.
+#[derive(Debug, Clone)]
+pub struct CatalystScanner {
+    credentials: CalendarCredentials,
+    client: Client,
+    endpoints: CalendarApiEndpoints,
+}
 
 impl CatalystScanner {
-    /// Return a deliberate stub error until catalyst scanning is implemented.
-    pub fn scan(&self, _request: &CatalystScanRequest) -> Result<Vec<CatalystEvent>, AdvisorError> {
-        Err(AdvisorError::NotImplemented {
-            feature: "catalyst",
+    /// Build a scanner from explicit calendar credentials.
+    pub fn new(credentials: CalendarCredentials) -> Self {
+        Self::with_client(credentials, Client::new())
+    }
+
+    /// Build a scanner from explicit calendar credentials and an HTTP client.
+    pub fn with_client(credentials: CalendarCredentials, client: Client) -> Self {
+        Self {
+            credentials,
+            client,
+            endpoints: CalendarApiEndpoints::default(),
+        }
+    }
+
+    /// Build a scanner from keychain-backed advisor configuration.
+    pub fn from_keychain() -> Result<Self, AdvisorError> {
+        Ok(Self::new(CalendarCredentials::read()?))
+    }
+
+    /// Fetch, classify, and persist catalyst events for a trade.
+    pub fn scan(
+        &self,
+        request: &CatalystScanRequest,
+        writer: &mut dyn WriteTradeEventDB,
+    ) -> Result<CatalystScanResult, AdvisorError> {
+        validate_request(request)?;
+        if let Some(warning) = self.skip_warning() {
+            return Ok(CatalystScanResult::skipped(warning));
+        }
+
+        let symbol = normalized_symbol(&request.symbol)?;
+        let candidates = self.fetch_candidates(&symbol)?;
+        let mut events = Vec::new();
+        for candidate in candidates {
+            if is_relevant_candidate(&candidate, request, &symbol) {
+                let event = candidate.into_trade_event(request.trade_id, &symbol);
+                let created = writer
+                    .create_trade_event(&event)
+                    .map_err(|error| AdvisorError::Persistence(error.to_string()))?;
+                events.push(created);
+            }
+        }
+        Ok(CatalystScanResult {
+            events,
+            warning: None,
         })
     }
+
+    #[cfg(test)]
+    fn with_endpoints(
+        credentials: CalendarCredentials,
+        client: Client,
+        endpoints: CalendarApiEndpoints,
+    ) -> Self {
+        Self {
+            credentials,
+            client,
+            endpoints,
+        }
+    }
+
+    fn skip_warning(&self) -> Option<String> {
+        match self.credentials.provider() {
+            CalendarProvider::None => {
+                Some("calendar provider disabled; catalyst scan skipped".into())
+            }
+            _ if !self.credentials.has_api_key() => {
+                Some("calendar API key missing; catalyst scan skipped".into())
+            }
+            _ => None,
+        }
+    }
+
+    fn fetch_candidates(&self, symbol: &str) -> Result<Vec<CalendarEventCandidate>, AdvisorError> {
+        let api_key = self
+            .credentials
+            .api_key()
+            .ok_or_else(|| AdvisorError::CalendarResponse {
+                message: "calendar API key missing after configuration check".to_string(),
+            })?;
+        let requests = self.calendar_requests(symbol, api_key)?;
+        let mut candidates = Vec::new();
+        for request in requests {
+            let body = self.get_json(request.url)?;
+            candidates.extend(decode_calendar_response(&body, request.kind, symbol)?);
+        }
+        Ok(candidates)
+    }
+
+    fn calendar_requests(
+        &self,
+        symbol: &str,
+        api_key: &str,
+    ) -> Result<Vec<CalendarApiRequest>, AdvisorError> {
+        match self.credentials.provider() {
+            CalendarProvider::Fmp => Ok(vec![
+                CalendarApiRequest::new(
+                    CalendarEndpointKind::FmpEarnings,
+                    build_calendar_url(
+                        &self.endpoints.fmp_base_url,
+                        "api/v3/earning_calendar",
+                        &[("symbol", symbol), ("apikey", api_key)],
+                    )?,
+                ),
+                CalendarApiRequest::new(
+                    CalendarEndpointKind::FmpDividends,
+                    build_calendar_url(
+                        &self.endpoints.fmp_base_url,
+                        "api/v3/stock_dividend_calendar",
+                        &[("symbol", symbol), ("apikey", api_key)],
+                    )?,
+                ),
+            ]),
+            CalendarProvider::Polygon => Ok(vec![CalendarApiRequest::new(
+                CalendarEndpointKind::PolygonEvents,
+                build_calendar_url(
+                    &self.endpoints.polygon_base_url,
+                    &format!("v3/reference/tickers/{symbol}/events"),
+                    &[("apiKey", api_key)],
+                )?,
+            )]),
+            CalendarProvider::None => Ok(Vec::new()),
+        }
+    }
+
+    fn get_json(&self, url: Url) -> Result<Value, AdvisorError> {
+        let response = self.client.get(url).send()?;
+        let status = response.status();
+        if !status.is_success() {
+            return Err(AdvisorError::Http(format!(
+                "calendar API returned status {status}"
+            )));
+        }
+        Ok(response.json::<Value>()?)
+    }
+}
+
+impl Default for CatalystScanner {
+    fn default() -> Self {
+        Self::new(CalendarCredentials::default())
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct CalendarApiEndpoints {
+    fmp_base_url: String,
+    polygon_base_url: String,
+}
+
+impl Default for CalendarApiEndpoints {
+    fn default() -> Self {
+        Self {
+            fmp_base_url: FMP_BASE_URL.to_string(),
+            polygon_base_url: POLYGON_BASE_URL.to_string(),
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+struct CalendarApiRequest {
+    kind: CalendarEndpointKind,
+    url: Url,
+}
+
+impl CalendarApiRequest {
+    fn new(kind: CalendarEndpointKind, url: Url) -> Self {
+        Self { kind, url }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum CalendarEndpointKind {
+    FmpEarnings,
+    FmpDividends,
+    PolygonEvents,
+}
+
+impl CalendarEndpointKind {
+    fn default_event_type(self) -> TradeEventType {
+        match self {
+            CalendarEndpointKind::FmpEarnings => TradeEventType::Earnings,
+            CalendarEndpointKind::FmpDividends => TradeEventType::ExDividend,
+            CalendarEndpointKind::PolygonEvents => TradeEventType::Other,
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct CalendarEventCandidate {
+    symbol: Option<String>,
+    event_type: TradeEventType,
+    event_date: NaiveDate,
+    severity: TradeEventSeverity,
+    notes: Option<String>,
+}
+
+impl CalendarEventCandidate {
+    fn into_trade_event(self, trade_id: Uuid, symbol: &str) -> TradeEvent {
+        let now = Utc::now().naive_utc();
+        TradeEvent {
+            id: Uuid::new_v4(),
+            created_at: now,
+            updated_at: now,
+            deleted_at: None,
+            trade_id,
+            symbol: symbol.to_string(),
+            event_type: self.event_type,
+            event_date: self.event_date,
+            severity: self.severity,
+            notes: self.notes,
+            source: TradeEventSource::CalendarApi,
+        }
+    }
+}
+
+fn validate_request(request: &CatalystScanRequest) -> Result<(), AdvisorError> {
+    normalized_symbol(&request.symbol)?;
+    if request.end_date < request.start_date {
+        return Err(AdvisorError::InvalidDateWindow {
+            start_date: request.start_date,
+            end_date: request.end_date,
+        });
+    }
+    Ok(())
+}
+
+fn normalized_symbol(symbol: &str) -> Result<String, AdvisorError> {
+    let trimmed = symbol.trim();
+    if trimmed.is_empty() {
+        return Err(AdvisorError::BlankValue { field: "symbol" });
+    }
+    Ok(trimmed.to_ascii_uppercase())
+}
+
+fn build_calendar_url(
+    base_url: &str,
+    path: &str,
+    params: &[(&str, &str)],
+) -> Result<Url, AdvisorError> {
+    let mut url = Url::parse(base_url).map_err(|error| AdvisorError::Http(error.to_string()))?;
+    url.set_path(path);
+    url.query_pairs_mut()
+        .clear()
+        .extend_pairs(params.iter().copied());
+    Ok(url)
+}
+
+fn decode_calendar_response(
+    value: &Value,
+    kind: CalendarEndpointKind,
+    request_symbol: &str,
+) -> Result<Vec<CalendarEventCandidate>, AdvisorError> {
+    let items = calendar_items(value)?;
+    let mut candidates = Vec::new();
+    for item in items {
+        if let Some(candidate) = candidate_from_item(item, kind, request_symbol) {
+            candidates.push(candidate);
+        }
+    }
+    Ok(candidates)
+}
+
+fn calendar_items(value: &Value) -> Result<Vec<&Value>, AdvisorError> {
+    if let Some(items) = value.as_array() {
+        return Ok(items.iter().collect());
+    }
+    for field in ["results", "events", "data", "historical"] {
+        if let Some(items) = value.get(field).and_then(Value::as_array) {
+            return Ok(items.iter().collect());
+        }
+    }
+    Err(AdvisorError::CalendarResponse {
+        message: "expected a calendar event array".to_string(),
+    })
+}
+
+fn candidate_from_item(
+    item: &Value,
+    kind: CalendarEndpointKind,
+    request_symbol: &str,
+) -> Option<CalendarEventCandidate> {
+    let event_date = parse_event_date(item)?;
+    let label = event_label(item);
+    let event_type = classify_event_type(kind.default_event_type(), label.as_deref());
+    Some(CalendarEventCandidate {
+        symbol: extract_symbol(item).or_else(|| Some(request_symbol.to_string())),
+        event_type,
+        event_date,
+        severity: severity_for(event_type),
+        notes: event_notes(kind, label.as_deref()),
+    })
+}
+
+fn parse_event_date(item: &Value) -> Option<NaiveDate> {
+    for field in [
+        "date",
+        "event_date",
+        "eventDate",
+        "start_date",
+        "startDate",
+        "exDate",
+        "ex_dividend_date",
+    ] {
+        if let Some(value) = string_field(item, field).and_then(|date| parse_date_text(&date)) {
+            return Some(value);
+        }
+    }
+    None
+}
+
+fn parse_date_text(value: &str) -> Option<NaiveDate> {
+    let trimmed = value.trim();
+    NaiveDate::parse_from_str(trimmed, "%Y-%m-%d")
+        .ok()
+        .or_else(|| {
+            trimmed
+                .split('T')
+                .next()
+                .and_then(|date| NaiveDate::parse_from_str(date, "%Y-%m-%d").ok())
+        })
+}
+
+fn event_label(item: &Value) -> Option<String> {
+    let mut parts = Vec::new();
+    for field in [
+        "event_type",
+        "eventType",
+        "type",
+        "event",
+        "title",
+        "name",
+        "description",
+    ] {
+        if let Some(value) = string_field(item, field) {
+            parts.push(value);
+        }
+    }
+    if parts.is_empty() {
+        None
+    } else {
+        Some(parts.join(" "))
+    }
+}
+
+fn extract_symbol(item: &Value) -> Option<String> {
+    for field in ["symbol", "ticker", "ticker_symbol"] {
+        if let Some(value) = string_field(item, field) {
+            return Some(value.to_ascii_uppercase());
+        }
+    }
+    None
+}
+
+fn string_field(item: &Value, field: &str) -> Option<String> {
+    item.get(field).and_then(Value::as_str).and_then(|value| {
+        let trimmed = value.trim();
+        if trimmed.is_empty() {
+            None
+        } else {
+            Some(trimmed.to_string())
+        }
+    })
+}
+
+fn classify_event_type(default_type: TradeEventType, label: Option<&str>) -> TradeEventType {
+    let Some(text) = label else {
+        return default_type;
+    };
+    let lower = text.to_ascii_lowercase();
+    if text_matches_earnings(&lower) {
+        TradeEventType::Earnings
+    } else if text_matches_fed(&lower) {
+        TradeEventType::Fed
+    } else if text_matches_cpi(&lower) {
+        TradeEventType::Cpi
+    } else if text_matches_nfp(&lower) {
+        TradeEventType::Nfp
+    } else if text_matches_ex_dividend(&lower) {
+        TradeEventType::ExDividend
+    } else if text_matches_guidance(&lower) {
+        TradeEventType::Guidance
+    } else {
+        default_type
+    }
+}
+
+fn text_matches_earnings(text: &str) -> bool {
+    text.contains("earnings") || text.contains("earning report")
+}
+
+fn text_matches_fed(text: &str) -> bool {
+    text.contains("fomc")
+        || text.contains("federal reserve")
+        || text.contains("fed decision")
+        || text.contains("fed minutes")
+}
+
+fn text_matches_cpi(text: &str) -> bool {
+    text.contains("consumer price index") || text_has_token(text, "cpi")
+}
+
+fn text_matches_nfp(text: &str) -> bool {
+    text.contains("nonfarm")
+        || text.contains("non-farm")
+        || text.contains("payroll")
+        || text_has_token(text, "nfp")
+}
+
+fn text_matches_ex_dividend(text: &str) -> bool {
+    text.contains("ex-dividend") || text.contains("ex dividend") || text.contains("dividend")
+}
+
+fn text_matches_guidance(text: &str) -> bool {
+    text.contains("guidance") || text.contains("forecast") || text.contains("outlook")
+}
+
+fn text_has_token(text: &str, token: &str) -> bool {
+    text.split(|character: char| !character.is_ascii_alphanumeric())
+        .any(|part| part == token)
+}
+
+fn severity_for(event_type: TradeEventType) -> TradeEventSeverity {
+    match event_type {
+        TradeEventType::Earnings
+        | TradeEventType::Fed
+        | TradeEventType::Cpi
+        | TradeEventType::Nfp => TradeEventSeverity::High,
+        TradeEventType::ExDividend => TradeEventSeverity::Low,
+        TradeEventType::Guidance | TradeEventType::Other => TradeEventSeverity::Medium,
+    }
+}
+
+fn event_notes(kind: CalendarEndpointKind, label: Option<&str>) -> Option<String> {
+    let provider = match kind {
+        CalendarEndpointKind::FmpEarnings | CalendarEndpointKind::FmpDividends => "FMP",
+        CalendarEndpointKind::PolygonEvents => "Polygon",
+    };
+    let prefix = format!("{provider} calendar API");
+    label.map_or(Some(prefix.clone()), |value| {
+        Some(format!("{prefix}: {value}"))
+    })
+}
+
+fn is_relevant_candidate(
+    candidate: &CalendarEventCandidate,
+    request: &CatalystScanRequest,
+    normalized_symbol: &str,
+) -> bool {
+    let in_window =
+        candidate.event_date >= request.start_date && candidate.event_date <= request.end_date;
+    let symbol_matches = candidate
+        .symbol
+        .as_deref()
+        .map(|symbol| symbol.eq_ignore_ascii_case(normalized_symbol))
+        .unwrap_or(true);
+    in_window && symbol_matches
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use chrono::NaiveDate;
+    use model::WriteTradeEventDB;
+    use std::error::Error;
+    use std::io::{BufRead, BufReader, Write};
+    use std::net::{Ipv4Addr, TcpListener, TcpStream};
+    use std::thread::{self, JoinHandle};
+
+    #[derive(Debug, Default)]
+    struct MemoryTradeEventWriter {
+        events: Vec<TradeEvent>,
+    }
+
+    impl WriteTradeEventDB for MemoryTradeEventWriter {
+        fn create_trade_event(&mut self, event: &TradeEvent) -> Result<TradeEvent, Box<dyn Error>> {
+            self.events.push(event.clone());
+            Ok(event.clone())
+        }
+
+        fn delete_trade_event(&mut self, _event_id: Uuid) -> Result<(), Box<dyn Error>> {
+            Ok(())
+        }
+    }
+
+    struct MockCalendarServer {
+        base_url: String,
+        handle: JoinHandle<()>,
+    }
+
+    impl MockCalendarServer {
+        fn start(routes: Vec<(&'static str, &'static str)>) -> Self {
+            let listener = TcpListener::bind((Ipv4Addr::LOCALHOST, 0)).unwrap();
+            let base_url = format!("http://{}", listener.local_addr().unwrap());
+            let handle = thread::spawn(move || serve_routes(listener, routes));
+            Self { base_url, handle }
+        }
+
+        fn base_url(&self) -> &str {
+            &self.base_url
+        }
+
+        fn join(self) {
+            self.handle.join().unwrap();
+        }
+    }
+
+    fn serve_routes(listener: TcpListener, routes: Vec<(&'static str, &'static str)>) {
+        for _route in &routes {
+            let (stream, _) = listener.accept().unwrap();
+            serve_request(stream, &routes);
+        }
+    }
+
+    fn serve_request(mut stream: TcpStream, routes: &[(&'static str, &'static str)]) {
+        let mut request_line = String::new();
+        let mut reader = BufReader::new(stream.try_clone().unwrap());
+        reader.read_line(&mut request_line).unwrap();
+        let path = request_line.split_whitespace().nth(1).unwrap();
+        let body = routes
+            .iter()
+            .find(|(route_path, _body)| path.starts_with(route_path))
+            .map(|(_route_path, body)| *body)
+            .unwrap();
+        write!(
+            stream,
+            "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\n\r\n{}",
+            body.len(),
+            body
+        )
+        .unwrap();
+    }
+
+    fn date(year: i32, month: u32, day: u32) -> NaiveDate {
+        NaiveDate::from_ymd_opt(year, month, day).unwrap()
+    }
+
+    fn request() -> CatalystScanRequest {
+        CatalystScanRequest::new(Uuid::new_v4(), "aapl", date(2026, 5, 1), date(2026, 5, 31))
+    }
 
     #[test]
-    fn catalyst_scanner_is_explicit_stub() {
-        let request = CatalystScanRequest {
-            symbols: vec!["AAPL".to_string()],
-        };
+    fn missing_calendar_api_key_skips_with_warning() {
+        let scanner = CatalystScanner::new(CalendarCredentials::new(CalendarProvider::Fmp, None));
+        let mut writer = MemoryTradeEventWriter::default();
 
-        let error = CatalystScanner.scan(&request).unwrap_err();
+        let result = scanner.scan(&request(), &mut writer).unwrap();
 
-        assert!(error.to_string().contains("catalyst"));
+        assert!(result.events.is_empty());
+        assert!(writer.events.is_empty());
+        assert_eq!(
+            result.warning,
+            Some("calendar API key missing; catalyst scan skipped".to_string())
+        );
+    }
+
+    #[test]
+    fn classification_matches_risk_table() {
+        let cases = [
+            (
+                "earnings",
+                TradeEventType::Earnings,
+                TradeEventSeverity::High,
+            ),
+            (
+                "FOMC fed decision",
+                TradeEventType::Fed,
+                TradeEventSeverity::High,
+            ),
+            ("CPI release", TradeEventType::Cpi, TradeEventSeverity::High),
+            (
+                "NFP payrolls",
+                TradeEventType::Nfp,
+                TradeEventSeverity::High,
+            ),
+            (
+                "ex-dividend date",
+                TradeEventType::ExDividend,
+                TradeEventSeverity::Low,
+            ),
+            (
+                "guidance revision",
+                TradeEventType::Guidance,
+                TradeEventSeverity::Medium,
+            ),
+        ];
+
+        for (label, event_type, severity) in cases {
+            let classified = classify_event_type(TradeEventType::Other, Some(label));
+            assert_eq!(classified, event_type);
+            assert_eq!(severity_for(classified), severity);
+        }
+    }
+
+    #[test]
+    fn fmp_scan_persists_windowed_events_from_mock_http() {
+        let server = MockCalendarServer::start(vec![
+            (
+                "/api/v3/earning_calendar",
+                r#"[{"date":"2026-05-14","symbol":"AAPL"},{"date":"2026-06-01","symbol":"AAPL"}]"#,
+            ),
+            (
+                "/api/v3/stock_dividend_calendar",
+                r#"[{"date":"2026-05-20","symbol":"AAPL","label":"ex-dividend"}]"#,
+            ),
+        ]);
+        let credentials =
+            CalendarCredentials::new(CalendarProvider::Fmp, Some("test-key".to_string()));
+        let scanner = CatalystScanner::with_endpoints(
+            credentials,
+            Client::new(),
+            CalendarApiEndpoints {
+                fmp_base_url: server.base_url().to_string(),
+                polygon_base_url: POLYGON_BASE_URL.to_string(),
+            },
+        );
+        let mut writer = MemoryTradeEventWriter::default();
+
+        let result = scanner.scan(&request(), &mut writer).unwrap();
+        server.join();
+
+        assert_eq!(result.warning, None);
+        assert_eq!(result.events.len(), 2);
+        assert_eq!(writer.events, result.events);
+        assert_eq!(
+            result.events.first().unwrap().event_type,
+            TradeEventType::Earnings
+        );
+        assert_eq!(
+            result.events.first().unwrap().severity,
+            TradeEventSeverity::High
+        );
+        assert_eq!(
+            result.events.get(1).unwrap().event_type,
+            TradeEventType::ExDividend
+        );
+        assert_eq!(
+            result.events.get(1).unwrap().severity,
+            TradeEventSeverity::Low
+        );
+        assert!(result
+            .events
+            .iter()
+            .all(|event| event.source == TradeEventSource::CalendarApi));
+    }
+
+    #[test]
+    fn polygon_scan_reads_results_array() {
+        let server = MockCalendarServer::start(vec![(
+            "/v3/reference/tickers/AAPL/events",
+            r#"{"results":[{"event_date":"2026-05-22","ticker":"AAPL","type":"guidance revision"}]}"#,
+        )]);
+        let credentials =
+            CalendarCredentials::new(CalendarProvider::Polygon, Some("test-key".to_string()));
+        let scanner = CatalystScanner::with_endpoints(
+            credentials,
+            Client::new(),
+            CalendarApiEndpoints {
+                fmp_base_url: FMP_BASE_URL.to_string(),
+                polygon_base_url: server.base_url().to_string(),
+            },
+        );
+        let mut writer = MemoryTradeEventWriter::default();
+
+        let result = scanner.scan(&request(), &mut writer).unwrap();
+        server.join();
+
+        assert_eq!(result.events.len(), 1);
+        assert_eq!(
+            result.events.first().unwrap().event_type,
+            TradeEventType::Guidance
+        );
+        assert_eq!(
+            result.events.first().unwrap().severity,
+            TradeEventSeverity::Medium
+        );
     }
 }

--- a/advisor/src/config.rs
+++ b/advisor/src/config.rs
@@ -91,6 +91,71 @@ impl Default for AdvisorConfig {
     }
 }
 
+/// Calendar provider credentials used by HTTP-backed catalyst scans.
+#[derive(Clone, PartialEq, Eq)]
+pub struct CalendarCredentials {
+    /// Configured calendar provider.
+    provider: CalendarProvider,
+    api_key: Option<String>,
+}
+
+impl CalendarCredentials {
+    /// Build explicit calendar credentials.
+    pub fn new(provider: CalendarProvider, api_key: Option<String>) -> Self {
+        let normalized_key = api_key.and_then(|value| {
+            let trimmed = value.trim();
+            if trimmed.is_empty() {
+                None
+            } else {
+                Some(trimmed.to_string())
+            }
+        });
+        Self {
+            provider,
+            api_key: normalized_key,
+        }
+    }
+
+    /// Read calendar credentials from the system keychain.
+    pub fn read() -> Result<Self, AdvisorError> {
+        let store = KeychainSecretStore;
+        read_calendar_credentials_with_store(&store)
+    }
+
+    /// Configured calendar provider.
+    pub fn provider(&self) -> CalendarProvider {
+        self.provider
+    }
+
+    /// Calendar API key, if one is configured.
+    pub fn api_key(&self) -> Option<&str> {
+        self.api_key.as_deref()
+    }
+
+    /// Returns true when a nonblank calendar API key is available.
+    pub fn has_api_key(&self) -> bool {
+        self.api_key().is_some()
+    }
+}
+
+impl Default for CalendarCredentials {
+    fn default() -> Self {
+        Self {
+            provider: CalendarProvider::None,
+            api_key: None,
+        }
+    }
+}
+
+impl fmt::Debug for CalendarCredentials {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        f.debug_struct("CalendarCredentials")
+            .field("provider", &self.provider)
+            .field("api_key_configured", &self.has_api_key())
+            .finish()
+    }
+}
+
 /// Partial advisor configuration update.
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub struct AdvisorConfigUpdate {
@@ -159,15 +224,25 @@ fn apply_update_with_store(
 }
 
 fn read_with_store(store: &dyn SecretStore) -> Result<AdvisorConfig, AdvisorError> {
+    let credentials = read_calendar_credentials_with_store(store)?;
+    Ok(AdvisorConfig {
+        calendar_provider: credentials.provider(),
+        calendar_api_key_configured: credentials.has_api_key(),
+        claude_api_key_configured: has_nonblank_secret(store, CLAUDE_API_KEY)?,
+    })
+}
+
+fn read_calendar_credentials_with_store(
+    store: &dyn SecretStore,
+) -> Result<CalendarCredentials, AdvisorError> {
     let provider = match store.read(CALENDAR_PROVIDER)? {
         Some(value) => CalendarProvider::from_str(&value)?,
         None => CalendarProvider::None,
     };
-    Ok(AdvisorConfig {
-        calendar_provider: provider,
-        calendar_api_key_configured: has_nonblank_secret(store, CALENDAR_API_KEY)?,
-        claude_api_key_configured: has_nonblank_secret(store, CLAUDE_API_KEY)?,
-    })
+    Ok(CalendarCredentials::new(
+        provider,
+        read_nonblank_secret(store, CALENDAR_API_KEY)?,
+    ))
 }
 
 fn store_secret(
@@ -184,10 +259,21 @@ fn store_secret(
 }
 
 fn has_nonblank_secret(store: &dyn SecretStore, name: &'static str) -> Result<bool, AdvisorError> {
-    Ok(store
-        .read(name)?
-        .map(|value| !value.trim().is_empty())
-        .unwrap_or(false))
+    Ok(read_nonblank_secret(store, name)?.is_some())
+}
+
+fn read_nonblank_secret(
+    store: &dyn SecretStore,
+    name: &'static str,
+) -> Result<Option<String>, AdvisorError> {
+    Ok(store.read(name)?.and_then(|value| {
+        let trimmed = value.trim();
+        if trimmed.is_empty() {
+            None
+        } else {
+            Some(trimmed.to_string())
+        }
+    }))
 }
 
 fn redacted_key_state(is_configured: bool) -> &'static str {
@@ -264,6 +350,10 @@ mod tests {
             store.read(CALENDAR_API_KEY).unwrap(),
             Some("calendar-secret".to_string())
         );
+        let credentials = read_calendar_credentials_with_store(&store).unwrap();
+        assert_eq!(credentials.provider(), CalendarProvider::Polygon);
+        assert_eq!(credentials.api_key(), Some("calendar-secret"));
+        assert!(!format!("{credentials:?}").contains("calendar-secret"));
     }
 
     #[test]

--- a/advisor/src/error.rs
+++ b/advisor/src/error.rs
@@ -1,3 +1,4 @@
+use chrono::NaiveDate;
 use thiserror::Error;
 
 /// Error type for advisor crate configuration and stub advisory features.
@@ -15,12 +16,29 @@ pub enum AdvisorError {
         /// Raw provider value supplied by the caller.
         value: String,
     },
+    /// A catalyst scan window ended before it started.
+    #[error("invalid catalyst scan window: {start_date} through {end_date}")]
+    InvalidDateWindow {
+        /// Inclusive start date supplied by the caller.
+        start_date: NaiveDate,
+        /// Inclusive end date supplied by the caller.
+        end_date: NaiveDate,
+    },
+    /// Calendar API returned a response that could not be interpreted.
+    #[error("calendar API response error: {message}")]
+    CalendarResponse {
+        /// Human-readable response parsing error.
+        message: String,
+    },
     /// The system keychain could not be read or written.
     #[error("advisor keychain error: {0}")]
     Keychain(String),
     /// HTTP client setup or execution failed.
     #[error("advisor HTTP error: {0}")]
     Http(String),
+    /// Persisting advisor output through model database traits failed.
+    #[error("advisor persistence error: {0}")]
+    Persistence(String),
     /// The requested advisor feature is intentionally not implemented yet.
     #[error("{feature} advisory is not implemented yet")]
     NotImplemented {

--- a/advisor/src/lib.rs
+++ b/advisor/src/lib.rs
@@ -1,8 +1,9 @@
 //! AI-powered advisory integration scaffolding for Trust.
 //!
-//! This crate owns external advisory configuration and future HTTP-backed
-//! advisory features. The catalyst, correlation, and regime modules are stubs
-//! until their issue-specific implementations land.
+//! This crate owns external advisory configuration and HTTP-backed advisory
+//! features. Catalyst scanning is implemented against configurable calendar
+//! APIs; correlation and regime modules remain explicit stubs until their
+//! issue-specific implementations land.
 
 #![deny(
     clippy::unwrap_used,
@@ -20,7 +21,7 @@
 #![cfg_attr(test, allow(clippy::unwrap_used, clippy::expect_used))]
 #![warn(missing_docs, rust_2018_idioms, missing_debug_implementations)]
 
-/// Catalyst-calendar advisory scaffolding.
+/// Catalyst-calendar advisory integration.
 pub mod catalyst;
 /// Keychain-backed advisor configuration.
 pub mod config;
@@ -31,7 +32,8 @@ pub mod error;
 /// Market-regime advisory scaffolding.
 pub mod regime;
 
-pub use config::{AdvisorConfig, AdvisorConfigUpdate, CalendarProvider};
+pub use catalyst::{CatalystScanRequest, CatalystScanResult, CatalystScanner};
+pub use config::{AdvisorConfig, AdvisorConfigUpdate, CalendarCredentials, CalendarProvider};
 pub use error::AdvisorError;
 
 /// Entry point for future external advisory integrations.


### PR DESCRIPTION
## Summary
- implement HTTP-backed catalyst scanning for FMP and Polygon calendar providers
- classify calendar events into TradeEvent severity levels and persist via WriteTradeEventDB
- add graceful missing-key warnings plus mock HTTP scanner coverage

## Verification
- cargo test -p advisor -- --test-threads=1
- cargo clippy -p advisor --all-targets --all-features -- -D warnings
- cargo build
- make ci-fast
- cargo test --locked --all-features --workspace
- cargo test --locked --no-default-features --workspace

Closes #110