### PR TITLE
feat(cli): add trade autopsy

### DIFF
--- a/cli/src/command_routing.rs
+++ b/cli/src/command_routing.rs
@@ -79,6 +79,7 @@ pub enum TradeSubcommand<'a> {
     Hypothesis(&'a ArgMatches),
     Advisor(&'a ArgMatches),
     Events(&'a ArgMatches),
+    Autopsy(&'a ArgMatches),
 }
 
 pub enum DistributionSubcommand<'a> {
@@ -255,6 +256,7 @@ pub fn parse_trade_subcommand(sub_matches: &ArgMatches) -> TradeSubcommand<'_> {
         Some(("hypothesis", sub_sub_matches)) => TradeSubcommand::Hypothesis(sub_sub_matches),
         Some(("advisor", sub_sub_matches)) => TradeSubcommand::Advisor(sub_sub_matches),
         Some(("events", sub_sub_matches)) => TradeSubcommand::Events(sub_sub_matches),
+        Some(("autopsy", sub_sub_matches)) => TradeSubcommand::Autopsy(sub_sub_matches),
         _ => unreachable!("No subcommand provided"),
     }
 }
@@ -564,7 +566,8 @@ mod tests {
                 .subcommand(Command::new("size-preview"))
                 .subcommand(Command::new("hypothesis"))
                 .subcommand(Command::new("advisor"))
-                .subcommand(Command::new("events")),
+                .subcommand(Command::new("events"))
+                .subcommand(Command::new("autopsy")),
         );
         let trade_variants = [
             ("create", "Create"),
@@ -586,6 +589,7 @@ mod tests {
             ("hypothesis", "Hypothesis"),
             ("advisor", "Advisor"),
             ("events", "Events"),
+            ("autopsy", "Autopsy"),
         ];
         for (sub, expected) in trade_variants {
             let m = trade_app.clone().get_matches_from(["trust", "trade", sub]);
@@ -611,6 +615,7 @@ mod tests {
                 TradeSubcommand::Hypothesis(_) => "Hypothesis",
                 TradeSubcommand::Advisor(_) => "Advisor",
                 TradeSubcommand::Events(_) => "Events",
+                TradeSubcommand::Autopsy(_) => "Autopsy",
             };
             assert_eq!(got, expected);
         }

--- a/cli/src/commands/trade_command.rs
+++ b/cli/src/commands/trade_command.rs
@@ -491,6 +491,21 @@ impl TradeCommandBuilder {
         self
     }
 
+    pub fn autopsy(mut self) -> Self {
+        self.subcommands.push(
+            Command::new("autopsy")
+                .about("Record a structured post-trade mistake review")
+                .arg(
+                    Arg::new("trade-id")
+                        .long("trade-id")
+                        .value_name("UUID")
+                        .help("Closed, graded trade UUID")
+                        .required(true),
+                ),
+        );
+        self
+    }
+
     pub fn events(mut self) -> Self {
         self.subcommands.push(
             Command::new("events")
@@ -583,6 +598,7 @@ mod tests {
             .hypothesis()
             .advisor()
             .events()
+            .autopsy()
             .build()
     }
 
@@ -609,6 +625,7 @@ mod tests {
             "hypothesis",
             "advisor",
             "events",
+            "autopsy",
         ] {
             assert!(cmd.get_subcommands().any(|c| c.get_name() == name));
         }
@@ -864,6 +881,7 @@ mod tests {
         );
 
         let list = cmd
+            .clone()
             .try_get_matches_from([
                 "trade",
                 "events",
@@ -878,5 +896,19 @@ mod tests {
             .subcommand_matches("events")
             .expect("events subcommand");
         assert!(events_sub.subcommand_matches("list").is_some());
+    }
+
+    #[test]
+    fn trade_autopsy_parses_required_trade_id() {
+        let cmd = TradeCommandBuilder::new().autopsy().build();
+        let autopsy = cmd
+            .try_get_matches_from([
+                "trade",
+                "autopsy",
+                "--trade-id",
+                "00000000-0000-0000-0000-000000000001",
+            ])
+            .expect("trade autopsy should parse");
+        assert!(autopsy.subcommand_matches("autopsy").is_some());
     }
 }

--- a/cli/src/dialogs.rs
+++ b/cli/src/dialogs.rs
@@ -21,7 +21,8 @@ pub use account_dialog::AccountDialogBuilder;
 pub use account_dialog::AccountSearchDialog;
 #[cfg(test)]
 pub(crate) use io::{
-    scripted_push_confirm, scripted_push_input, scripted_push_select, scripted_reset,
+    scripted_push_confirm, scripted_push_input, scripted_push_multi_select, scripted_push_select,
+    scripted_reset,
 };
 pub use io::{ConsoleDialogIo, DialogIo};
 pub use keys_dialog::KeysDeleteDialogBuilder;

--- a/cli/src/dialogs/io.rs
+++ b/cli/src/dialogs/io.rs
@@ -1,5 +1,5 @@
 #[cfg(not(test))]
-use dialoguer::{theme::ColorfulTheme, Confirm, FuzzySelect};
+use dialoguer::{theme::ColorfulTheme, Confirm, FuzzySelect, MultiSelect};
 use std::io::Error as IoError;
 use std::io::ErrorKind;
 
@@ -12,6 +12,17 @@ pub trait DialogIo {
     ) -> Result<Option<usize>, IoError>;
 
     fn confirm(&mut self, prompt: &str, default: bool) -> Result<bool, IoError>;
+
+    fn multi_select_indices(
+        &mut self,
+        _prompt: &str,
+        _labels: &[String],
+    ) -> Result<Vec<usize>, IoError> {
+        Err(IoError::new(
+            ErrorKind::Unsupported,
+            "multi_select_indices not implemented",
+        ))
+    }
 
     fn input_text(&mut self, _prompt: &str, _allow_empty: bool) -> Result<String, IoError> {
         Err(IoError::new(
@@ -31,6 +42,17 @@ pub trait DialogBackend {
 
     fn confirm(&mut self, prompt: &str, default: bool) -> Result<bool, dialoguer::Error>;
 
+    fn multi_select_indices(
+        &mut self,
+        _prompt: &str,
+        _labels: &[String],
+    ) -> Result<Vec<usize>, dialoguer::Error> {
+        Err(dialoguer::Error::IO(IoError::new(
+            ErrorKind::Unsupported,
+            "multi_select_indices not implemented",
+        )))
+    }
+
     fn input_text(&mut self, prompt: &str, allow_empty: bool) -> Result<String, dialoguer::Error>;
 }
 
@@ -46,6 +68,7 @@ mod scripted_backend {
     #[derive(Default)]
     pub struct ScriptedState {
         pub selects: VecDeque<Result<Option<usize>, IoError>>,
+        pub multi_selects: VecDeque<Result<Vec<usize>, IoError>>,
         pub confirms: VecDeque<Result<bool, IoError>>,
         pub inputs: VecDeque<Result<String, IoError>>,
     }
@@ -56,6 +79,10 @@ mod scripted_backend {
 
     pub(crate) fn push_select(result: Result<Option<usize>, IoError>) {
         STATE.with(|state| state.borrow_mut().selects.push_back(result));
+    }
+
+    pub(crate) fn push_multi_select(result: Result<Vec<usize>, IoError>) {
+        STATE.with(|state| state.borrow_mut().multi_selects.push_back(result));
     }
 
     #[allow(dead_code)]
@@ -78,6 +105,16 @@ mod scripted_backend {
                 .selects
                 .pop_front()
                 .unwrap_or_else(|| Err(IoError::other("no scripted selection response")))
+        })
+    }
+
+    pub(crate) fn next_multi_select() -> Result<Vec<usize>, IoError> {
+        STATE.with(|state| {
+            state
+                .borrow_mut()
+                .multi_selects
+                .pop_front()
+                .unwrap_or_else(|| Err(IoError::other("no scripted multi-selection response")))
         })
     }
 
@@ -141,6 +178,27 @@ impl DialogBackend for DialoguerBackend {
     }
 
     #[cfg(not(test))]
+    fn multi_select_indices(
+        &mut self,
+        prompt: &str,
+        labels: &[String],
+    ) -> Result<Vec<usize>, dialoguer::Error> {
+        MultiSelect::with_theme(&ColorfulTheme::default())
+            .with_prompt(prompt)
+            .items(labels)
+            .interact()
+    }
+
+    #[cfg(test)]
+    fn multi_select_indices(
+        &mut self,
+        _prompt: &str,
+        _labels: &[String],
+    ) -> Result<Vec<usize>, dialoguer::Error> {
+        scripted_backend::next_multi_select().map_err(dialoguer::Error::IO)
+    }
+
+    #[cfg(not(test))]
     fn input_text(&mut self, prompt: &str, allow_empty: bool) -> Result<String, dialoguer::Error> {
         dialoguer::Input::with_theme(&ColorfulTheme::default())
             .with_prompt(prompt)
@@ -188,6 +246,16 @@ impl<B: DialogBackend> DialogIo for ConsoleDialogIo<B> {
             .map_err(Self::to_io_error)
     }
 
+    fn multi_select_indices(
+        &mut self,
+        prompt: &str,
+        labels: &[String],
+    ) -> Result<Vec<usize>, IoError> {
+        self.backend
+            .multi_select_indices(prompt, labels)
+            .map_err(Self::to_io_error)
+    }
+
     fn input_text(&mut self, prompt: &str, allow_empty: bool) -> Result<String, IoError> {
         self.backend
             .input_text(prompt, allow_empty)
@@ -212,6 +280,11 @@ pub(crate) fn scripted_push_select(result: Result<Option<usize>, IoError>) {
 }
 
 #[cfg(test)]
+pub(crate) fn scripted_push_multi_select(result: Result<Vec<usize>, IoError>) {
+    scripted_backend::push_multi_select(result);
+}
+
+#[cfg(test)]
 #[allow(dead_code)]
 pub(crate) fn scripted_push_confirm(result: Result<bool, IoError>) {
     scripted_backend::push_confirm(result);
@@ -230,8 +303,9 @@ pub(crate) fn scripted_reset() {
 #[cfg(test)]
 mod tests {
     use super::{
-        scripted_push_confirm, scripted_push_input, scripted_push_select, scripted_reset,
-        ConsoleDialogIo, DialogBackend, DialogIo, DialoguerBackend,
+        scripted_push_confirm, scripted_push_input, scripted_push_multi_select,
+        scripted_push_select, scripted_reset, ConsoleDialogIo, DialogBackend, DialogIo,
+        DialoguerBackend,
     };
     use std::io::ErrorKind;
 
@@ -283,6 +357,21 @@ mod tests {
 
         let result = io.select_index("Pick one", &labels, 1).unwrap();
         assert_eq!(result, Some(2));
+    }
+
+    #[test]
+    fn multi_select_uses_scripted_test_backend() {
+        scripted_reset();
+        scripted_push_multi_select(Ok(vec![0, 2]));
+        let mut io = ConsoleDialogIo::<DialoguerBackend>::default();
+        let labels = vec!["a".to_string(), "b".to_string(), "c".to_string()];
+
+        let result = io
+            .multi_select_indices("Pick many", &labels)
+            .expect("scripted multi-select should succeed");
+
+        assert_eq!(result, vec![0, 2]);
+        scripted_reset();
     }
 
     #[test]

--- a/cli/src/dispatcher.rs
+++ b/cli/src/dispatcher.rs
@@ -22,10 +22,11 @@ use crate::command_routing::{
 };
 use crate::dialogs::{
     AccountDialogBuilder, AccountSearchDialog, CancelDialogBuilder, CloseDialogBuilder,
-    ExitDialogBuilder, FillTradeDialogBuilder, FundingDialogBuilder, KeysDeleteDialogBuilder,
-    KeysReadDialogBuilder, KeysWriteDialogBuilder, ModifyDialogBuilder, SubmitDialogBuilder,
-    SyncTradeDialogBuilder, TradeDialogBuilder, TradeSearchDialogBuilder, TradeWatchDialogBuilder,
-    TradingVehicleDialogBuilder, TradingVehicleSearchDialogBuilder, TransactionDialogBuilder,
+    ConsoleDialogIo, DialogIo, ExitDialogBuilder, FillTradeDialogBuilder, FundingDialogBuilder,
+    KeysDeleteDialogBuilder, KeysReadDialogBuilder, KeysWriteDialogBuilder, ModifyDialogBuilder,
+    SubmitDialogBuilder, SyncTradeDialogBuilder, TradeDialogBuilder, TradeSearchDialogBuilder,
+    TradeWatchDialogBuilder, TradingVehicleDialogBuilder, TradingVehicleSearchDialogBuilder,
+    TransactionDialogBuilder,
 };
 use crate::dialogs::{RuleDialogBuilder, RuleRemoveDialogBuilder};
 use crate::protected_keyword;
@@ -50,8 +51,8 @@ use ibkr_broker::IbkrBroker;
 use model::{
     Account, AccountType, BarTimeframe, BrokerKind, Currency, DraftTrade, Environment,
     FixedIncomeTerms, Level, LevelAdjustmentRules, LevelTrigger, MarketDataChannel,
-    MarketSnapshotSource, Status, Trade, TradeCategory, TradeEvent, TradeEventSeverity,
-    TradeEventType, TransactionCategory,
+    MarketSnapshotSource, Mistake, MistakeErrorType, MungerTendency, Status, Trade, TradeCategory,
+    TradeEvent, TradeEventSeverity, TradeEventType, TradeGrade, TransactionCategory,
 };
 use rust_decimal::prelude::ToPrimitive;
 use rust_decimal::Decimal;
@@ -654,6 +655,7 @@ impl ArgDispatcher {
                 self.trade_advisor(sub_sub_matches, Self::parse_report_format(sub_sub_matches))?
             }
             TradeSubcommand::Events(sub_sub_matches) => self.trade_events(sub_sub_matches)?,
+            TradeSubcommand::Autopsy(sub_sub_matches) => self.trade_autopsy(sub_sub_matches)?,
         }
         Ok(())
     }
@@ -4005,6 +4007,360 @@ impl ArgDispatcher {
                 "risk_reward_ratio": report.risk_reward_ratio.map(Self::decimal_string),
             }
         })
+    }
+
+    fn trade_autopsy(&mut self, sub_matches: &ArgMatches) -> Result<(), CliError> {
+        let format = ReportOutputFormat::Text;
+        let trade_id = Self::parse_uuid_arg(sub_matches, "trade-id", format)?;
+        let trade = self.trust.read_trade(trade_id).map_err(|error| {
+            Self::report_error(
+                format,
+                "trade_not_found",
+                format!("Trade {trade_id} not found: {error}"),
+            )
+        })?;
+
+        if !Self::is_closed_trade_status(trade.status) {
+            return Err(Self::report_error(
+                format,
+                "trade_not_closed",
+                format!("Trade {trade_id} is not closed"),
+            ));
+        }
+
+        let grade = self
+            .trust
+            .latest_trade_grade(trade.id)
+            .map_err(|error| {
+                Self::report_error(
+                    format,
+                    "grade_read_failed",
+                    format!("Failed to read latest trade grade: {error}"),
+                )
+            })?
+            .ok_or_else(|| {
+                Self::report_error(
+                    format,
+                    "trade_not_graded",
+                    format!("Trade {trade_id} has not been graded"),
+                )
+            })?;
+
+        let mut io = ConsoleDialogIo::default();
+        let mistake = Self::trade_autopsy_with_io(&trade, &grade, &mut io)?;
+        let persisted = self.trust.create_mistake(mistake).map_err(|error| {
+            Self::report_error(
+                format,
+                "mistake_create_failed",
+                format!("Failed to store trade autopsy: {error}"),
+            )
+        })?;
+
+        Self::print_trade_autopsy_summary(&trade, &grade, &persisted);
+        Ok(())
+    }
+
+    fn trade_autopsy_with_io(
+        trade: &Trade,
+        grade: &TradeGrade,
+        io: &mut dyn DialogIo,
+    ) -> Result<Mistake, CliError> {
+        Self::print_trade_autopsy_context(trade, grade);
+        let mut bias_tags = Self::select_autopsy_biases(io)?;
+        let lollapalooza = bias_tags.len() >= 2;
+        if lollapalooza && !bias_tags.contains(&MungerTendency::Lollapalooza) {
+            bias_tags.push(MungerTendency::Lollapalooza);
+        }
+        let error_type = Self::select_autopsy_error_type(io)?;
+        let rule_violated = Self::read_optional_autopsy_text(io, "What rule was violated?")?;
+        let counterfactual_r = Self::read_counterfactual_r(io)?;
+        let lesson = Self::read_required_autopsy_text(io, "One-sentence lesson")?;
+        let now = Utc::now().naive_utc();
+
+        Ok(Mistake {
+            id: Uuid::new_v4(),
+            created_at: now,
+            updated_at: now,
+            deleted_at: None,
+            trade_id: trade.id,
+            bias_tags,
+            lollapalooza,
+            error_type,
+            rule_violated,
+            counterfactual_r,
+            lesson,
+        })
+    }
+
+    fn print_trade_autopsy_context(trade: &Trade, grade: &TradeGrade) {
+        println!("Trade autopsy");
+        println!("Trade: {} {}", trade.id, trade.trading_vehicle.symbol);
+        println!(
+            "Entry: {}",
+            Self::decimal_string(
+                trade
+                    .entry
+                    .average_filled_price
+                    .unwrap_or(trade.entry.unit_price)
+            )
+        );
+        println!(
+            "Exit: {}",
+            Self::trade_exit_price(trade)
+                .map(Self::decimal_string)
+                .unwrap_or_else(|| "n/a".to_string())
+        );
+        println!(
+            "R-multiple: {}",
+            Self::trade_r_multiple(trade)
+                .map(Self::decimal_string)
+                .unwrap_or_else(|| "n/a".to_string())
+        );
+        println!(
+            "Grade: {} ({}/100)",
+            grade.overall_grade, grade.overall_score
+        );
+        println!(
+            "Thesis: {}",
+            trade
+                .thesis
+                .as_deref()
+                .filter(|value| !value.trim().is_empty())
+                .unwrap_or("n/a")
+        );
+        println!();
+        println!("Common firing patterns:");
+        println!("Loser held too long: #11 + #14");
+        println!("Doubled down on a loser: #14 + #5");
+        println!("Chased a breakout late: #15 + #18");
+        println!("Sized up after win streak: #12 + #13");
+        println!("Followed a tip/guru: #22 + #15");
+        println!("Two or more biases together: #25 Lollapalooza");
+    }
+
+    fn print_trade_autopsy_summary(trade: &Trade, grade: &TradeGrade, mistake: &Mistake) {
+        println!();
+        println!("Stored trade autopsy: {}", mistake.id);
+        println!("Trade: {} {}", trade.id, trade.trading_vehicle.symbol);
+        println!(
+            "Grade: {} ({}/100)",
+            grade.overall_grade, grade.overall_score
+        );
+        println!(
+            "Biases: {}",
+            mistake
+                .bias_tags
+                .iter()
+                .map(|tag| Self::munger_tendency_display(*tag))
+                .collect::<Vec<String>>()
+                .join(", ")
+        );
+        println!(
+            "Lollapalooza: {}",
+            if mistake.lollapalooza { "yes" } else { "no" }
+        );
+        println!("Error type: {}", mistake.error_type);
+        println!(
+            "Rule violated: {}",
+            mistake.rule_violated.as_deref().unwrap_or("n/a")
+        );
+        println!(
+            "Counterfactual R: {}",
+            Self::decimal_string(mistake.counterfactual_r)
+        );
+        println!("Lesson: {}", mistake.lesson);
+    }
+
+    fn select_autopsy_biases(io: &mut dyn DialogIo) -> Result<Vec<MungerTendency>, CliError> {
+        let options = Self::autopsy_bias_options();
+        let labels = options
+            .iter()
+            .map(|tag| Self::munger_tendency_display(*tag))
+            .collect::<Vec<String>>();
+        let selected = io
+            .multi_select_indices("Which biases were active? (select all that apply)", &labels)
+            .map_err(|error| {
+                Self::report_error(
+                    ReportOutputFormat::Text,
+                    "autopsy_cancelled",
+                    format!("Bias selection failed: {error}"),
+                )
+            })?;
+
+        if selected.is_empty() {
+            return Err(Self::report_error(
+                ReportOutputFormat::Text,
+                "missing_bias_tags",
+                "Select at least one active bias",
+            ));
+        }
+
+        selected
+            .into_iter()
+            .map(|index| {
+                options.get(index).copied().ok_or_else(|| {
+                    Self::report_error(
+                        ReportOutputFormat::Text,
+                        "invalid_bias_selection",
+                        format!("Invalid bias selection index: {index}"),
+                    )
+                })
+            })
+            .collect()
+    }
+
+    fn select_autopsy_error_type(io: &mut dyn DialogIo) -> Result<MistakeErrorType, CliError> {
+        let labels = vec!["Commission".to_string(), "Omission".to_string()];
+        let selected = io
+            .select_index("Error of commission or omission?", &labels, 0)
+            .map_err(|error| {
+                Self::report_error(
+                    ReportOutputFormat::Text,
+                    "autopsy_cancelled",
+                    format!("Error type selection failed: {error}"),
+                )
+            })?
+            .ok_or_else(|| {
+                Self::report_error(
+                    ReportOutputFormat::Text,
+                    "autopsy_cancelled",
+                    "Autopsy cancelled before error type selection",
+                )
+            })?;
+
+        match selected {
+            0 => Ok(MistakeErrorType::Commission),
+            1 => Ok(MistakeErrorType::Omission),
+            _ => Err(Self::report_error(
+                ReportOutputFormat::Text,
+                "invalid_error_type_selection",
+                format!("Invalid error type selection index: {selected}"),
+            )),
+        }
+    }
+
+    fn read_optional_autopsy_text(
+        io: &mut dyn DialogIo,
+        prompt: &str,
+    ) -> Result<Option<String>, CliError> {
+        let value = io.input_text(prompt, true).map_err(|error| {
+            Self::report_error(
+                ReportOutputFormat::Text,
+                "autopsy_cancelled",
+                format!("Autopsy input failed: {error}"),
+            )
+        })?;
+        let trimmed = value.trim();
+        if trimmed.is_empty() {
+            Ok(None)
+        } else {
+            Ok(Some(trimmed.to_string()))
+        }
+    }
+
+    fn read_required_autopsy_text(io: &mut dyn DialogIo, prompt: &str) -> Result<String, CliError> {
+        let value = io.input_text(prompt, false).map_err(|error| {
+            Self::report_error(
+                ReportOutputFormat::Text,
+                "autopsy_cancelled",
+                format!("Autopsy input failed: {error}"),
+            )
+        })?;
+        let trimmed = value.trim();
+        if trimmed.is_empty() {
+            return Err(Self::report_error(
+                ReportOutputFormat::Text,
+                "missing_autopsy_input",
+                format!("{prompt} cannot be empty"),
+            ));
+        }
+        Ok(trimmed.to_string())
+    }
+
+    fn read_counterfactual_r(io: &mut dyn DialogIo) -> Result<Decimal, CliError> {
+        let value = Self::read_required_autopsy_text(
+            io,
+            "What would have happened if you had followed the rule? (counterfactual R-multiple)",
+        )?;
+        Decimal::from_str(&value).map_err(|_| {
+            Self::report_error(
+                ReportOutputFormat::Text,
+                "invalid_counterfactual_r",
+                format!("Invalid counterfactual R-multiple: {value}"),
+            )
+        })
+    }
+
+    fn autopsy_bias_options() -> Vec<MungerTendency> {
+        MungerTendency::all()
+            .into_iter()
+            .filter(|tag| *tag != MungerTendency::Lollapalooza)
+            .collect()
+    }
+
+    fn munger_tendency_display(tag: MungerTendency) -> String {
+        format!("#{} {}", tag.number(), Self::munger_tendency_label(tag))
+    }
+
+    fn munger_tendency_label(tag: MungerTendency) -> &'static str {
+        match tag {
+            MungerTendency::RewardPunishment => "Reward/Punishment Superresponse",
+            MungerTendency::InconsistencyAvoidance => "Inconsistency-Avoidance",
+            MungerTendency::MereAssociation => "Influence-from-Mere-Association",
+            MungerTendency::PainAvoidingDenial => "Pain-Avoiding Psychological Denial",
+            MungerTendency::ExcessiveSelfRegard => "Excessive Self-Regard",
+            MungerTendency::Overoptimism => "Overoptimism",
+            MungerTendency::DeprivalSuperreaction => "Deprival Superreaction",
+            MungerTendency::SocialProof => "Social-Proof",
+            MungerTendency::ContrastMisreaction => "Contrast-Misreaction",
+            MungerTendency::StressInfluence => "Stress-Influence",
+            MungerTendency::AvailabilityMisweighing => "Availability-Misweighing",
+            MungerTendency::AuthorityMisinfluence => "Authority-Misinfluence",
+            MungerTendency::Lollapalooza => "Lollapalooza",
+        }
+    }
+
+    fn is_closed_trade_status(status: Status) -> bool {
+        matches!(status, Status::ClosedTarget | Status::ClosedStopLoss)
+    }
+
+    fn trade_exit_price(trade: &Trade) -> Option<Decimal> {
+        match trade.status {
+            Status::ClosedTarget => Some(
+                trade
+                    .target
+                    .average_filled_price
+                    .unwrap_or(trade.target.unit_price),
+            ),
+            Status::ClosedStopLoss => Some(
+                trade
+                    .safety_stop
+                    .average_filled_price
+                    .unwrap_or(trade.safety_stop.unit_price),
+            ),
+            _ => None,
+        }
+    }
+
+    fn trade_r_multiple(trade: &Trade) -> Option<Decimal> {
+        let entry = trade
+            .entry
+            .average_filled_price
+            .unwrap_or(trade.entry.unit_price);
+        let stop = trade.safety_stop.unit_price;
+        let exit = Self::trade_exit_price(trade)?;
+        let risk = match trade.category {
+            TradeCategory::Long => entry.checked_sub(stop)?,
+            TradeCategory::Short => stop.checked_sub(entry)?,
+        };
+        if risk <= Decimal::ZERO {
+            return None;
+        }
+        let pnl = match trade.category {
+            TradeCategory::Long => exit.checked_sub(entry)?,
+            TradeCategory::Short => entry.checked_sub(exit)?,
+        };
+        pnl.checked_div(risk)
     }
 
     fn trade_advisor(
@@ -9066,6 +9422,14 @@ mod tests {
         Command::new("test")
             .arg(Arg::new("trade-id").long("trade-id"))
             .arg(Arg::new("format").long("format"))
+            .get_matches_from(argv)
+    }
+
+    fn trade_autopsy_matches(args: &[&str]) -> clap::ArgMatches {
+        let mut argv: Vec<&str> = vec!["test"];
+        argv.extend_from_slice(args);
+        Command::new("test")
+            .arg(Arg::new("trade-id").long("trade-id"))
             .get_matches_from(argv)
     }
 
@@ -16649,6 +17013,83 @@ mod tests {
         assert_eq!(payload["catalyst"]["events"][0]["severity"], "High");
         assert_eq!(payload["correlation"]["status"], "OK");
         assert_eq!(payload["regime"]["composite"], "Normal");
+    }
+
+    #[test]
+    fn test_trade_autopsy_interactive_persists_mistake_for_closed_graded_trade() {
+        let mut dispatcher =
+            test_dispatcher_with_broker(Box::new(StubBroker::submitted_fill_fixture()));
+        let (_account, trade) = seed_closed_target_trade(&mut dispatcher);
+        dispatcher
+            .trust
+            .grade_trade(
+                trade.id,
+                core::services::grading::GradingWeightsPermille::default(),
+            )
+            .expect("closed trade should grade");
+        let trade_id = trade.id.to_string();
+        let matches = trade_autopsy_matches(&["--trade-id", &trade_id]);
+
+        crate::dialogs::scripted_reset();
+        crate::dialogs::scripted_push_multi_select(Ok(vec![3, 6]));
+        crate::dialogs::scripted_push_select(Ok(Some(0)));
+        crate::dialogs::scripted_push_input(Ok("held past stop rule".to_string()));
+        crate::dialogs::scripted_push_input(Ok("1.5".to_string()));
+        crate::dialogs::scripted_push_input(Ok(
+            "Exit when the invalidation level breaks.".to_string()
+        ));
+
+        dispatcher
+            .trade_autopsy(&matches)
+            .expect("trade autopsy should persist");
+
+        let mistakes = dispatcher
+            .trust
+            .mistakes_for_trade(trade.id)
+            .expect("mistakes should read");
+        assert_eq!(mistakes.len(), 1);
+        let mistake = &mistakes[0];
+        assert_eq!(mistake.trade_id, trade.id);
+        assert!(mistake
+            .bias_tags
+            .contains(&model::MungerTendency::PainAvoidingDenial));
+        assert!(mistake
+            .bias_tags
+            .contains(&model::MungerTendency::DeprivalSuperreaction));
+        assert!(mistake
+            .bias_tags
+            .contains(&model::MungerTendency::Lollapalooza));
+        assert!(mistake.lollapalooza);
+        assert_eq!(mistake.error_type, model::MistakeErrorType::Commission);
+        assert_eq!(
+            mistake.rule_violated.as_deref(),
+            Some("held past stop rule")
+        );
+        assert_eq!(mistake.counterfactual_r, dec!(1.5));
+        assert_eq!(mistake.lesson, "Exit when the invalidation level breaks.");
+        crate::dialogs::scripted_reset();
+    }
+
+    #[test]
+    fn test_trade_autopsy_rejects_open_and_ungraded_trades_before_dialogs() {
+        let mut open_dispatcher = test_dispatcher();
+        let (_account, open_trade) = seed_new_trade(&mut open_dispatcher);
+        let open_trade_id = open_trade.id.to_string();
+        let open_matches = trade_autopsy_matches(&["--trade-id", &open_trade_id]);
+        let error = open_dispatcher
+            .trade_autopsy(&open_matches)
+            .expect_err("open trade should be rejected");
+        assert_eq!(error.code, "trade_not_closed");
+
+        let mut ungraded_dispatcher =
+            test_dispatcher_with_broker(Box::new(StubBroker::submitted_fill_fixture()));
+        let (_account, closed_trade) = seed_closed_target_trade(&mut ungraded_dispatcher);
+        let closed_trade_id = closed_trade.id.to_string();
+        let closed_matches = trade_autopsy_matches(&["--trade-id", &closed_trade_id]);
+        let error = ungraded_dispatcher
+            .trade_autopsy(&closed_matches)
+            .expect_err("ungraded trade should be rejected");
+        assert_eq!(error.code, "trade_not_graded");
     }
 
     #[test]

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -128,6 +128,7 @@ fn build_cli() -> Command {
                 .hypothesis()
                 .advisor()
                 .events()
+                .autopsy()
                 .build(),
         )
         .subcommand(

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -55,9 +55,9 @@ use model::{
     DatabaseFactory, DistributionHistory, DistributionResult, DistributionRules, DraftTrade,
     Environment, Execution, Level, LevelAdjustmentRules, LevelChange, LevelTrigger, MarketBar,
     MarketDataChannel, MarketDataStreamEvent, MarketSnapshot, MarketSnapshotSource,
-    MarketSnapshotV2, Order, Rule, RuleLevel, RuleName, Status, Trade, TradeBalance, TradeEvent,
-    TradeEventSeverity, TradeEventSource, TradeEventType, TradingVehicle, TradingVehicleCategory,
-    Transaction, TransactionCategory,
+    MarketSnapshotV2, Mistake, Order, Rule, RuleLevel, RuleName, Status, Trade, TradeBalance,
+    TradeEvent, TradeEventSeverity, TradeEventSource, TradeEventType, TradingVehicle,
+    TradingVehicleCategory, Transaction, TransactionCategory,
 };
 use rand_core::OsRng;
 use rust_decimal::Decimal;
@@ -837,6 +837,26 @@ impl TrustFacade {
         self.factory
             .trade_event_read()
             .read_trade_events_for_trade(trade_id)
+    }
+
+    /// Persist a post-trade mistake review for a closed, graded trade.
+    pub fn create_mistake(
+        &mut self,
+        mistake: Mistake,
+    ) -> Result<Mistake, Box<dyn std::error::Error>> {
+        self.read_trade(mistake.trade_id)?;
+        self.factory.mistake_write().create_mistake(&mistake)
+    }
+
+    /// Read active post-trade mistakes for a trade.
+    pub fn mistakes_for_trade(
+        &mut self,
+        trade_id: Uuid,
+    ) -> Result<Vec<Mistake>, Box<dyn std::error::Error>> {
+        self.read_trade(trade_id)?;
+        self.factory
+            .mistake_read()
+            .read_mistakes_for_trade(trade_id)
     }
 
     /// Scan external calendar catalysts for a trade and persist returned events.


### PR DESCRIPTION
## Summary
- add `trade autopsy --trade-id <UUID>` routing and command registration
- add interactive mistake capture with Munger tendency multi-select and automatic lollapalooza tagging
- persist autopsy output through `TrustFacade` and print a post-save summary

## Verification
- `cargo test -p trust-cli trade_autopsy -- --test-threads=1`
- `cargo test -p trust-cli autopsy -- --test-threads=1`
- `cargo test -p trust-cli multi_select -- --test-threads=1`
- `cargo clippy -p core -p trust-cli --all-targets --all-features -- -D warnings`
- `cargo test -p trust-cli trade -- --test-threads=1`
- `cargo test -p core -- --test-threads=1`
- `make ci-fast`
- `cargo test --locked --no-default-features --workspace`
- `cargo test --locked --all-features --workspace`

Closes #114