### PR TITLE
feat(core): add protected account deletion

### DIFF
--- a/cli/src/command_routing.rs
+++ b/cli/src/command_routing.rs
@@ -41,6 +41,7 @@ pub enum AccountsSubcommand<'a> {
     List(&'a ArgMatches),
     Balance(&'a ArgMatches),
     Transfer(&'a ArgMatches),
+    Delete(&'a ArgMatches),
 }
 
 pub enum TransactionsSubcommand<'a> {
@@ -210,6 +211,7 @@ pub fn parse_accounts_subcommand(sub_matches: &ArgMatches) -> AccountsSubcommand
         Some(("list", sub_sub_matches)) => AccountsSubcommand::List(sub_sub_matches),
         Some(("balance", sub_sub_matches)) => AccountsSubcommand::Balance(sub_sub_matches),
         Some(("transfer", sub_sub_matches)) => AccountsSubcommand::Transfer(sub_sub_matches),
+        Some(("delete", sub_sub_matches)) => AccountsSubcommand::Delete(sub_sub_matches),
         _ => unreachable!("No subcommand provided"),
     }
 }
@@ -757,7 +759,8 @@ mod tests {
                 .subcommand(Command::new("search"))
                 .subcommand(Command::new("list"))
                 .subcommand(Command::new("balance"))
-                .subcommand(Command::new("transfer")),
+                .subcommand(Command::new("transfer"))
+                .subcommand(Command::new("delete")),
         );
         for (sub, expected) in [
             ("create", "create"),
@@ -765,6 +768,7 @@ mod tests {
             ("list", "list"),
             ("balance", "balance"),
             ("transfer", "transfer"),
+            ("delete", "delete"),
         ] {
             let m = account.clone().get_matches_from(["trust", "account", sub]);
             let (_, sm) = m.subcommand().expect("expected account");
@@ -774,6 +778,7 @@ mod tests {
                 AccountsSubcommand::List(_) => "list",
                 AccountsSubcommand::Balance(_) => "balance",
                 AccountsSubcommand::Transfer(_) => "transfer",
+                AccountsSubcommand::Delete(_) => "delete",
             };
             assert_eq!(got, expected);
         }

--- a/cli/src/commands/account_command.rs
+++ b/cli/src/commands/account_command.rs
@@ -144,6 +144,36 @@ impl AccountCommandBuilder {
         self
     }
 
+    pub fn delete_account(mut self) -> Self {
+        self.subcommands.push(
+            Command::new("delete")
+                .about("Delete an account after safety checks")
+                .arg(
+                    Arg::new("account")
+                        .long("account")
+                        .short('a')
+                        .value_name("UUID")
+                        .help("Account ID to delete")
+                        .required(true),
+                )
+                .arg(
+                    Arg::new("force")
+                        .long("force")
+                        .help("Bypass the zero-balance check")
+                        .action(clap::ArgAction::SetTrue)
+                        .required(false),
+                )
+                .arg(
+                    Arg::new("confirm-protected")
+                        .long("confirm-protected")
+                        .value_name("KEYWORD")
+                        .help("Protected mutation keyword")
+                        .required(false),
+                ),
+        );
+        self
+    }
+
     pub fn list_accounts(mut self) -> Self {
         self.subcommands.push(
             Command::new("list").about("List accounts").arg(
@@ -215,6 +245,21 @@ mod tests {
     fn balance_detailed_parses() {
         let cmd = AccountCommandBuilder::new().balance_accounts().build();
         let result = cmd.try_get_matches_from(["accounts", "balance", "--detailed"]);
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn delete_account_parses() {
+        let cmd = AccountCommandBuilder::new().delete_account().build();
+        let result = cmd.try_get_matches_from([
+            "accounts",
+            "delete",
+            "--account",
+            "550e8400-e29b-41d4-a716-446655440000",
+            "--force",
+            "--confirm-protected",
+            "secret",
+        ]);
         assert!(result.is_ok());
     }
 }

--- a/cli/src/dispatcher.rs
+++ b/cli/src/dispatcher.rs
@@ -608,6 +608,7 @@ impl ArgDispatcher {
             AccountsSubcommand::Transfer(transfer_matches) => {
                 self.transfer_accounts(transfer_matches)?
             }
+            AccountsSubcommand::Delete(delete_matches) => self.delete_account(delete_matches)?,
         }
         Ok(())
     }
@@ -1648,6 +1649,27 @@ impl ArgDispatcher {
                 println!("{} ({}) total={}", account.name, account.id, total);
             }
         }
+        Ok(())
+    }
+
+    fn delete_account(&mut self, matches: &ArgMatches) -> Result<(), CliError> {
+        self.ensure_protected_keyword(matches, ReportOutputFormat::Text, "account deletion")?;
+        let account_id = matches
+            .get_one::<String>("account")
+            .ok_or_else(|| CliError::new("missing_account", "Missing --account"))?;
+        let account_id = Uuid::parse_str(account_id)
+            .map_err(|_| CliError::new("invalid_uuid", "Invalid --account UUID"))?;
+        let force = matches.get_flag("force");
+
+        let account = self
+            .trust
+            .delete_account(account_id, force)
+            .map_err(|e| CliError::new("delete_account_failed", e.to_string()))?;
+
+        println!("Account deleted:");
+        println!("  id: {}", account.id);
+        println!("  name: {}", account.name);
+        println!("  force: {}", force);
         Ok(())
     }
 
@@ -10157,6 +10179,12 @@ mod tests {
             .arg(Arg::new("broker").long("broker"))
             .arg(Arg::new("broker-account-id").long("broker-account-id"))
             .arg(Arg::new("parent").long("parent"))
+            .arg(Arg::new("account").long("account"))
+            .arg(
+                Arg::new("force")
+                    .long("force")
+                    .action(clap::ArgAction::SetTrue),
+            )
             .get_matches_from(argv)
     }
 
@@ -10409,6 +10437,7 @@ mod tests {
                     .list_accounts()
                     .balance_accounts()
                     .transfer_account()
+                    .delete_account()
                     .build(),
             )
             .subcommand(
@@ -17327,6 +17356,128 @@ mod tests {
             .create_account(&duplicate)
             .expect_err("duplicate account creation should fail");
         assert!(error.to_string().contains("create_account_failed"));
+
+        std::env::remove_var("TRUST_PROTECTED_KEYWORD_EXPECTED");
+    }
+
+    #[test]
+    fn test_delete_account_requires_protected_keyword_and_deletes_zero_balance_account() {
+        let _guard = env_guard();
+        std::env::set_var("TRUST_PROTECTED_KEYWORD_EXPECTED", "secret");
+        let mut dispatcher = test_dispatcher();
+        let account = dispatcher
+            .trust
+            .create_account(
+                "delete-cli",
+                "delete",
+                Environment::Paper,
+                dec!(20),
+                dec!(10),
+            )
+            .expect("account should be created");
+        let account_id = account.id.to_string();
+
+        let missing = account_matches(&["--account", &account_id]);
+        let error = dispatcher
+            .delete_account(&missing)
+            .expect_err("protected keyword should be required");
+        assert!(error.to_string().contains("protected_keyword_required"));
+
+        let invalid = account_matches(&[
+            "--account",
+            &account_id,
+            "--confirm-protected",
+            "wrong-secret",
+        ]);
+        let error = dispatcher
+            .delete_account(&invalid)
+            .expect_err("invalid protected keyword should fail");
+        assert!(error.to_string().contains("protected_keyword_invalid"));
+
+        let valid = account_matches(&["--account", &account_id, "--confirm-protected", "secret"]);
+        dispatcher
+            .delete_account(&valid)
+            .expect("account deletion should succeed");
+        assert!(dispatcher.trust.search_account("delete-cli").is_err());
+        assert!(dispatcher
+            .trust
+            .search_all_accounts()
+            .expect("accounts should load")
+            .is_empty());
+
+        std::env::remove_var("TRUST_PROTECTED_KEYWORD_EXPECTED");
+    }
+
+    #[test]
+    fn test_delete_account_rejects_non_zero_balance_unless_forced() {
+        let _guard = env_guard();
+        std::env::set_var("TRUST_PROTECTED_KEYWORD_EXPECTED", "secret");
+        let mut dispatcher = test_dispatcher();
+        let account = dispatcher
+            .trust
+            .create_account(
+                "delete-balance-cli",
+                "delete",
+                Environment::Paper,
+                dec!(20),
+                dec!(10),
+            )
+            .expect("account should be created");
+        dispatcher
+            .trust
+            .create_transaction(
+                &account,
+                &TransactionCategory::Deposit,
+                dec!(50),
+                &Currency::USD,
+            )
+            .expect("deposit should create non-zero balance");
+        let account_id = account.id.to_string();
+
+        let safe_delete =
+            account_matches(&["--account", &account_id, "--confirm-protected", "secret"]);
+        let error = dispatcher
+            .delete_account(&safe_delete)
+            .expect_err("non-zero account should require force");
+        assert!(error.to_string().contains("non-zero balance"));
+
+        let forced = account_matches(&[
+            "--account",
+            &account_id,
+            "--force",
+            "--confirm-protected",
+            "secret",
+        ]);
+        dispatcher
+            .delete_account(&forced)
+            .expect("force should bypass zero-balance check");
+        assert!(dispatcher
+            .trust
+            .search_account("delete-balance-cli")
+            .is_err());
+
+        std::env::remove_var("TRUST_PROTECTED_KEYWORD_EXPECTED");
+    }
+
+    #[test]
+    fn test_delete_account_rejects_open_trades() {
+        let _guard = env_guard();
+        std::env::set_var("TRUST_PROTECTED_KEYWORD_EXPECTED", "secret");
+        let mut dispatcher = test_dispatcher();
+        let (account, _trade) = seed_new_trade(&mut dispatcher);
+        let account_id = account.id.to_string();
+        let matches = account_matches(&[
+            "--account",
+            &account_id,
+            "--force",
+            "--confirm-protected",
+            "secret",
+        ]);
+
+        let error = dispatcher
+            .delete_account(&matches)
+            .expect_err("account with open trades should not delete");
+        assert!(error.to_string().contains("open trade"));
 
         std::env::remove_var("TRUST_PROTECTED_KEYWORD_EXPECTED");
     }

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -86,6 +86,7 @@ fn build_cli() -> Command {
                 .list_accounts()
                 .balance_accounts()
                 .transfer_account()
+                .delete_account()
                 .build(),
         )
         .subcommand(

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -510,6 +510,31 @@ impl TrustFacade {
         self.factory.account_read().all()
     }
 
+    /// Soft-delete an account after protected-mode and database safety checks.
+    ///
+    /// `force` bypasses only the zero-balance check; open trades and active child
+    /// accounts remain protected by the database implementation.
+    pub fn delete_account(
+        &mut self,
+        account_id: Uuid,
+        force: bool,
+    ) -> Result<Account, Box<dyn std::error::Error>> {
+        self.consume_protected_authorization("delete_account")?;
+        let savepoint = "delete_account";
+        self.factory.begin_savepoint(savepoint)?;
+
+        let deleted = match self.factory.account_write().delete(account_id, force) {
+            Ok(account) => account,
+            Err(error) => {
+                let _ = self.factory.rollback_to_savepoint(savepoint);
+                return Err(error);
+            }
+        };
+
+        self.factory.release_savepoint(savepoint)?;
+        Ok(deleted)
+    }
+
     /// Retrieve all risk management rules for a specific account.
     ///
     /// # Arguments

--- a/db-sqlite/src/workers/accounts.rs
+++ b/db-sqlite/src/workers/accounts.rs
@@ -1,9 +1,9 @@
 use crate::error::{ConversionError, IntoDomainModel, IntoDomainModels};
-use crate::schema::accounts;
+use crate::schema::{accounts, accounts_balances, trades};
 use chrono::{NaiveDateTime, Utc};
 use diesel::prelude::*;
 use model::AccountRead;
-use model::{Account, AccountType, AccountWrite, BrokerKind, Environment};
+use model::{Account, AccountType, AccountWrite, BrokerKind, Environment, Status};
 use rust_decimal::Decimal;
 use std::error::Error;
 use std::str::FromStr;
@@ -29,6 +29,105 @@ impl AccountDB {
         self.connection.lock().map_err(|error| {
             format!("failed to acquire account database connection lock: {error}").into()
         })
+    }
+
+    fn ensure_no_active_children(
+        connection: &mut SqliteConnection,
+        account_id: Uuid,
+    ) -> Result<(), Box<dyn Error>> {
+        let child_names = accounts::table
+            .filter(accounts::deleted_at.is_null())
+            .filter(accounts::parent_account_id.eq(account_id.to_string()))
+            .select(accounts::name)
+            .load::<String>(connection)
+            .map_err(|error| {
+                error!("Error checking child accounts before deletion: {:?}", error);
+                error
+            })?;
+
+        if child_names.is_empty() {
+            return Ok(());
+        }
+
+        Err(format!(
+            "Cannot delete account with child accounts. Delete child accounts first: {}",
+            child_names.join(", ")
+        )
+        .into())
+    }
+
+    fn ensure_no_open_trades(
+        connection: &mut SqliteConnection,
+        account_id: Uuid,
+    ) -> Result<(), Box<dyn Error>> {
+        let open_statuses = [
+            Status::New,
+            Status::Funded,
+            Status::Submitted,
+            Status::PartiallyFilled,
+            Status::Filled,
+        ]
+        .into_iter()
+        .map(|status| status.to_string())
+        .collect::<Vec<_>>();
+
+        let open_trade_count = trades::table
+            .filter(trades::deleted_at.is_null())
+            .filter(trades::account_id.eq(account_id.to_string()))
+            .filter(trades::status.eq_any(open_statuses))
+            .count()
+            .get_result::<i64>(connection)
+            .map_err(|error| {
+                error!(
+                    "Error checking open trades before account deletion: {:?}",
+                    error
+                );
+                error
+            })?;
+
+        if open_trade_count == 0 {
+            return Ok(());
+        }
+
+        Err(
+            format!("Cannot delete account {account_id}: {open_trade_count} open trade(s) exist")
+                .into(),
+        )
+    }
+
+    fn ensure_zero_balances(
+        connection: &mut SqliteConnection,
+        account_id: Uuid,
+    ) -> Result<(), Box<dyn Error>> {
+        let balance_rows = accounts_balances::table
+            .filter(accounts_balances::deleted_at.is_null())
+            .filter(accounts_balances::account_id.eq(account_id.to_string()))
+            .select((
+                accounts_balances::total_balance,
+                accounts_balances::total_in_trade,
+                accounts_balances::total_available,
+                accounts_balances::taxed,
+                accounts_balances::total_earnings,
+            ))
+            .load::<BalanceSafetyRow>(connection)
+            .map_err(|error| {
+                error!(
+                    "Error checking account balances before account deletion: {:?}",
+                    error
+                );
+                error
+            })?;
+
+        for row in balance_rows {
+            if row.has_non_zero_amount()? {
+                return Err(format!(
+                    "Cannot delete account {account_id}: account has a non-zero balance. Use --force to bypass the zero-balance check"
+                )
+                .into());
+            }
+        }
+
+        Ok(())
     }
 }
 
@@ -142,6 +241,63 @@ impl AccountWrite for AccountDB {
             })?
             .into_domain_model()
     }
+
+    fn delete(&mut self, account_id: Uuid, force: bool) -> Result<Account, Box<dyn Error>> {
+        let mut guard = self.connection_guard()?;
+        let connection: &mut SqliteConnection = &mut guard;
+
+        let account = accounts::table
+            .filter(accounts::id.eq(account_id.to_string()))
+            .filter(accounts::deleted_at.is_null())
+            .first::<AccountSQLite>(connection)
+            .map_err(|error| {
+                error!("Error reading account before deletion: {:?}", error);
+                error
+            })?;
+
+        Self::ensure_no_active_children(connection, account_id)?;
+        Self::ensure_no_open_trades(connection, account_id)?;
+        if !force {
+            Self::ensure_zero_balances(connection, account_id)?;
+        }
+
+        let now = Utc::now().naive_utc();
+        diesel::update(
+            accounts_balances::table
+                .filter(accounts_balances::account_id.eq(account_id.to_string()))
+                .filter(accounts_balances::deleted_at.is_null()),
+        )
+        .set((
+            accounts_balances::updated_at.eq(now),
+            accounts_balances::deleted_at.eq(Some(now)),
+        ))
+        .execute(connection)
+        .map_err(|error| {
+            error!("Error soft-deleting account balances: {:?}", error);
+            error
+        })?;
+
+        diesel::update(
+            accounts::table
+                .filter(accounts::id.eq(account_id.to_string()))
+                .filter(accounts::deleted_at.is_null()),
+        )
+        .set((
+            accounts::updated_at.eq(now),
+            accounts::deleted_at.eq(Some(now)),
+        ))
+        .execute(connection)
+        .map_err(|error| {
+            error!("Error soft-deleting account: {:?}", error);
+            error
+        })?;
+
+        Ok(Account {
+            updated_at: now,
+            deleted_at: Some(now),
+            ..account.into_domain_model()?
+        })
+    }
 }
 
 impl AccountRead for AccountDB {
@@ -151,6 +307,7 @@ impl AccountRead for AccountDB {
 
         accounts::table
             .filter(accounts::name.eq(name.to_lowercase()))
+            .filter(accounts::deleted_at.is_null())
             .first::<AccountSQLite>(connection)
             .map_err(|error| {
                 error!("Error reading account: {:?}", error);
@@ -165,6 +322,7 @@ impl AccountRead for AccountDB {
 
         accounts::table
             .filter(accounts::id.eq(id.to_string()))
+            .filter(accounts::deleted_at.is_null())
             .first::<AccountSQLite>(connection)
             .map_err(|error| {
                 error!("Error reading account: {:?}", error);
@@ -283,12 +441,48 @@ struct NewAccount {
     broker_account_id: Option<String>,
 }
 
+#[derive(Queryable)]
+struct BalanceSafetyRow {
+    total_balance: String,
+    total_in_trade: String,
+    total_available: String,
+    taxed: String,
+    total_earnings: String,
+}
+
+impl BalanceSafetyRow {
+    fn has_non_zero_amount(&self) -> Result<bool, Box<dyn Error>> {
+        let amounts = [
+            (&self.total_balance, "total_balance"),
+            (&self.total_in_trade, "total_in_trade"),
+            (&self.total_available, "total_available"),
+            (&self.taxed, "taxed"),
+            (&self.total_earnings, "total_earnings"),
+        ];
+
+        for (value, field) in amounts {
+            let amount = Decimal::from_str(value).map_err(|_| {
+                ConversionError::new(field, "Failed to parse account balance amount")
+            })?;
+            if amount != Decimal::ZERO {
+                return Ok(true);
+            }
+        }
+
+        Ok(false)
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::workers::{WorkerOrder, WorkerTrade, WorkerTradingVehicle};
     use crate::SqliteDatabase;
     use diesel_migrations::*;
-    use model::DatabaseFactory;
+    use model::{
+        Currency, DatabaseFactory, DraftTrade, OrderAction, OrderCategory, TradeCategory,
+        TradingVehicleCategory,
+    };
     use rust_decimal_macros::dec;
     pub const MIGRATIONS: EmbeddedMigrations = embed_migrations!();
     // Declare a test database connection
@@ -342,6 +536,92 @@ mod tests {
         AccountDB {
             connection: Arc::new(Mutex::new(establish_connection())),
         }
+    }
+
+    fn create_account_balance(
+        db: &AccountDB,
+        account: &Account,
+        balance: Decimal,
+    ) -> model::AccountBalance {
+        let database = SqliteDatabase::new_from(Arc::clone(&db.connection));
+        let account_balance = database
+            .account_balance_write()
+            .create(account, &Currency::USD)
+            .expect("account balance should be created");
+        database
+            .account_balance_write()
+            .update(
+                &account_balance,
+                balance,
+                Decimal::ZERO,
+                balance,
+                Decimal::ZERO,
+            )
+            .expect("account balance should be updated")
+    }
+
+    fn create_open_trade(db: &AccountDB, account: &Account) {
+        let mut connection = db
+            .connection
+            .lock()
+            .expect("connection lock should be available");
+        let vehicle = WorkerTradingVehicle::create(
+            &mut connection,
+            "DELETEOPEN",
+            Some("DELETEOPEN"),
+            &TradingVehicleCategory::Stock,
+            "alpaca",
+        )
+        .expect("trading vehicle should be created");
+        let stop = WorkerOrder::create(
+            &mut connection,
+            dec!(90),
+            &Currency::USD,
+            10,
+            &OrderAction::Sell,
+            &OrderCategory::Stop,
+            &vehicle,
+        )
+        .expect("stop order should be created");
+        let entry = WorkerOrder::create(
+            &mut connection,
+            dec!(100),
+            &Currency::USD,
+            10,
+            &OrderAction::Buy,
+            &OrderCategory::Limit,
+            &vehicle,
+        )
+        .expect("entry order should be created");
+        let target = WorkerOrder::create(
+            &mut connection,
+            dec!(120),
+            &Currency::USD,
+            10,
+            &OrderAction::Sell,
+            &OrderCategory::Limit,
+            &vehicle,
+        )
+        .expect("target order should be created");
+
+        WorkerTrade::create(
+            &mut connection,
+            DraftTrade {
+                account: account.clone(),
+                trading_vehicle: vehicle,
+                quantity: 10,
+                currency: Currency::USD,
+                category: TradeCategory::Long,
+                thesis: None,
+                sector: None,
+                asset_class: None,
+                context: None,
+            },
+            &stop,
+            &entry,
+            &target,
+        )
+        .expect("open trade should be created");
     }
 
     fn poisoned_account_db() -> AccountDB {
@@ -398,6 +678,7 @@ mod tests {
             dec!(20),
             dec!(80),
         ));
+        assert_connection_lock_error(db.delete(Uuid::new_v4(), false));
         assert_connection_lock_error(db.for_name("locked account"));
         assert_connection_lock_error(db.id(Uuid::new_v4()));
         assert_connection_lock_error(db.all());
@@ -713,6 +994,119 @@ mod tests {
     }
 
     #[test]
+    fn delete_soft_deletes_zero_balance_account_and_hides_it_from_reads() {
+        let mut db = account_db();
+        let account = db
+            .create(
+                "Delete Zero Balance",
+                "delete",
+                Environment::Paper,
+                dec!(20),
+                dec!(80),
+            )
+            .expect("account should be created");
+        create_account_balance(&db, &account, Decimal::ZERO);
+
+        let deleted = db
+            .delete(account.id, false)
+            .expect("zero balance account should delete");
+
+        assert_eq!(deleted.id, account.id);
+        assert!(deleted.deleted_at.is_some());
+        assert!(db.id(account.id).is_err());
+        assert!(db.for_name("delete zero balance").is_err());
+        assert!(db.all().expect("active accounts should read").is_empty());
+
+        let database = SqliteDatabase::new_from(Arc::clone(&db.connection));
+        assert!(database
+            .account_balance_read()
+            .for_account(account.id)
+            .expect("balances should read")
+            .is_empty());
+    }
+
+    #[test]
+    fn delete_rejects_non_zero_balance_unless_forced() {
+        let mut db = account_db();
+        let account = db
+            .create(
+                "Delete Non Zero Balance",
+                "delete",
+                Environment::Paper,
+                dec!(20),
+                dec!(80),
+            )
+            .expect("account should be created");
+        create_account_balance(&db, &account, dec!(25));
+
+        let error = db
+            .delete(account.id, false)
+            .expect_err("non-zero account should require force");
+        assert_error_mentions(error, "non-zero balance");
+
+        let deleted = db
+            .delete(account.id, true)
+            .expect("force should bypass zero-balance check");
+        assert_eq!(deleted.id, account.id);
+        assert!(deleted.deleted_at.is_some());
+    }
+
+    #[test]
+    fn delete_rejects_accounts_with_active_children() {
+        let mut db = account_db();
+        let parent = db
+            .create(
+                "Delete Parent",
+                "delete",
+                Environment::Paper,
+                dec!(20),
+                dec!(80),
+            )
+            .expect("parent account should be created");
+        let child = db
+            .create_with_hierarchy(
+                "Delete Child",
+                "child",
+                Environment::Paper,
+                dec!(20),
+                dec!(80),
+                AccountType::Earnings,
+                Some(parent.id),
+            )
+            .expect("child account should be created");
+
+        let error = db
+            .delete(parent.id, true)
+            .expect_err("parent with active child should not delete");
+        assert_error_mentions(error, "child accounts");
+
+        db.delete(child.id, true)
+            .expect("child account should delete first");
+        db.delete(parent.id, true)
+            .expect("parent should delete after child");
+    }
+
+    #[test]
+    fn delete_rejects_accounts_with_open_trades() {
+        let mut db = account_db();
+        let account = db
+            .create(
+                "Delete Open Trade",
+                "delete",
+                Environment::Paper,
+                dec!(20),
+                dec!(80),
+            )
+            .expect("account should be created");
+        create_open_trade(&db, &account);
+
+        let error = db
+            .delete(account.id, true)
+            .expect_err("open trade account should not delete");
+        assert_error_mentions(error, "open trade");
+    }
+
+    #[test]
     fn read_all_surfaces_corrupt_row_id() {
         let mut db = account_db();
         {
@@ -750,6 +1144,11 @@ mod tests {
                 dec!(80),
             )
             .expect_err("missing accounts table should fail create");
+        assert_error_mentions(error, "accounts");
+
+        let error = db
+            .delete(Uuid::new_v4(), true)
+            .expect_err("missing accounts table should fail delete");
         assert_error_mentions(error, "accounts");
 
         let error = db

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -41,12 +41,15 @@ trust accounts search
 trust accounts list --hierarchy
 trust accounts balance --detailed
 trust accounts transfer --from <account-id> --to <account-id> --amount 100 --reason "rebalance"
+trust accounts delete --account <account-id> --confirm-protected "<keyword>"
+trust accounts delete --account <account-id> --force --confirm-protected "<keyword>"
 
 trust transaction deposit --account <account-id> --amount 1000 --currency USD
 trust transaction withdraw --account <account-id> --amount 100 --currency USD
 ```
 
 Account hierarchy supports primary, earnings, tax reserve, and reinvestment accounts.
+Deletion is protected, blocks open trades and active child accounts, and requires zero balances unless `--force` is supplied.
 
 ## Rules And Levels
 

--- a/model/src/database.rs
+++ b/model/src/database.rs
@@ -175,6 +175,17 @@ pub trait AccountWrite {
             parent_account_id,
         )
     }
+
+    /// Soft-deletes an account after implementation-specific safety checks.
+    ///
+    /// `force` may bypass zero-balance checks, but implementations should still
+    /// protect account hierarchy integrity and open trade state.
+    fn delete(&mut self, account_id: Uuid, _force: bool) -> Result<Account, Box<dyn Error>> {
+        Err(format!(
+            "account deletion is not supported by this database implementation: {account_id}"
+        )
+        .into())
+    }
 }
 
 /// Trait for reading account balance data from the database


### PR DESCRIPTION
## Summary
- add account soft-delete support to the model contract, SQLite worker, and TrustFacade
- enforce deletion safety checks for active child accounts, open trades, and non-zero balances unless --force is used
- add the protected accounts delete CLI command plus routing, docs, and regression coverage

Closes #97

## Verification
- cargo test -p db-sqlite workers::accounts::tests --lib
- cargo test -p core delete_account
- cargo test -p trust-cli delete_account -- --test-threads=1
- cargo test -p trust-cli command_routing -- --test-threads=1
- cargo clippy -p trust-model -p db-sqlite -p core -p trust-cli --all-targets --all-features -- -D warnings
- cargo test -p trust-cli -- --test-threads=1
- git diff --check
- make ci-fast
- cargo test --locked --no-default-features --workspace
- cargo test --locked --all-features --workspace