### PR TITLE
feat(core): add bias aggregation report

### DIFF
--- a/cli/src/command_routing.rs
+++ b/cli/src/command_routing.rs
@@ -100,6 +100,7 @@ pub enum ReportSubcommand<'a> {
     Attribution(&'a ArgMatches),
     Benchmark(&'a ArgMatches),
     Timeline(&'a ArgMatches),
+    BiasSummary(&'a ArgMatches),
 }
 
 pub enum MarketDataSubcommand<'a> {
@@ -292,6 +293,7 @@ pub fn parse_report_subcommand(sub_matches: &ArgMatches) -> ReportSubcommand<'_>
         Some(("attribution", sub_sub_matches)) => ReportSubcommand::Attribution(sub_sub_matches),
         Some(("benchmark", sub_sub_matches)) => ReportSubcommand::Benchmark(sub_sub_matches),
         Some(("timeline", sub_sub_matches)) => ReportSubcommand::Timeline(sub_sub_matches),
+        Some(("bias-summary", sub_sub_matches)) => ReportSubcommand::BiasSummary(sub_sub_matches),
         _ => unreachable!("No subcommand provided"),
     }
 }
@@ -786,7 +788,8 @@ mod tests {
                 .subcommand(Command::new("metrics"))
                 .subcommand(Command::new("attribution"))
                 .subcommand(Command::new("benchmark"))
-                .subcommand(Command::new("timeline")),
+                .subcommand(Command::new("timeline"))
+                .subcommand(Command::new("bias-summary")),
         );
         for (sub, expected) in [
             ("drawdown", "drawdown"),
@@ -798,6 +801,7 @@ mod tests {
             ("attribution", "attribution"),
             ("benchmark", "benchmark"),
             ("timeline", "timeline"),
+            ("bias-summary", "bias-summary"),
         ] {
             let m = report.clone().get_matches_from(["trust", "report", sub]);
             let (_, sm) = m.subcommand().expect("expected report");
@@ -811,6 +815,7 @@ mod tests {
                 ReportSubcommand::Attribution(_) => "attribution",
                 ReportSubcommand::Benchmark(_) => "benchmark",
                 ReportSubcommand::Timeline(_) => "timeline",
+                ReportSubcommand::BiasSummary(_) => "bias-summary",
             };
             assert_eq!(got, expected);
         }

--- a/cli/src/commands/report_command.rs
+++ b/cli/src/commands/report_command.rs
@@ -15,7 +15,7 @@ impl ReportCommandBuilder {
                         .long("format")
                         .value_name("FORMAT")
                         .help("Output format")
-                        .value_parser(["text", "json"])
+                        .value_parser(["text", "human", "json"])
                         .default_value("text")
                         .global(true),
                 )
@@ -250,6 +250,30 @@ impl ReportCommandBuilder {
         );
         self
     }
+
+    pub fn bias_summary(mut self) -> Self {
+        self.subcommands.push(
+            Command::new("bias-summary")
+                .about("Aggregate post-trade mistake bias tendencies over a lookback window")
+                .arg(
+                    Arg::new("account")
+                        .long("account")
+                        .value_name("ACCOUNT_ID")
+                        .help("Account ID")
+                        .required(true),
+                )
+                .arg(
+                    Arg::new("days")
+                        .long("days")
+                        .value_name("DAYS")
+                        .help("Look back over the last N days")
+                        .value_parser(clap::value_parser!(i32).range(1..))
+                        .default_value("7")
+                        .required(false),
+                ),
+        );
+        self
+    }
 }
 
 impl Default for ReportCommandBuilder {
@@ -274,6 +298,7 @@ mod tests {
             .attribution()
             .benchmark()
             .timeline()
+            .bias_summary()
             .build();
         for name in [
             "performance",
@@ -285,6 +310,7 @@ mod tests {
             "attribution",
             "benchmark",
             "timeline",
+            "bias-summary",
         ] {
             assert!(cmd.get_subcommands().any(|c| c.get_name() == name));
         }
@@ -473,5 +499,34 @@ mod tests {
                 .map(String::as_str),
             Some("week")
         );
+    }
+
+    #[test]
+    fn report_bias_summary_parses_days_and_human_format() {
+        let cmd = ReportCommandBuilder::new().bias_summary().build();
+        let matches = cmd
+            .try_get_matches_from([
+                "report",
+                "bias-summary",
+                "--format",
+                "human",
+                "--account",
+                "acc-1",
+                "--days",
+                "14",
+            ])
+            .expect("bias-summary should parse");
+        assert_eq!(
+            matches.get_one::<String>("format").map(String::as_str),
+            Some("human")
+        );
+        let sub = matches
+            .subcommand_matches("bias-summary")
+            .expect("bias-summary subcommand");
+        assert_eq!(
+            sub.get_one::<String>("account").map(String::as_str),
+            Some("acc-1")
+        );
+        assert_eq!(sub.get_one::<i32>("days"), Some(&14));
     }
 }

--- a/cli/src/dispatcher.rs
+++ b/cli/src/dispatcher.rs
@@ -39,6 +39,7 @@ use advisor::{
 use alpaca_broker::AlpacaBroker;
 use chrono::{DateTime, Datelike, Days, NaiveDate, Utc};
 use clap::ArgMatches;
+use core::calculators_performance::BiasAggregation;
 use core::services::leveling::{
     LevelCriterionProgress, LevelEvaluationOutcome, LevelPathProgress, LevelPerformanceSnapshot,
     LevelProgressReport,
@@ -285,6 +286,7 @@ struct MetricsReportCommand;
 struct AttributionReportCommand;
 struct BenchmarkReportCommand;
 struct TimelineReportCommand;
+struct BiasSummaryReportCommand;
 
 impl MarketDataCommandHandler for MarketDataSnapshotCommand {
     fn execute(
@@ -448,6 +450,17 @@ impl ReportCommandHandler for TimelineReportCommand {
         format: ReportOutputFormat,
     ) -> Result<(), CliError> {
         dispatcher.timeline_report(sub_matches, format)
+    }
+}
+
+impl ReportCommandHandler for BiasSummaryReportCommand {
+    fn execute(
+        &self,
+        dispatcher: &mut ArgDispatcher,
+        sub_matches: &ArgMatches,
+        format: ReportOutputFormat,
+    ) -> Result<(), CliError> {
+        dispatcher.bias_summary_report(sub_matches, format)
     }
 }
 
@@ -713,6 +726,7 @@ impl ArgDispatcher {
         static ATTRIBUTION: AttributionReportCommand = AttributionReportCommand;
         static BENCHMARK: BenchmarkReportCommand = BenchmarkReportCommand;
         static TIMELINE: TimelineReportCommand = TimelineReportCommand;
+        static BIAS_SUMMARY: BiasSummaryReportCommand = BiasSummaryReportCommand;
 
         match subcommand {
             ReportSubcommand::Performance(sub_matches) => (&PERFORMANCE, sub_matches),
@@ -724,6 +738,7 @@ impl ArgDispatcher {
             ReportSubcommand::Attribution(sub_matches) => (&ATTRIBUTION, sub_matches),
             ReportSubcommand::Benchmark(sub_matches) => (&BENCHMARK, sub_matches),
             ReportSubcommand::Timeline(sub_matches) => (&TIMELINE, sub_matches),
+            ReportSubcommand::BiasSummary(sub_matches) => (&BIAS_SUMMARY, sub_matches),
         }
     }
 
@@ -4329,6 +4344,15 @@ impl ArgDispatcher {
         format!("#{} {}", tag.number(), Self::munger_tendency_label(tag))
     }
 
+    fn munger_tendency_label_by_number(number: i32) -> String {
+        MungerTendency::all()
+            .into_iter()
+            .find(|tag| i32::from(tag.number()) == number)
+            .map(Self::munger_tendency_label)
+            .unwrap_or("Unknown")
+            .to_string()
+    }
+
     fn munger_tendency_label(tag: MungerTendency) -> &'static str {
         match tag {
             MungerTendency::RewardPunishment => "Reward/Punishment Superresponse",
@@ -7532,6 +7556,116 @@ impl ArgDispatcher {
         Ok(())
     }
 
+    fn bias_summary_report(
+        &mut self,
+        sub_matches: &ArgMatches,
+        format: ReportOutputFormat,
+    ) -> Result<(), CliError> {
+        let account_raw = sub_matches
+            .get_one::<String>("account")
+            .ok_or_else(|| Self::report_error(format, "missing_argument", "Missing --account"))?;
+        let account = self.resolve_account_arg(account_raw, format)?;
+        let days = sub_matches.get_one::<i32>("days").copied().unwrap_or(7);
+        let aggregation = self
+            .trust
+            .bias_aggregation_for_account(account.id, days)
+            .map_err(|error| Self::report_error(format, "report_failed", error.to_string()))?;
+
+        match format {
+            ReportOutputFormat::Text => Self::print_bias_summary_text(&aggregation),
+            ReportOutputFormat::Json => {
+                let payload = Self::bias_aggregation_payload(account.id, &aggregation);
+                Self::print_json(&payload)?;
+            }
+        }
+
+        Ok(())
+    }
+
+    fn print_bias_summary_text(aggregation: &BiasAggregation) {
+        println!(
+            "Bias Summary (last {} days, {} mistakes)",
+            aggregation.window_days, aggregation.total_mistakes
+        );
+        println!("----------------------------------------");
+        if let Some((tendency_number, count)) = aggregation.most_frequent_tendency {
+            let label = Self::munger_tendency_label_by_number(tendency_number);
+            let percentage = Self::bias_count_percentage(count, aggregation.total_mistakes);
+            println!(
+                "Most frequent:  #{} {} ({}/{} = {}%)",
+                tendency_number, label, count, aggregation.total_mistakes, percentage
+            );
+            if aggregation.mechanical_antidote_needed {
+                println!("                -> Consider mechanical antidote");
+            }
+        } else {
+            println!("Most frequent:  n/a");
+        }
+        println!("Lollapaloozas:  {}", aggregation.lollapalooza_count);
+        println!("Omissions:      {}", aggregation.omission_count);
+        println!("Commissions:    {}", aggregation.commission_count);
+        println!(
+            "Standdown:      {}",
+            if aggregation.standdown_recommended {
+                "Yes"
+            } else {
+                "No"
+            }
+        );
+        println!(
+            "Mechanical antidote: {}",
+            if aggregation.mechanical_antidote_needed {
+                "Yes"
+            } else {
+                "No"
+            }
+        );
+    }
+
+    fn bias_aggregation_payload(account_id: Uuid, aggregation: &BiasAggregation) -> Value {
+        json!({
+            "report": "bias_summary",
+            "schema_version": 1,
+            "generated_at": Utc::now().to_rfc3339(),
+            "account_id": account_id.to_string(),
+            "window_days": aggregation.window_days,
+            "total_mistakes": aggregation.total_mistakes,
+            "most_frequent_tendency": Self::most_frequent_tendency_payload(aggregation),
+            "lollapalooza_count": aggregation.lollapalooza_count,
+            "omission_count": aggregation.omission_count,
+            "commission_count": aggregation.commission_count,
+            "standdown_recommended": aggregation.standdown_recommended,
+            "mechanical_antidote_needed": aggregation.mechanical_antidote_needed,
+        })
+    }
+
+    fn most_frequent_tendency_payload(aggregation: &BiasAggregation) -> Value {
+        aggregation
+            .most_frequent_tendency
+            .map(|(tendency_number, count)| {
+                json!({
+                    "tendency_number": tendency_number,
+                    "count": count,
+                    "label": Self::munger_tendency_label_by_number(tendency_number),
+                    "percentage": Self::bias_count_percentage(count, aggregation.total_mistakes),
+                })
+            })
+            .unwrap_or(Value::Null)
+    }
+
+    fn bias_count_percentage(count: i32, total: i32) -> String {
+        if total <= 0 {
+            return "0".to_string();
+        }
+
+        let percentage = Decimal::from(count)
+            .checked_mul(dec!(100))
+            .and_then(|value| value.checked_div(Decimal::from(total)))
+            .unwrap_or(Decimal::ZERO)
+            .round_dp(0);
+        Self::decimal_string(percentage)
+    }
+
     #[allow(clippy::too_many_lines)]
     fn grade_show(
         &mut self,
@@ -9741,8 +9875,9 @@ mod tests {
         database::TradingVehicleUpsert, AccountType, Broker, BrokerKind, BrokerLog, Currency,
         Environment, FixedIncomeTerms, Level, LevelAdjustmentRules, LevelDirection, LevelStatus,
         LevelTrigger, MarketBar, MarketDataChannel, MarketDataStreamEvent, MarketQuote,
-        MarketSnapshotSource, MarketSnapshotV2, MarketTradeTick, OrderIds, SessionRegime, Status,
-        Trade, TradingVehicleCategory, TransactionCategory,
+        MarketSnapshotSource, MarketSnapshotV2, MarketTradeTick, Mistake, MistakeErrorType,
+        MungerTendency, OrderIds, SessionRegime, Status, Trade, TradingVehicleCategory,
+        TransactionCategory,
     };
     use rust_decimal::Decimal;
     use rust_decimal_macros::dec;
@@ -10334,6 +10469,7 @@ mod tests {
                     .attribution()
                     .benchmark()
                     .timeline()
+                    .bias_summary()
                     .build(),
             )
             .subcommand(
@@ -10466,6 +10602,32 @@ mod tests {
             .find(|candidate| candidate.id == filled.id)
             .expect("closed trade should be persisted");
         (account, closed)
+    }
+
+    fn seed_mistake(
+        dispatcher: &mut ArgDispatcher,
+        trade_id: Uuid,
+        bias_tags: Vec<MungerTendency>,
+        lollapalooza: bool,
+        error_type: MistakeErrorType,
+    ) -> Mistake {
+        let now = Utc::now().naive_utc();
+        dispatcher
+            .trust
+            .create_mistake(Mistake {
+                id: Uuid::new_v4(),
+                created_at: now,
+                updated_at: now,
+                deleted_at: None,
+                trade_id,
+                bias_tags,
+                lollapalooza,
+                error_type,
+                rule_violated: None,
+                counterfactual_r: Decimal::ZERO,
+                lesson: "Review the process rule before taking the next setup.".to_string(),
+            })
+            .expect("mistake should persist")
     }
 
     #[test]
@@ -11726,6 +11888,14 @@ mod tests {
                 "--to",
                 "2026-01-31",
             ],
+            vec![
+                "report",
+                "bias-summary",
+                "--account",
+                invalid_account,
+                "--days",
+                "7",
+            ],
         ];
 
         for argv in commands {
@@ -11739,6 +11909,7 @@ mod tests {
                 .attribution()
                 .benchmark()
                 .timeline()
+                .bias_summary()
                 .build()
                 .get_matches_from(argv);
 
@@ -15217,6 +15388,91 @@ mod tests {
                 .timeline_report(timeline.subcommand_matches("timeline").unwrap(), format)
                 .expect("timeline report should succeed");
         }
+    }
+
+    #[test]
+    fn test_bias_summary_report_aggregates_mistakes_and_renders_formats() {
+        let mut dispatcher =
+            test_dispatcher_with_broker(Box::new(StubBroker::submitted_fill_fixture()));
+        let (account, closed) = seed_closed_target_trade(&mut dispatcher);
+        seed_mistake(
+            &mut dispatcher,
+            closed.id,
+            vec![
+                MungerTendency::DeprivalSuperreaction,
+                MungerTendency::SocialProof,
+            ],
+            false,
+            MistakeErrorType::Commission,
+        );
+        seed_mistake(
+            &mut dispatcher,
+            closed.id,
+            vec![MungerTendency::DeprivalSuperreaction],
+            false,
+            MistakeErrorType::Omission,
+        );
+        seed_mistake(
+            &mut dispatcher,
+            closed.id,
+            vec![
+                MungerTendency::DeprivalSuperreaction,
+                MungerTendency::Lollapalooza,
+            ],
+            true,
+            MistakeErrorType::Commission,
+        );
+
+        let account_id = account.id.to_string();
+        let json_matches = ReportCommandBuilder::new()
+            .bias_summary()
+            .build()
+            .get_matches_from([
+                "report",
+                "bias-summary",
+                "--format",
+                "json",
+                "--account",
+                &account_id,
+                "--days",
+                "7",
+            ]);
+        dispatcher
+            .dispatch_report(&json_matches)
+            .expect("bias summary json should dispatch");
+
+        let human_matches = ReportCommandBuilder::new()
+            .bias_summary()
+            .build()
+            .get_matches_from([
+                "report",
+                "bias-summary",
+                "--format",
+                "human",
+                "--account",
+                &account_id,
+                "--days",
+                "7",
+            ]);
+        dispatcher
+            .dispatch_report(&human_matches)
+            .expect("bias summary human should dispatch");
+
+        let aggregation = dispatcher
+            .trust
+            .bias_aggregation_for_account(account.id, 7)
+            .expect("bias aggregation should calculate");
+        let payload = ArgDispatcher::bias_aggregation_payload(account.id, &aggregation);
+        assert_eq!(payload["report"], "bias_summary");
+        assert_eq!(payload["window_days"], 7);
+        assert_eq!(payload["total_mistakes"], 3);
+        assert_eq!(payload["most_frequent_tendency"]["tendency_number"], 14);
+        assert_eq!(payload["most_frequent_tendency"]["count"], 3);
+        assert_eq!(payload["lollapalooza_count"], 1);
+        assert_eq!(payload["omission_count"], 1);
+        assert_eq!(payload["commission_count"], 2);
+        assert_eq!(payload["mechanical_antidote_needed"], true);
+        assert_eq!(payload["standdown_recommended"], false);
     }
 
     #[test]
@@ -20356,6 +20612,14 @@ mod tests {
                 "--to",
                 "2026-01-31",
             ],
+            vec![
+                "report",
+                "bias-summary",
+                "--account",
+                invalid_account,
+                "--days",
+                "7",
+            ],
         ];
 
         for argv in report_commands {
@@ -20367,6 +20631,7 @@ mod tests {
                 .attribution()
                 .benchmark()
                 .timeline()
+                .bias_summary()
                 .build()
                 .get_matches_from(argv);
             let error = dispatcher

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -151,6 +151,7 @@ fn build_cli() -> Command {
                 .attribution()
                 .benchmark()
                 .timeline()
+                .bias_summary()
                 .build(),
         )
         .subcommand(

--- a/cli/tests/integration_test_report_json_snapshots.rs
+++ b/cli/tests/integration_test_report_json_snapshots.rs
@@ -1,6 +1,9 @@
 use core::TrustFacade;
 use db_sqlite::SqliteDatabase;
-use model::{Currency, DraftTrade, Environment, TradeCategory, TradingVehicleCategory};
+use model::{
+    Currency, DraftTrade, Environment, Mistake, MistakeErrorType, MungerTendency, TradeCategory,
+    TradingVehicleCategory,
+};
 use rust_decimal_macros::dec;
 use serde_json::Value;
 use std::fs;
@@ -154,7 +157,63 @@ fn seed_snapshot_dataset(database_url: &str) -> Uuid {
         .expect("create trade 2");
     let _ = trust.fund_trade(&t2).expect("fund trade 2");
 
+    seed_snapshot_mistake(
+        &mut trust,
+        t1.id,
+        vec![
+            MungerTendency::DeprivalSuperreaction,
+            MungerTendency::SocialProof,
+        ],
+        false,
+        MistakeErrorType::Commission,
+    );
+    seed_snapshot_mistake(
+        &mut trust,
+        t1.id,
+        vec![
+            MungerTendency::DeprivalSuperreaction,
+            MungerTendency::Lollapalooza,
+        ],
+        true,
+        MistakeErrorType::Omission,
+    );
+    seed_snapshot_mistake(
+        &mut trust,
+        t2.id,
+        vec![
+            MungerTendency::InconsistencyAvoidance,
+            MungerTendency::Lollapalooza,
+        ],
+        true,
+        MistakeErrorType::Commission,
+    );
+
     account.id
+}
+
+fn seed_snapshot_mistake(
+    trust: &mut TrustFacade,
+    trade_id: Uuid,
+    bias_tags: Vec<MungerTendency>,
+    lollapalooza: bool,
+    error_type: MistakeErrorType,
+) {
+    let now = chrono::Utc::now().naive_utc();
+    trust
+        .create_mistake(Mistake {
+            id: Uuid::new_v4(),
+            created_at: now,
+            updated_at: now,
+            deleted_at: None,
+            trade_id,
+            bias_tags,
+            lollapalooza,
+            error_type,
+            rule_violated: None,
+            counterfactual_r: rust_decimal::Decimal::ZERO,
+            lesson: "Review the bias cluster before the next session.".to_string(),
+        })
+        .expect("create snapshot mistake");
 }
 
 fn normalize_json(mut payload: Value) -> Value {
@@ -370,6 +429,19 @@ fn test_report_json_snapshots() {
                 "json".into(),
                 "--account".into(),
                 account_arg.clone(),
+            ],
+        ),
+        (
+            "report_bias_summary",
+            vec![
+                "report".into(),
+                "bias-summary".into(),
+                "--format".into(),
+                "json".into(),
+                "--account".into(),
+                account_arg.clone(),
+                "--days".into(),
+                "7".into(),
             ],
         ),
     ];

--- a/cli/tests/snapshots/report_bias_summary.json
+++ b/cli/tests/snapshots/report_bias_summary.json
@@ -1,0 +1,19 @@
+{
+  "account_id": "<account-id>",
+  "commission_count": 2,
+  "generated_at": "<redacted>",
+  "lollapalooza_count": 2,
+  "mechanical_antidote_needed": true,
+  "most_frequent_tendency": {
+    "count": 2,
+    "label": "Deprival Superreaction",
+    "percentage": "67",
+    "tendency_number": 14
+  },
+  "omission_count": 1,
+  "report": "bias_summary",
+  "schema_version": 1,
+  "standdown_recommended": true,
+  "total_mistakes": 3,
+  "window_days": 7
+}

--- a/core/src/calculators_performance.rs
+++ b/core/src/calculators_performance.rs
@@ -4,8 +4,10 @@
 //! metrics using precise decimal arithmetic for financial safety.
 
 use model::trade::{Status, Trade};
+use model::{Mistake, MistakeErrorType};
 use rust_decimal::Decimal;
 use rust_decimal_macros::dec;
+use std::collections::BTreeMap;
 
 /// Error types for performance calculations
 #[derive(Debug, PartialEq)]
@@ -41,9 +43,87 @@ pub struct PerformanceStats {
     pub worst_trade: Option<Decimal>,
 }
 
+/// Aggregated post-trade bias pattern summary for a fixed lookback window.
+#[derive(Debug, PartialEq, Eq, Clone)]
+pub struct BiasAggregation {
+    /// Number of days included in the lookback window.
+    pub window_days: i32,
+    /// Number of mistake records included in the aggregation.
+    pub total_mistakes: i32,
+    /// Most frequently observed Munger tendency as `(tendency_number, count)`.
+    pub most_frequent_tendency: Option<(i32, i32)>,
+    /// Number of mistake records flagged as lollapaloozas.
+    pub lollapalooza_count: i32,
+    /// Number of omission mistake records.
+    pub omission_count: i32,
+    /// Number of commission mistake records.
+    pub commission_count: i32,
+    /// Whether lollapalooza frequency warrants standing down.
+    pub standdown_recommended: bool,
+    /// Whether one tendency appears in more than half of mistake records.
+    pub mechanical_antidote_needed: bool,
+}
+
 /// Calculator for trading performance metrics and statistics
 #[derive(Debug)]
 pub struct PerformanceCalculator;
+
+/// Calculator for aggregating post-trade mistake bias tendencies.
+#[derive(Debug)]
+pub struct BiasAggregationCalculator;
+
+impl BiasAggregationCalculator {
+    /// Aggregate mistake records into a bias summary for the provided window length.
+    pub fn calculate(mistakes: &[Mistake], window_days: i32) -> BiasAggregation {
+        let total_mistakes = Self::count_as_i32(mistakes.len());
+        let mut tendency_counts: BTreeMap<i32, i32> = BTreeMap::new();
+        let mut lollapalooza_count = 0_i32;
+        let mut omission_count = 0_i32;
+        let mut commission_count = 0_i32;
+
+        for mistake in mistakes {
+            for tendency in &mistake.bias_tags {
+                let number = i32::from(tendency.number());
+                let count = tendency_counts.entry(number).or_insert(0);
+                *count = count.saturating_add(1);
+            }
+
+            if mistake.lollapalooza {
+                lollapalooza_count = lollapalooza_count.saturating_add(1);
+            }
+
+            match mistake.error_type {
+                MistakeErrorType::Omission => omission_count = omission_count.saturating_add(1),
+                MistakeErrorType::Commission => {
+                    commission_count = commission_count.saturating_add(1);
+                }
+            }
+        }
+
+        let most_frequent_tendency = tendency_counts
+            .into_iter()
+            .max_by(|left, right| left.1.cmp(&right.1).then_with(|| right.0.cmp(&left.0)));
+        let mechanical_antidote_needed = most_frequent_tendency
+            .map(|(_, count)| count.saturating_mul(2) > total_mistakes)
+            .unwrap_or(false);
+        let standdown_recommended = lollapalooza_count >= 2;
+
+        BiasAggregation {
+            window_days,
+            total_mistakes,
+            most_frequent_tendency,
+            lollapalooza_count,
+            omission_count,
+            commission_count,
+            standdown_recommended,
+            mechanical_antidote_needed,
+        }
+    }
+
+    fn count_as_i32(count: usize) -> i32 {
+        i32::try_from(count).unwrap_or(i32::MAX)
+    }
+}
 
 impl PerformanceCalculator {
     /// Calculate win rate as percentage (0.0 to 100.0)
@@ -249,6 +329,27 @@ mod tests {
     use super::*;
     use model::trade::Trade;
 
+    fn create_test_mistake(
+        bias_tags: Vec<model::MungerTendency>,
+        lollapalooza: bool,
+        error_type: MistakeErrorType,
+    ) -> Mistake {
+        let now = chrono::Utc::now().naive_utc();
+        Mistake {
+            id: uuid::Uuid::new_v4(),
+            created_at: now,
+            updated_at: now,
+            deleted_at: None,
+            trade_id: uuid::Uuid::new_v4(),
+            bias_tags,
+            lollapalooza,
+            error_type,
+            rule_violated: None,
+            counterfactual_r: Decimal::ZERO,
+            lesson: "lesson".to_string(),
+        }
+    }
+
     fn create_test_trade(
         entry_price: Decimal,
         stop_price: Decimal,
@@ -284,6 +385,90 @@ mod tests {
         trade.balance.total_performance = performance;
         trade.category = category;
         trade
+    }
+
+    #[test]
+    fn test_bias_aggregation_counts_tendencies_and_thresholds() {
+        let mistakes = vec![
+            create_test_mistake(
+                vec![
+                    model::MungerTendency::DeprivalSuperreaction,
+                    model::MungerTendency::SocialProof,
+                ],
+                false,
+                MistakeErrorType::Commission,
+            ),
+            create_test_mistake(
+                vec![model::MungerTendency::DeprivalSuperreaction],
+                false,
+                MistakeErrorType::Omission,
+            ),
+            create_test_mistake(
+                vec![
+                    model::MungerTendency::DeprivalSuperreaction,
+                    model::MungerTendency::Lollapalooza,
+                ],
+                true,
+                MistakeErrorType::Commission,
+            ),
+            create_test_mistake(
+                vec![
+                    model::MungerTendency::InconsistencyAvoidance,
+                    model::MungerTendency::Lollapalooza,
+                ],
+                true,
+                MistakeErrorType::Omission,
+            ),
+            create_test_mistake(
+                vec![model::MungerTendency::Overoptimism],
+                false,
+                MistakeErrorType::Commission,
+            ),
+        ];
+
+        let aggregation = BiasAggregationCalculator::calculate(&mistakes, 7);
+
+        assert_eq!(aggregation.window_days, 7);
+        assert_eq!(aggregation.total_mistakes, 5);
+        assert_eq!(aggregation.most_frequent_tendency, Some((14, 3)));
+        assert_eq!(aggregation.lollapalooza_count, 2);
+        assert_eq!(aggregation.omission_count, 2);
+        assert_eq!(aggregation.commission_count, 3);
+        assert!(aggregation.standdown_recommended);
+        assert!(aggregation.mechanical_antidote_needed);
+    }
+
+    #[test]
+    fn test_bias_aggregation_requires_strict_majority_and_ties_by_lowest_tendency() {
+        let mistakes = vec![
+            create_test_mistake(
+                vec![model::MungerTendency::DeprivalSuperreaction],
+                false,
+                MistakeErrorType::Commission,
+            ),
+            create_test_mistake(
+                vec![model::MungerTendency::DeprivalSuperreaction],
+                false,
+                MistakeErrorType::Omission,
+            ),
+            create_test_mistake(
+                vec![model::MungerTendency::InconsistencyAvoidance],
+                true,
+                MistakeErrorType::Commission,
+            ),
+            create_test_mistake(
+                vec![model::MungerTendency::InconsistencyAvoidance],
+                false,
+                MistakeErrorType::Omission,
+            ),
+        ];
+
+        let aggregation = BiasAggregationCalculator::calculate(&mistakes, 14);
+
+        assert_eq!(aggregation.most_frequent_tendency, Some((5, 2)));
+        assert!(!aggregation.mechanical_antidote_needed);
+        assert_eq!(aggregation.lollapalooza_count, 1);
+        assert!(!aggregation.standdown_recommended);
     }
 
     #[test]

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -45,6 +45,7 @@ use argon2::{
 };
 use broker_registry::BrokerRegistry;
 use calculators_fixed_income::{BondAnalytics, BondAnalyticsInput, FixedIncomeCalculator};
+use calculators_performance::{BiasAggregation, BiasAggregationCalculator};
 use calculators_trade::{
     LevelAdjustedQuantity, QuantityCalculator, TradeHypothesis, TradeHypothesisCalculator,
 };
@@ -871,6 +872,29 @@ impl TrustFacade {
         self.factory
             .mistake_read()
             .read_mistakes_for_trade(trade_id)
+    }
+
+    /// Aggregate post-trade mistake bias patterns for an account over a lookback window.
+    pub fn bias_aggregation_for_account(
+        &mut self,
+        account_id: Uuid,
+        window_days: i32,
+    ) -> Result<BiasAggregation, Box<dyn std::error::Error>> {
+        if window_days <= 0 {
+            return Err("bias aggregation window_days must be positive".into());
+        }
+
+        self.ensure_account_exists(account_id)?;
+        let end_at = chrono::Utc::now().naive_utc();
+        let start_at = end_at
+            .checked_sub_signed(chrono::Duration::days(i64::from(window_days)))
+            .ok_or("bias aggregation window is out of range")?;
+        let mistakes = self
+            .factory
+            .mistake_read()
+            .read_mistakes_for_account_in_period(account_id, start_at, end_at)?;
+
+        Ok(BiasAggregationCalculator::calculate(&mistakes, window_days))
     }
 
     /// Persist a new open plan-act-review session plan.


### PR DESCRIPTION
## Summary
- add a core `BiasAggregation` calculator for Mistake records over a configurable window
- expose `TrustFacade::bias_aggregation_for_account` and wire `report bias-summary` for JSON and human output
- add parser/dispatcher coverage plus a JSON snapshot contract for the new report

Closes #116

## Verification
- `cargo test -p core bias_aggregation`
- `cargo test -p trust-cli bias_summary -- --test-threads=1`
- `UPDATE_SNAPSHOTS=1 cargo test -p trust-cli --test integration_test_report_json_snapshots -- --test-threads=1`
- `cargo test -p trust-cli command_routing -- --test-threads=1`
- `cargo test -p trust-cli --test integration_test_report_json_snapshots -- --test-threads=1`
- `cargo clippy -p core -p trust-cli --all-targets --all-features -- -D warnings`
- `cargo test -p trust-cli -- --test-threads=1`
- `make ci-fast`
- `cargo test --locked --no-default-features --workspace`
- `cargo test --locked --all-features --workspace`