### PR TITLE
docs: add project documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,15 @@ Trust is a comprehensive algorithmic trading system written in Rust that enforce
 
 📚 **Full Documentation**: https://deepwiki.com/matiasvillaverde/trust
 
+## Project Documentation
+
+Local documentation lives in [`docs/`](docs/README.md):
+
+- [Getting Started](docs/getting-started.md)
+- [Architecture](docs/architecture.md)
+- [CLI Reference](docs/cli-reference.md)
+- [Core Concepts](docs/core-concepts.md)
+
 ## What Trust Does
 
 Trust solves a critical problem in algorithmic trading: **enforcing risk management rules automatically**. Many traders struggle with discipline when it comes to position sizing and risk limits. Trust addresses this by:

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,16 @@
+# Trust Documentation
+
+This directory contains the project documentation for Trust, a risk-managed trading system built as a Rust workspace.
+
+## Start Here
+
+- [Getting Started](getting-started.md): local setup, database setup, broker keys, and first risk-managed trade.
+- [Architecture](architecture.md): crate boundaries, data flow, trade state machine, broker integration, and sync model.
+- [CLI Reference](cli-reference.md): command groups, common flags, and representative examples.
+- [Core Concepts](core-concepts.md): risk rules, levels, advisors, grading, session plans, mistakes, and distribution.
+
+## Specialized Notes
+
+- [Interactive Brokers E2E](interactive-brokers-e2e.md)
+- [Multi-Asset Completion Audit](multi-asset-completion-audit.md)
+- [Trust Proof](trust-proof.md)

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,103 @@
+# Architecture
+
+Trust is organized as a Rust workspace with strict boundaries between domain types, business logic, persistence, brokers, and CLI presentation.
+
+## Workspace Crates
+
+- `trust-model`: domain types and trait contracts. Monetary values use `rust_decimal::Decimal`.
+- `core`: business logic and the `TrustFacade` entry point.
+- `db-sqlite`: Diesel-backed SQLite implementation of the database factory traits.
+- `trust-cli`: Clap CLI, dialogs, command routing, and user-facing views.
+- `alpaca-broker`: Alpaca implementation of the `Broker` trait.
+- `ibkr-broker`: Interactive Brokers implementation and gateway adapters.
+- `broker-sync`: actor-based realtime sync and reconciliation support.
+- `advisor`: advisory checks for catalyst, correlation, regime, and position heat.
+
+## Dependency Direction
+
+The intended runtime flow is:
+
+```text
+CLI -> core::TrustFacade -> model traits -> db/broker implementations
+```
+
+The CLI should not call the database or broker directly for business decisions. It parses arguments, asks dialogs, calls core, and renders results. Core validates and coordinates state transitions. Database and broker crates implement the traits defined in `trust-model`.
+
+## Core Facade
+
+`TrustFacade` is the single public business-logic entry point used by the CLI. It owns:
+
+- account and transaction operations
+- trade creation, funding, submission, sync, cancellation, and close workflows
+- risk validation before capital commitment
+- level evaluation and adjustment
+- distribution rules and execution
+- grading, catalyst events, mistakes, session plans, and reports
+- advisor checks and broker registry routing
+
+This keeps user-facing commands thin and makes tests exercise the same path real users exercise.
+
+## Database Layer
+
+`DatabaseFactory` returns specialized read/write trait objects such as account, trade, order, execution, grade, mistake, and session-plan readers/writers. SQLite implements those traits in `db-sqlite`.
+
+Schema changes are made through migrations:
+
+```bash
+make migration NAME=descriptive_name
+make build
+```
+
+Do not manually edit `db-sqlite/src/schema.rs`; Diesel generates it.
+
+## Trade State Machine
+
+Trades move through explicit states:
+
+```text
+Draft/New -> Funded -> Submitted -> Filled -> ClosedTarget | ClosedStopLoss
+                         |              |
+                         |              -> Canceled for manual close/cancel paths
+                         -> Canceled
+```
+
+Each trade owns three order records:
+
+- entry order
+- safety stop order
+- target order
+
+State transitions are persisted with transaction records so capital reservation, fills, fees, and releases are auditable.
+
+## Risk Validation Flow
+
+Funding is the main capital commitment boundary:
+
+```text
+CLI command
+  -> TrustFacade
+  -> validators and calculators
+  -> database reads for balances, rules, and open exposure
+  -> database writes for funded trade and fund transaction
+```
+
+Submission happens after funding. Broker calls do not decide whether a trade is acceptable; core does that first.
+
+## Broker Integration
+
+Brokers implement `model::Broker`. The core broker registry routes operations based on account broker kind. Broker crates are responsible for mapping broker-specific order payloads, statuses, market data, executions, and fees into Trust domain objects.
+
+Broker operations are split by behavior. For Alpaca, submit, sync, close, cancel, and modify operations each have dedicated modules.
+
+## Event-Driven Review
+
+Closed trades feed post-trade processes:
+
+- trade grading
+- profit distribution
+- level evaluation
+- catalyst event review
+- mistake and bias autopsy
+- session plan review
+
+The key principle is that closing a trade creates data for both accounting and future decision quality, not just a terminal trade status.

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -1,0 +1,171 @@
+# CLI Reference
+
+Run `trust --help` for the authoritative command list and `trust <command> --help` for command-specific flags. Many commands support interactive prompts when required arguments are omitted.
+
+## Global Patterns
+
+- JSON output: many reporting/list commands accept `--format json`.
+- Human output: report commands default to text/human output; some commands also accept `--format human`.
+- Protected changes: sensitive mutations may require `--confirm-protected <keyword>`.
+- Account arguments: commands generally accept account UUIDs; some flows can resolve account names.
+
+## Database
+
+```bash
+trust db export --output backup.json
+trust db import --input backup.json --mode strict
+```
+
+Use database export/import for full SQLite backup and restore workflows.
+
+## Keys And Onboarding
+
+```bash
+trust onboarding init
+trust onboarding status --format json
+trust keys create
+trust keys show
+trust keys delete
+trust keys protected-set --value "<keyword>"
+trust keys protected-show
+trust keys protected-delete --confirm-protected "<keyword>"
+```
+
+Use onboarding and protected keywords before running agent-driven or automated mutation workflows.
+
+## Accounts And Capital
+
+```bash
+trust accounts create
+trust accounts search
+trust accounts list --hierarchy
+trust accounts balance --detailed
+trust accounts transfer --from <account-id> --to <account-id> --amount 100 --reason "rebalance"
+
+trust transaction deposit --account <account-id> --amount 1000 --currency USD
+trust transaction withdraw --account <account-id> --amount 100 --currency USD
+```
+
+Account hierarchy supports primary, earnings, tax reserve, and reinvestment accounts.
+
+## Rules And Levels
+
+```bash
+trust rule create
+trust rule remove
+
+trust level status --account <account-id>
+trust level triggers
+trust level history --account <account-id> --days 30
+trust level change --account <account-id> --level 2 --reason "manual review"
+trust level evaluate --account <account-id> --apply
+trust level progress --account <account-id>
+trust level rules show --account <account-id>
+trust level rules set --account <account-id> --rule <key> --value <value>
+```
+
+Rules define base risk limits. Levels adjust allowable position size and can change from performance policy.
+
+## Trading Vehicles
+
+```bash
+trust trading-vehicle create
+trust trading-vehicle search --symbol AAPL --format json
+trust trading-vehicle update-bond-terms --id <vehicle-id>
+trust trading-vehicle stats --format json
+```
+
+Trading vehicles include broker identity, category, optional ISIN, sector/asset-class metadata, and optional fixed-income terms for bonds.
+
+## Trade Lifecycle
+
+```bash
+trust trade create
+trust trade size-preview --account <account-id> --entry 100 --stop 95
+trust trade hypothesis --account <account-id> --entry 100 --stop 95 --target 115 --quantity 10
+trust trade fund
+trust trade submit
+trust trade sync
+trust trade watch
+trust trade cancel
+trust trade manually-fill
+trust trade manually-stop
+trust trade manually-target
+trust trade manually-close
+trust trade modify-stop
+trust trade modify-target
+trust trade search --account <account-id> --status filled --format json
+trust trade list-open --account <account-id> --format json
+trust trade reconcile --account <account-id>
+```
+
+Trades should move through create, fund, submit, sync, and close paths. Manual commands exist for broker-independent workflows and reconciliation.
+
+## Trade Review
+
+```bash
+trust grade show --trade-id <trade-id> --format json
+trust grade summary --account <account-id> --days 30
+trust trade events add --trade-id <trade-id>
+trust trade events list --trade-id <trade-id> --format json
+trust trade autopsy --trade-id <trade-id>
+```
+
+Use these commands after a trade closes to capture process quality, catalysts, mistakes, and bias tags.
+
+## Sessions
+
+```bash
+trust session open --account <account-id>
+trust session close --account <account-id>
+trust session list --account <account-id> --format json
+```
+
+Session plans capture pre-session regime, permitted setups, max new positions, hypothesis, and review notes.
+
+## Reports
+
+```bash
+trust report summary --account <account-id> --format json
+trust report performance --account <account-id> --days 30
+trust report drawdown --account <account-id>
+trust report risk --account <account-id>
+trust report concentration --account <account-id> --open-only
+trust report metrics --account <account-id> --days 30
+trust report attribution --account <account-id> --by symbol --from 2026-01-01 --to 2026-01-31
+trust report benchmark --account <account-id> --benchmark SPY --from 2026-01-01 --to 2026-01-31
+trust report timeline --account <account-id> --granularity week --from 2026-01-01 --to 2026-01-31
+trust report bias-summary --account <account-id> --days 7 --format json
+```
+
+Reports use core calculators and database reads; JSON report snapshots are contract-tested.
+
+## Advisors And Market Data
+
+```bash
+trust advisor configure --account <account-id>
+trust advisor check --account <account-id> --symbol AAPL
+trust advisor status --account <account-id> --format json
+trust advisor history --account <account-id>
+
+trust market-data snapshot --account <account-id> --symbol AAPL --format json
+trust market-data bars --account <account-id> --symbol AAPL --timeframe 1d --start 2026-01-01T00:00:00Z --end 2026-02-01T00:00:00Z
+trust market-data stream --account <account-id> --symbols AAPL,MSFT --channels bars,quotes --max-events 10
+trust market-data quote --account <account-id> --symbol AAPL
+trust market-data trade --account <account-id> --symbol AAPL
+trust market-data session --account <account-id> --symbol AAPL
+```
+
+Advisor commands combine concentration, catalyst, correlation, and regime checks. Market-data commands normalize broker responses into Trust domain payloads.
+
+## Distribution And Policy
+
+```bash
+trust distribution configure --account <account-id>
+trust distribution execute --account-id <account-id> --amount 100
+trust distribution history --account-id <account-id>
+trust distribution rules show --account-id <account-id>
+trust policy --format json
+```
+
+Distribution rules split realized profits into earnings, taxes, and reinvestment according to configured percentages.

--- a/docs/core-concepts.md
+++ b/docs/core-concepts.md
@@ -1,0 +1,77 @@
+# Core Concepts
+
+Trust is designed around mechanical risk control. The important concepts below show how account data, risk rules, trades, reviews, and distributions fit together.
+
+## Accounts
+
+Accounts hold balances and broker configuration. Primary trading accounts can have child accounts for earnings, tax reserve, and reinvestment. Transfers between related accounts are recorded as transaction pairs.
+
+## Trading Vehicles
+
+A trading vehicle represents a tradable instrument such as a stock, ETF, crypto asset, or bond. Vehicles store normalized identity and metadata so concentration reports, advisor checks, and broker adapters can reason about the same security consistently.
+
+## Risk Rules
+
+Risk rules define boundaries such as maximum risk per trade and maximum monthly risk. Funding a trade reads active rules, account capital, existing exposure, and proposed trade geometry before reserving capital.
+
+Risk is based on planned entry and stop distance. For long trades, the stop must be below entry. For short trades, the stop must be above entry.
+
+## Levels
+
+Levels adjust how much size a trader is allowed to take. Level policy can evaluate recent performance and move an account up, down, or into cooldown. Level-adjusted quantity appears in sizing previews and funding validation.
+
+## Trade Lifecycle
+
+The normal lifecycle is:
+
+```text
+New -> Funded -> Submitted -> Filled -> ClosedTarget | ClosedStopLoss
+```
+
+Funding reserves capital. Submission creates broker orders. Sync reconciles broker status, fills, fees, executions, and close conditions. Manual fill/stop/target/close commands support workflows where the broker is not the source of truth.
+
+## Orders
+
+Every trade has three planned orders:
+
+- entry
+- safety stop
+- target
+
+Broker implementations map these local orders to broker-specific payloads and broker order IDs.
+
+## Transactions
+
+Transactions are the accounting record. Deposits and withdrawals move account cash. Funding, fills, close payments, fees, distributions, and transfers all create auditable rows. Reports derive realized equity and capital-at-risk from these records plus trade state.
+
+## Advisors
+
+Advisors produce pre-trade warnings and blocks from portfolio concentration, catalyst calendar events, correlation clusters, and market regime. Advisor output should inform trade selection before funding.
+
+## Grading
+
+Closed trades can be graded with weighted criteria. Grade summaries make process quality visible across windows and accounts. Regrading creates a new grade snapshot rather than mutating away the history.
+
+## Mistakes And Bias Tags
+
+Trade autopsy records structured mistakes with Munger tendency tags, commission/omission classification, lollapalooza flags, optional violated rules, counterfactual R, and a lesson. `report bias-summary` aggregates those mistakes over a window and flags repeated tendencies or multiple lollapaloozas.
+
+## Session Plans
+
+Session plans capture the pre-session plan:
+
+- market regime
+- permitted setups
+- maximum new positions
+- hypothesis
+- success and failure criteria
+
+Closing a session compares actual trades against permitted setups and records adherence notes and a grade.
+
+## Distribution
+
+Distribution rules split realized profit between earnings, taxes, and reinvestment accounts once profit is available. Distribution execution writes the transfer legs and a history row atomically.
+
+## Protected Mode
+
+Protected mode uses a keyword to authorize critical mutations. Use it when running automated workflows or delegating work to agents so destructive operations require an explicit confirmation token.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,0 +1,115 @@
+# Getting Started
+
+Trust is a local-first trading workflow for designing, validating, funding, submitting, syncing, and reviewing trades. The CLI talks to `core::TrustFacade`; broker and database details stay behind core traits.
+
+## Prerequisites
+
+- Rust toolchain with Cargo.
+- SQLite development libraries.
+- Diesel CLI with SQLite support:
+
+```bash
+cargo install diesel_cli --no-default-features --features sqlite
+```
+
+- Broker credentials for the environment you intend to use. Alpaca is supported for normal broker execution. Interactive Brokers support is available for configured IBKR accounts and related workflows.
+
+## Local Setup
+
+```bash
+git clone https://github.com/matiasvillaverde/trust.git
+cd trust
+make build
+```
+
+Useful verification commands:
+
+```bash
+make ci-fast
+cargo test -p trust-cli -- --test-threads=1
+cargo test --locked --no-default-features --workspace
+```
+
+SQLite defaults to the project database configuration. For isolated local runs, set `TRUST_DB_URL`:
+
+```bash
+export TRUST_DB_URL="file:trust-dev.db"
+```
+
+## First Account
+
+Create an account, deposit capital, and define a risk rule before creating trades:
+
+```bash
+trust accounts create
+trust transaction deposit
+trust rule create
+```
+
+Most commands support interactive prompts. For automation or tests, use command-specific flags shown in `trust <command> <subcommand> --help`.
+
+## Broker Keys
+
+Store broker credentials through the key commands:
+
+```bash
+trust keys create
+trust keys show
+```
+
+Protected mutations can be guarded by a keyword:
+
+```bash
+trust onboarding init
+trust onboarding status
+trust keys protected-set --value "<keyword>"
+```
+
+Use paper trading credentials while validating setup. Critical account and policy changes should use protected mode where available.
+
+## First Trading Vehicle
+
+Register a security before creating a trade:
+
+```bash
+trust trading-vehicle create
+trust trading-vehicle search --symbol AAPL
+```
+
+Trust supports stocks, ETFs, crypto, and bonds in the model and database. Broker-specific availability depends on the configured broker.
+
+## First Risk-Managed Trade
+
+The normal lifecycle is:
+
+```bash
+trust trade create
+trust trade size-preview --account <account-id> --entry <price> --stop <price>
+trust trade fund
+trust trade submit
+trust trade sync
+```
+
+Every trade has an entry, safety stop, and target order. Funding validates risk before capital is reserved. Submitting sends the broker order only after the trade is funded.
+
+After exit:
+
+```bash
+trust grade show --trade-id <trade-id>
+trust trade autopsy --trade-id <trade-id>
+trust report bias-summary --account <account-id> --days 7
+```
+
+## Daily Workflow
+
+Use session plans and advisor checks to keep decisions mechanical:
+
+```bash
+trust session open --account <account-id>
+trust trade advisor --account <account-id> --symbol AAPL --entry 100 --stop 95 --target 115 --quantity 10
+trust report risk --account <account-id>
+trust report concentration --account <account-id>
+trust session close --account <account-id>
+```
+
+For JSON output, add `--format json` to supported report and list commands.


### PR DESCRIPTION
## Summary
- add docs index plus getting started, architecture, CLI reference, and core concepts pages
- link the local documentation set from the README
- document setup, broker keys, trade workflow, command groups, and risk-management concepts

Closes #101

## Verification
- `cargo run -p trust-cli -- --help`
- `git diff --check`
- `make ci-fast`