### PR TITLE
feat(alpaca-broker): support stop-limit safety orders

### DIFF
--- a/alpaca-broker/src/submit_trade.rs
+++ b/alpaca-broker/src/submit_trade.rs
@@ -8,7 +8,7 @@ use num_decimal::Num;
 use std::str::FromStr;
 use tokio::runtime::Runtime;
 
-use model::{Account, BrokerLog, Order, OrderIds, Trade, TradeCategory};
+use model::{Account, BrokerLog, Order, OrderCategory, OrderIds, Trade, TradeCategory};
 use std::error::Error;
 
 use crate::keys;
@@ -56,11 +56,7 @@ fn extract_ids(order: &AlpacaOrder, trade: &Trade) -> Result<OrderIds, Box<dyn E
     let mut target_id = None;
 
     for leg in &order.legs {
-        let leg_price = match (leg.limit_price.clone(), leg.stop_price.clone()) {
-            (Some(limit_price), None) => limit_price,
-            (None, Some(stop_price)) => stop_price,
-            _ => return Err(format!("No price found for leg: {:?}", leg.id).into()),
-        };
+        let leg_price = leg_match_price(leg)?;
 
         if leg_price.to_string() == trade.target.unit_price.to_string() {
             target_id = Some(leg.id);
@@ -81,6 +77,15 @@ fn extract_ids(order: &AlpacaOrder, trade: &Trade) -> Result<OrderIds, Box<dyn E
     })
 }
 
+fn leg_match_price(leg: &AlpacaOrder) -> Result<Num, Box<dyn Error>> {
+    match (leg.limit_price.clone(), leg.stop_price.clone()) {
+        (Some(limit_price), None) => Ok(limit_price),
+        (None, Some(stop_price)) => Ok(stop_price),
+        (Some(_limit_price), Some(stop_price)) if leg.type_ == Type::StopLimit => Ok(stop_price),
+        _ => Err(format!("No price found for leg: {:?}", leg.id).into()),
+    }
+}
+
 fn new_request(trade: &Trade) -> Result<CreateReq, Box<dyn Error>> {
     let entry = Num::from_str(&trade.entry.unit_price.to_string())
         .map_err(|e| format!("Failed to parse entry price: {e:?}"))?;
@@ -94,7 +99,7 @@ fn new_request(trade: &Trade) -> Result<CreateReq, Box<dyn Error>> {
         type_: Type::Limit,
         limit_price: Some(entry),
         take_profit: Some(TakeProfit::Limit(target)),
-        stop_loss: Some(StopLoss::Stop(stop)),
+        stop_loss: Some(stop_loss(&trade.safety_stop, stop)),
         time_in_force: time_in_force(&trade.entry),
         extended_hours: trade.entry.extended_hours,
         client_order_id: Some(trade.entry.id.to_string()),
@@ -105,6 +110,14 @@ fn new_request(trade: &Trade) -> Result<CreateReq, Box<dyn Error>> {
         side(trade),
         Amount::quantity(trade.entry.quantity),
     ))
+}
+
+fn stop_loss(safety_stop: &Order, stop: Num) -> StopLoss {
+    match safety_stop.category {
+        // Trust stores one safety price, so use it as both the trigger and limit price.
+        OrderCategory::StopLimit => StopLoss::StopLimit(stop.clone(), stop),
+        _ => StopLoss::Stop(stop),
+    }
 }
 
 fn time_in_force(entry: &Order) -> TimeInForce {
@@ -268,6 +281,36 @@ mod tests {
     }
 
     #[test]
+    fn new_request_uses_stop_limit_for_stop_limit_safety_orders() {
+        let trade = Trade {
+            safety_stop: Order {
+                unit_price: dec!(10.27),
+                category: OrderCategory::StopLimit,
+                ..Default::default()
+            },
+            entry: Order {
+                unit_price: dec!(13.22),
+                ..Default::default()
+            },
+            target: Order {
+                unit_price: dec!(15.03),
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+
+        let order_req = new_request(&trade).unwrap();
+
+        assert_eq!(
+            order_req.stop_loss.unwrap(),
+            StopLoss::StopLimit(
+                Num::from_str("10.27").unwrap(),
+                Num::from_str("10.27").unwrap()
+            )
+        );
+    }
+
+    #[test]
     fn test_extract_ids_stop_order() {
         // Create a sample AlpacaOrder with a Stop type
         let entry = default();
@@ -295,6 +338,35 @@ mod tests {
         // Check that the stop ID is correct and the target ID is a new UUID
         assert_eq!(result.stop, "8654f70e-3b42-4014-a9ac-5a7101989aad");
         assert_eq!(result.entry, "b6b12dc0-8e21-4d2e-8315-907d3116a6b8");
+        assert_eq!(result.target, "90e41b1e-9089-444d-9f68-c204a4d32914");
+    }
+
+    #[test]
+    fn extract_ids_accepts_stop_limit_leg() {
+        let mut entry = default();
+        let leg = entry
+            .legs
+            .get_mut(1)
+            .expect("fixture should include a safety stop leg");
+        leg.type_ = Type::StopLimit;
+        leg.limit_price = Some(Num::from_str("12.51").expect("valid limit price"));
+
+        let trade = Trade {
+            safety_stop: Order {
+                unit_price: dec!(12.52),
+                category: OrderCategory::StopLimit,
+                ..Default::default()
+            },
+            target: Order {
+                unit_price: dec!(12.58),
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+
+        let result = extract_ids(&entry, &trade).unwrap();
+
+        assert_eq!(result.stop, "8654f70e-3b42-4014-a9ac-5a7101989aad");
         assert_eq!(result.target, "90e41b1e-9089-444d-9f68-c204a4d32914");
     }
 

--- a/cli/src/commands/trade_command.rs
+++ b/cli/src/commands/trade_command.rs
@@ -56,6 +56,13 @@ impl TradeCommandBuilder {
                         .help("Stop price (non-interactive mode)"),
                 )
                 .arg(
+                    Arg::new("safety-order-type")
+                        .long("safety-order-type")
+                        .value_name("TYPE")
+                        .value_parser(["stop", "stop-limit"])
+                        .help("Safety order type (stop|stop-limit) (non-interactive mode)"),
+                )
+                .arg(
                     Arg::new("target")
                         .long("target")
                         .value_name("PRICE")
@@ -648,6 +655,8 @@ mod tests {
                 "100",
                 "--stop",
                 "95",
+                "--safety-order-type",
+                "stop-limit",
                 "--target",
                 "110",
                 "--quantity",
@@ -675,6 +684,11 @@ mod tests {
         assert_eq!(
             sub.get_one::<String>("category").map(String::as_str),
             Some("long")
+        );
+        assert_eq!(
+            sub.get_one::<String>("safety-order-type")
+                .map(String::as_str),
+            Some("stop-limit")
         );
         assert!(sub.get_flag("auto-submit"));
     }

--- a/cli/src/dialogs/trade_create_dialog.rs
+++ b/cli/src/dialogs/trade_create_dialog.rs
@@ -18,7 +18,7 @@ use crate::{
     views::TradeView,
 };
 use core::TrustFacade;
-use model::{Account, Currency, DraftTrade, Trade, TradeCategory, TradingVehicle};
+use model::{Account, Currency, DraftTrade, OrderCategory, Trade, TradeCategory, TradingVehicle};
 use rust_decimal::Decimal;
 use std::error::Error;
 
@@ -28,6 +28,7 @@ pub struct TradeDialogBuilder {
     category: Option<TradeCategory>,
     entry_price: Option<Decimal>,
     stop_price: Option<Decimal>,
+    safety_order_category: Option<OrderCategory>,
     currency: Option<Currency>,
     quantity: Option<i64>,
     target_price: Option<Decimal>,
@@ -46,6 +47,7 @@ impl TradeDialogBuilder {
             category: None,
             entry_price: None,
             stop_price: None,
+            safety_order_category: None,
             currency: None,
             quantity: None,
             target_price: None,
@@ -75,11 +77,12 @@ impl TradeDialogBuilder {
             context: self.context.clone(),
         };
 
-        self.result = Some(trust.create_trade(
+        self.result = Some(trust.create_trade_with_safety_order_category(
             draft,
             self.stop_price.unwrap(),
             self.entry_price.unwrap(),
             self.target_price.unwrap(),
+            self.safety_order_category.unwrap_or(OrderCategory::Stop),
         ));
         self
     }
@@ -169,6 +172,28 @@ impl TradeDialogBuilder {
                 Err(_) => println!("Please enter a valid number."),
             },
             Err(error) => println!("Error reading stop price: {error}"),
+        }
+        self
+    }
+
+    pub fn safety_order_category(mut self) -> Self {
+        let mut io = ConsoleDialogIo::default();
+        self = self.safety_order_category_with_io(&mut io);
+        self
+    }
+
+    pub fn safety_order_category_with_io(mut self, io: &mut dyn DialogIo) -> Self {
+        let available_categories = [OrderCategory::Stop, OrderCategory::StopLimit];
+        let labels: Vec<String> = available_categories
+            .iter()
+            .map(ToString::to_string)
+            .collect();
+        match io.select_index("Safety order type:", &labels, 0) {
+            Ok(Some(index)) => {
+                self.safety_order_category = available_categories.get(index).copied();
+            }
+            Ok(None) => {}
+            Err(error) => println!("Error selecting safety order type: {error}"),
         }
         self
     }
@@ -333,7 +358,7 @@ mod tests {
     use alpaca_broker::AlpacaBroker;
     use core::TrustFacade;
     use db_sqlite::SqliteDatabase;
-    use model::{Currency, Environment, TradeCategory, TradingVehicleCategory};
+    use model::{Currency, Environment, OrderCategory, TradeCategory, TradingVehicleCategory};
     use rust_decimal::Decimal;
     use rust_decimal_macros::dec;
     use std::collections::VecDeque;
@@ -419,6 +444,7 @@ mod tests {
         assert!(builder.category.is_none());
         assert!(builder.entry_price.is_none());
         assert!(builder.stop_price.is_none());
+        assert!(builder.safety_order_category.is_none());
         assert!(builder.currency.is_none());
         assert!(builder.quantity.is_none());
         assert!(builder.target_price.is_none());
@@ -437,6 +463,7 @@ mod tests {
             category: Some(TradeCategory::Long),
             entry_price: None,
             stop_price: None,
+            safety_order_category: None,
             currency: None,
             quantity: None,
             target_price: None,
@@ -478,6 +505,7 @@ mod tests {
             category: Some(TradeCategory::Long),
             entry_price: Some(dec!(100)),
             stop_price: Some(dec!(95)),
+            safety_order_category: Some(OrderCategory::StopLimit),
             currency: Some(Currency::USD),
             quantity: Some(1),
             target_price: Some(dec!(110)),
@@ -500,6 +528,7 @@ mod tests {
         assert_eq!(trade.category, TradeCategory::Long);
         assert_eq!(trade.currency, Currency::USD);
         assert_eq!(trade.safety_stop.unit_price, dec!(95));
+        assert_eq!(trade.safety_stop.category, OrderCategory::StopLimit);
         assert_eq!(trade.entry.unit_price, dec!(100));
         assert_eq!(trade.target.unit_price, dec!(110));
         assert_eq!(trade.thesis.as_deref(), Some("breakout"));
@@ -520,6 +549,7 @@ mod tests {
             category: Some(TradeCategory::Long),
             entry_price: Some(dec!(100)),
             stop_price: Some(dec!(95)),
+            safety_order_category: None,
             currency: Some(Currency::USD),
             quantity: Some(1),
             target_price: Some(dec!(110)),
@@ -601,6 +631,23 @@ mod tests {
     }
 
     #[test]
+    fn safety_order_category_with_io_sets_stop_limit_and_ignores_cancel() {
+        let mut io = ScriptedIo::with(vec![Ok(Some(1)), Ok(None)], vec![]);
+
+        let builder = TradeDialogBuilder::new().safety_order_category_with_io(&mut io);
+        assert_eq!(
+            builder.safety_order_category,
+            Some(OrderCategory::StopLimit)
+        );
+
+        let unchanged = builder.safety_order_category_with_io(&mut io);
+        assert_eq!(
+            unchanged.safety_order_category,
+            Some(OrderCategory::StopLimit)
+        );
+    }
+
+    #[test]
     fn required_selection_and_price_setters_cover_error_paths() {
         let mut trust = test_trust();
         let account = account_with_usd_deposit(&mut trust, "trade-io-errors", dec!(100));
@@ -633,6 +680,17 @@ mod tests {
         );
         let builder = TradeDialogBuilder::new().stop_price_with_io(&mut stop_error);
         assert!(builder.stop_price.is_none());
+
+        let mut safety_order_error = ScriptedIo::with(
+            vec![Err(IoError::new(
+                ErrorKind::BrokenPipe,
+                "safety order type failed",
+            ))],
+            vec![],
+        );
+        let builder =
+            TradeDialogBuilder::new().safety_order_category_with_io(&mut safety_order_error);
+        assert!(builder.safety_order_category.is_none());
 
         let mut currency_cancel = ScriptedIo::with(vec![Ok(None)], vec![]);
         let builder = TradeDialogBuilder {
@@ -787,6 +845,7 @@ mod tests {
         scripted_push_select(Ok(Some(0)));
         scripted_push_select(Ok(Some(0)));
         scripted_push_select(Ok(Some(0)));
+        scripted_push_select(Ok(Some(1)));
         scripted_push_input(Ok("100".to_string()));
         scripted_push_input(Ok("95".to_string()));
         scripted_push_select(Ok(Some(0)));
@@ -803,6 +862,7 @@ mod tests {
             .category()
             .entry_price()
             .stop_price()
+            .safety_order_category()
             .currency(&mut trust)
             .quantity(&mut trust)
             .target_price()
@@ -826,6 +886,10 @@ mod tests {
         assert_eq!(builder.category, Some(TradeCategory::Long));
         assert_eq!(builder.entry_price, Some(dec!(100)));
         assert_eq!(builder.stop_price, Some(dec!(95)));
+        assert_eq!(
+            builder.safety_order_category,
+            Some(OrderCategory::StopLimit)
+        );
         assert_eq!(builder.currency, Some(Currency::USD));
         assert_eq!(builder.quantity, Some(2));
         assert_eq!(builder.target_price, Some(dec!(110)));

--- a/cli/src/dispatcher.rs
+++ b/cli/src/dispatcher.rs
@@ -53,9 +53,9 @@ use ibkr_broker::IbkrBroker;
 use model::{
     Account, AccountType, BarTimeframe, BrokerKind, Currency, DraftTrade, Environment,
     FixedIncomeTerms, Level, LevelAdjustmentRules, LevelTrigger, MarketDataChannel,
-    MarketSnapshotSource, Mistake, MistakeErrorType, MungerTendency, SessionPlan, SessionPlanClose,
-    SessionRegime, Status, Trade, TradeCategory, TradeEvent, TradeEventSeverity, TradeEventType,
-    TradeGrade, TransactionCategory,
+    MarketSnapshotSource, Mistake, MistakeErrorType, MungerTendency, OrderCategory, SessionPlan,
+    SessionPlanClose, SessionRegime, Status, Trade, TradeCategory, TradeEvent, TradeEventSeverity,
+    TradeEventType, TradeGrade, TransactionCategory,
 };
 use rust_decimal::prelude::ToPrimitive;
 use rust_decimal::Decimal;
@@ -483,6 +483,7 @@ impl ArgDispatcher {
             || sub_matches.get_one::<String>("category").is_some()
             || sub_matches.get_one::<String>("entry").is_some()
             || sub_matches.get_one::<String>("stop").is_some()
+            || sub_matches.get_one::<String>("safety-order-type").is_some()
             || sub_matches.get_one::<String>("target").is_some()
             || sub_matches.get_one::<String>("quantity").is_some()
     }
@@ -5002,6 +5003,7 @@ impl ArgDispatcher {
                 .category()
                 .entry_price()
                 .stop_price()
+                .safety_order_category()
                 .currency(&mut self.trust)
                 .quantity(&mut self.trust)
                 .target_price()
@@ -5080,6 +5082,28 @@ impl ArgDispatcher {
         let entry_price = Self::parse_decimal_arg(sub_matches, "entry", format)?;
         let stop_price = Self::parse_decimal_arg(sub_matches, "stop", format)?;
         let target_price = Self::parse_decimal_arg(sub_matches, "target", format)?;
+        let safety_order_category = sub_matches
+            .get_one::<String>("safety-order-type")
+            .map(|raw| {
+                let category = OrderCategory::from_str(raw).map_err(|_| {
+                    Self::report_error(
+                        format,
+                        "invalid_safety_order_type",
+                        format!("Invalid --safety-order-type value: {raw}"),
+                    )
+                })?;
+                if matches!(category, OrderCategory::Stop | OrderCategory::StopLimit) {
+                    Ok(category)
+                } else {
+                    Err(Self::report_error(
+                        format,
+                        "invalid_safety_order_type",
+                        format!("Invalid --safety-order-type value: {raw}"),
+                    ))
+                }
+            })
+            .transpose()?
+            .unwrap_or(OrderCategory::Stop);
 
         let quantity = quantity_raw.parse::<i64>().map_err(|_| {
             Self::report_error(
@@ -5123,7 +5147,13 @@ impl ArgDispatcher {
 
         let trade = self
             .trust
-            .create_trade(draft, stop_price, entry_price, target_price)
+            .create_trade_with_safety_order_category(
+                draft,
+                stop_price,
+                entry_price,
+                target_price,
+                safety_order_category,
+            )
             .map_err(|error| {
                 Self::report_error(
                     format,
@@ -9898,8 +9928,8 @@ mod tests {
         Environment, FixedIncomeTerms, Level, LevelAdjustmentRules, LevelDirection, LevelStatus,
         LevelTrigger, MarketBar, MarketDataChannel, MarketDataStreamEvent, MarketQuote,
         MarketSnapshotSource, MarketSnapshotV2, MarketTradeTick, Mistake, MistakeErrorType,
-        MungerTendency, OrderIds, SessionRegime, Status, Trade, TradingVehicleCategory,
-        TransactionCategory,
+        MungerTendency, OrderCategory, OrderIds, SessionRegime, Status, Trade,
+        TradingVehicleCategory, TransactionCategory,
     };
     use rust_decimal::Decimal;
     use rust_decimal_macros::dec;
@@ -10197,6 +10227,7 @@ mod tests {
             .arg(Arg::new("category").long("category"))
             .arg(Arg::new("entry").long("entry"))
             .arg(Arg::new("stop").long("stop"))
+            .arg(Arg::new("safety-order-type").long("safety-order-type"))
             .arg(Arg::new("target").long("target"))
             .arg(Arg::new("quantity").long("quantity"))
             .arg(Arg::new("currency").long("currency"))
@@ -17493,6 +17524,7 @@ mod tests {
         crate::dialogs::scripted_push_select(Ok(Some(0))); // long category
         crate::dialogs::scripted_push_input(Ok("100".to_string()));
         crate::dialogs::scripted_push_input(Ok("95".to_string()));
+        crate::dialogs::scripted_push_select(Ok(Some(1))); // stop-limit safety order
         crate::dialogs::scripted_push_select(Ok(Some(0))); // USD balance
         crate::dialogs::scripted_push_input(Ok("2".to_string()));
         crate::dialogs::scripted_push_input(Ok("110".to_string()));
@@ -17513,6 +17545,7 @@ mod tests {
         assert_eq!(created.len(), 1);
         assert_eq!(created[0].trading_vehicle.symbol, "AAPL");
         assert_eq!(created[0].entry.quantity, 2);
+        assert_eq!(created[0].safety_stop.category, OrderCategory::StopLimit);
         assert_eq!(created[0].thesis.as_deref(), Some("scripted breakout"));
 
         crate::dialogs::scripted_reset();
@@ -17972,6 +18005,8 @@ mod tests {
             "100",
             "--stop",
             "95",
+            "--safety-order-type",
+            "stop-limit",
             "--target",
             "110",
             "--quantity",
@@ -18452,6 +18487,31 @@ mod tests {
             .create_trade(&invalid_currency)
             .expect_err("invalid currency should fail");
         assert!(currency_error.to_string().contains("invalid_currency"));
+
+        let invalid_safety_order_type = trade_matches(&[
+            "--account",
+            &account.name,
+            "--symbol",
+            "AAPL",
+            "--category",
+            "long",
+            "--entry",
+            "100",
+            "--stop",
+            "95",
+            "--safety-order-type",
+            "market",
+            "--target",
+            "110",
+            "--quantity",
+            "1",
+        ]);
+        let safety_order_error = dispatcher
+            .create_trade(&invalid_safety_order_type)
+            .expect_err("invalid safety order type should fail");
+        assert!(safety_order_error
+            .to_string()
+            .contains("invalid_safety_order_type"));
     }
 
     #[test]
@@ -18482,6 +18542,8 @@ mod tests {
             "100",
             "--stop",
             "95",
+            "--safety-order-type",
+            "stop-limit",
             "--target",
             "110",
             "--quantity",
@@ -18536,6 +18598,8 @@ mod tests {
             "100",
             "--stop",
             "95",
+            "--safety-order-type",
+            "stop-limit",
             "--target",
             "110",
             "--quantity",
@@ -18564,6 +18628,7 @@ mod tests {
         assert_eq!(funded.len(), 1);
         assert_eq!(funded[0].trading_vehicle.symbol, "AAPL");
         assert_eq!(funded[0].entry.quantity, 2);
+        assert_eq!(funded[0].safety_stop.category, OrderCategory::StopLimit);
         assert_eq!(funded[0].thesis.as_deref(), Some("breakout"));
     }
 

--- a/core/src/commands/order.rs
+++ b/core/src/commands/order.rs
@@ -12,6 +12,26 @@ pub fn create_stop(
     category: &TradeCategory,
     database: &mut dyn DatabaseFactory,
 ) -> Result<Order, Box<dyn std::error::Error>> {
+    create_stop_with_category(
+        trading_vehicle_id,
+        quantity,
+        price,
+        currency,
+        category,
+        &OrderCategory::Stop,
+        database,
+    )
+}
+
+pub fn create_stop_with_category(
+    trading_vehicle_id: Uuid,
+    quantity: i64,
+    price: Decimal,
+    currency: &Currency,
+    category: &TradeCategory,
+    order_category: &OrderCategory,
+    database: &mut dyn DatabaseFactory,
+) -> Result<Order, Box<dyn std::error::Error>> {
     let tv = database
         .trading_vehicle_read()
         .read_trading_vehicle(trading_vehicle_id)?;
@@ -21,7 +41,7 @@ pub fn create_stop(
         price,
         currency,
         &action_for_stop(category),
-        &OrderCategory::Market,
+        order_category,
     )
 }
 

--- a/core/src/commands/trade.rs
+++ b/core/src/commands/trade.rs
@@ -4,8 +4,8 @@ use crate::commands;
 use chrono::Utc;
 use model::{
     Account, AccountBalance, Broker, BrokerLog, DatabaseFactory, DraftTrade, Execution,
-    ExecutionSide, ExecutionSource, FeeActivity, Order, OrderStatus, Status, Trade, TradeBalance,
-    TradeCategory, TradingVehicleCategory, Transaction, TransactionCategory,
+    ExecutionSide, ExecutionSource, FeeActivity, Order, OrderCategory, OrderStatus, Status, Trade,
+    TradeBalance, TradeCategory, TradingVehicleCategory, Transaction, TransactionCategory,
 };
 use rust_decimal::Decimal;
 use rust_decimal_macros::dec;
@@ -75,6 +75,24 @@ pub fn create_trade(
     target_price: Decimal,
     database: &mut dyn DatabaseFactory,
 ) -> Result<Trade, Box<dyn std::error::Error>> {
+    create_trade_with_safety_order_category(
+        trade,
+        stop_price,
+        entry_price,
+        target_price,
+        OrderCategory::Stop,
+        database,
+    )
+}
+
+pub fn create_trade_with_safety_order_category(
+    trade: DraftTrade,
+    stop_price: Decimal,
+    entry_price: Decimal,
+    target_price: Decimal,
+    safety_order_category: OrderCategory,
+    database: &mut dyn DatabaseFactory,
+) -> Result<Trade, Box<dyn std::error::Error>> {
     if trade.quantity <= 0 {
         return Err(format!(
             "Trade quantity must be greater than zero, got {}",
@@ -84,14 +102,31 @@ pub fn create_trade(
     }
 
     // 1. Create Stop-loss Order
-    let stop = commands::order::create_stop(
-        trade.trading_vehicle.id,
-        trade.quantity,
-        stop_price,
-        &trade.currency,
-        &trade.category,
-        database,
-    )?;
+    let stop = match safety_order_category {
+        OrderCategory::Stop => commands::order::create_stop(
+            trade.trading_vehicle.id,
+            trade.quantity,
+            stop_price,
+            &trade.currency,
+            &trade.category,
+            database,
+        )?,
+        OrderCategory::StopLimit => commands::order::create_stop_with_category(
+            trade.trading_vehicle.id,
+            trade.quantity,
+            stop_price,
+            &trade.currency,
+            &trade.category,
+            &safety_order_category,
+            database,
+        )?,
+        _ => {
+            return Err(format!(
+                "Safety order category must be stop or stop_limit, got {safety_order_category}"
+            )
+            .into());
+        }
+    };
 
     // 2. Create Entry Order
     let entry = commands::order::create_entry(

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -815,6 +815,25 @@ impl TrustFacade {
         )
     }
 
+    /// Create a new trade and choose the safety order type.
+    pub fn create_trade_with_safety_order_category(
+        &mut self,
+        trade: DraftTrade,
+        stop_price: Decimal,
+        entry_price: Decimal,
+        target_price: Decimal,
+        safety_order_category: model::OrderCategory,
+    ) -> Result<Trade, Box<dyn std::error::Error>> {
+        commands::trade::create_trade_with_safety_order_category(
+            trade,
+            stop_price,
+            entry_price,
+            target_price,
+            safety_order_category,
+            &mut *self.factory,
+        )
+    }
+
     /// Search for trades by account and status.
     ///
     /// # Arguments

--- a/core/src/services/grading.rs
+++ b/core/src/services/grading.rs
@@ -310,7 +310,7 @@ fn score_process(trade: &Trade) -> (u8, Vec<String>) {
     let mut score: i32 = 100;
     let mut recs: Vec<String> = Vec::new();
 
-    // Planned bracket order shape (entry=limit, stop=stop, target=limit) is the default Trust flow.
+    // Planned bracket order shape (entry=limit, stop/stop-limit, target=limit) is the default Trust flow.
     if trade.entry.category != OrderCategory::Limit {
         score = score.saturating_sub(10);
         recs.push("Use limit orders for entries (reduce slippage)".to_string());
@@ -319,9 +319,12 @@ fn score_process(trade: &Trade) -> (u8, Vec<String>) {
         score = score.saturating_sub(10);
         recs.push("Use limit orders for targets when possible".to_string());
     }
-    if trade.safety_stop.category != OrderCategory::Stop {
+    if !matches!(
+        trade.safety_stop.category,
+        OrderCategory::Stop | OrderCategory::StopLimit
+    ) {
         score = score.saturating_sub(10);
-        recs.push("Use stop orders for safety stops".to_string());
+        recs.push("Use stop or stop-limit orders for safety stops".to_string());
     }
 
     // Planned risk/reward (wiki guidance: avoid 1:1, prefer >= 2:1).
@@ -1181,8 +1184,20 @@ mod tests {
             .any(|rec| rec.contains("limit orders for targets")));
         assert!(recs
             .iter()
-            .any(|rec| rec.contains("stop orders for safety stops")));
+            .any(|rec| rec.contains("stop or stop-limit orders for safety stops")));
         assert!(recs.iter().any(|rec| rec.contains("Planned R:R is < 1.0")));
+    }
+
+    #[test]
+    fn score_process_accepts_stop_limit_safety_order_shape() {
+        let trade = Trade {
+            safety_stop: order(dec!(95), OrderCategory::StopLimit, 10),
+            ..trade_with_plan(TradeCategory::Long, dec!(100), dec!(95), dec!(115))
+        };
+
+        let (_score, recs) = score_process(&trade);
+
+        assert!(!recs.iter().any(|rec| rec.contains("safety stops")));
     }
 
     #[test]

--- a/db-sqlite/migrations/2026-05-11-120000_add_stop_limit_order_category/down.sql
+++ b/db-sqlite/migrations/2026-05-11-120000_add_stop_limit_order_category/down.sql
@@ -1,0 +1,55 @@
+-- Revert stop_limit order categories to plain stop before restoring the
+-- previous CHECK constraint.
+
+PRAGMA foreign_keys=OFF;
+
+CREATE TABLE "orders_new" (
+    id                    TEXT NOT NULL PRIMARY KEY,
+    broker_order_id       TEXT,
+    created_at            DATETIME NOT NULL,
+    updated_at            DATETIME NOT NULL,
+    deleted_at            DATETIME,
+    unit_price            TEXT NOT NULL,
+    currency              TEXT CHECK(currency IN ('USD', 'EUR', 'BTC')) NOT NULL,
+    quantity              INTEGER NOT NULL,
+    category              TEXT CHECK(category IN ('market', 'limit', 'stop')) NOT NULL,
+    trading_vehicle_id    TEXT NOT NULL REFERENCES trading_vehicles (id),
+    action                TEXT CHECK(action IN ('sell', 'buy', 'short')) NOT NULL,
+    status                TEXT CHECK(status IN ('new', 'replaced', 'partially_filled', 'filled', 'done_for_day', 'canceled', 'expired', 'accepted', 'pending_new', 'accepted_for_bidding', 'pending_cancel', 'pending_replace', 'stopped', 'rejected', 'suspended', 'calculated', 'held', 'unknown')) NOT NULL,
+    time_in_force         TEXT CHECK(time_in_force IN ('until_canceled', 'day', 'until_market_open', 'until_market_close')) NOT NULL,
+    trailing_percentage   TEXT,
+    trailing_price        TEXT,
+    filled_quantity       INTEGER,
+    average_filled_price  TEXT,
+    extended_hours        BOOLEAN NOT NULL,
+    submitted_at          DATETIME,
+    filled_at             DATETIME,
+    expired_at            DATETIME,
+    cancelled_at          DATETIME,
+    closed_at             DATETIME
+);
+
+INSERT INTO orders_new (
+    id, broker_order_id, created_at, updated_at, deleted_at,
+    unit_price, currency, quantity, category, trading_vehicle_id,
+    action, status, time_in_force, trailing_percentage, trailing_price,
+    filled_quantity, average_filled_price, extended_hours, submitted_at,
+    filled_at, expired_at, cancelled_at, closed_at
+)
+SELECT
+    id, broker_order_id, created_at, updated_at, deleted_at,
+    unit_price, currency, quantity,
+    CASE category
+        WHEN 'stop_limit' THEN 'stop'
+        ELSE category
+    END,
+    trading_vehicle_id, action, status, time_in_force,
+    trailing_percentage, trailing_price, filled_quantity,
+    average_filled_price, extended_hours, submitted_at,
+    filled_at, expired_at, cancelled_at, closed_at
+FROM orders;
+
+DROP TABLE orders;
+ALTER TABLE orders_new RENAME TO orders;
+
+PRAGMA foreign_keys=ON;

--- a/db-sqlite/migrations/2026-05-11-120000_add_stop_limit_order_category/up.sql
+++ b/db-sqlite/migrations/2026-05-11-120000_add_stop_limit_order_category/up.sql
@@ -1,0 +1,52 @@
+-- Add stop_limit as a supported order category.
+--
+-- SQLite cannot alter CHECK constraints in place, so rebuild the orders table
+-- while preserving every persisted order field.
+
+PRAGMA foreign_keys=OFF;
+
+CREATE TABLE "orders_new" (
+    id                    TEXT NOT NULL PRIMARY KEY,
+    broker_order_id       TEXT,
+    created_at            DATETIME NOT NULL,
+    updated_at            DATETIME NOT NULL,
+    deleted_at            DATETIME,
+    unit_price            TEXT NOT NULL,
+    currency              TEXT CHECK(currency IN ('USD', 'EUR', 'BTC')) NOT NULL,
+    quantity              INTEGER NOT NULL,
+    category              TEXT CHECK(category IN ('market', 'limit', 'stop', 'stop_limit')) NOT NULL,
+    trading_vehicle_id    TEXT NOT NULL REFERENCES trading_vehicles (id),
+    action                TEXT CHECK(action IN ('sell', 'buy', 'short')) NOT NULL,
+    status                TEXT CHECK(status IN ('new', 'replaced', 'partially_filled', 'filled', 'done_for_day', 'canceled', 'expired', 'accepted', 'pending_new', 'accepted_for_bidding', 'pending_cancel', 'pending_replace', 'stopped', 'rejected', 'suspended', 'calculated', 'held', 'unknown')) NOT NULL,
+    time_in_force         TEXT CHECK(time_in_force IN ('until_canceled', 'day', 'until_market_open', 'until_market_close')) NOT NULL,
+    trailing_percentage   TEXT,
+    trailing_price        TEXT,
+    filled_quantity       INTEGER,
+    average_filled_price  TEXT,
+    extended_hours        BOOLEAN NOT NULL,
+    submitted_at          DATETIME,
+    filled_at             DATETIME,
+    expired_at            DATETIME,
+    cancelled_at          DATETIME,
+    closed_at             DATETIME
+);
+
+INSERT INTO orders_new (
+    id, broker_order_id, created_at, updated_at, deleted_at,
+    unit_price, currency, quantity, category, trading_vehicle_id,
+    action, status, time_in_force, trailing_percentage, trailing_price,
+    filled_quantity, average_filled_price, extended_hours, submitted_at,
+    filled_at, expired_at, cancelled_at, closed_at
+)
+SELECT
+    id, broker_order_id, created_at, updated_at, deleted_at,
+    unit_price, currency, quantity, category, trading_vehicle_id,
+    action, status, time_in_force, trailing_percentage, trailing_price,
+    filled_quantity, average_filled_price, extended_hours, submitted_at,
+    filled_at, expired_at, cancelled_at, closed_at
+FROM orders;
+
+DROP TABLE orders;
+ALTER TABLE orders_new RENAME TO orders;
+
+PRAGMA foreign_keys=ON;

--- a/db-sqlite/src/workers/worker_order.rs
+++ b/db-sqlite/src/workers/worker_order.rs
@@ -420,6 +420,26 @@ mod tests {
     }
 
     #[test]
+    fn create_order_roundtrips_stop_limit_category() {
+        let mut conn = establish_connection();
+        let trading_vehicle = trading_vehicle(&mut conn);
+
+        let order = WorkerOrder::create(
+            &mut conn,
+            dec!(95.00),
+            &Currency::USD,
+            100,
+            &OrderAction::Sell,
+            &OrderCategory::StopLimit,
+            &trading_vehicle,
+        )
+        .expect("stop-limit order should create");
+        let read = WorkerOrder::read(&mut conn, order.id).expect("stop-limit order should read");
+
+        assert_eq!(read.category, OrderCategory::StopLimit);
+    }
+
+    #[test]
     fn create_and_read_report_missing_orders_table_errors() {
         let mut conn = establish_connection();
         let trading_vehicle = trading_vehicle(&mut conn);

--- a/model/src/order.rs
+++ b/model/src/order.rs
@@ -90,6 +90,8 @@ pub enum OrderCategory {
     Limit,
     /// Stop order - buy or sell at a specific price or worse. The order is executed when the price is reached.
     Stop,
+    /// Stop-limit order - becomes a limit order after the stop price is reached.
+    StopLimit,
 }
 
 /// The action of the order - buy, sell, short, etc.
@@ -246,6 +248,7 @@ impl std::fmt::Display for OrderCategory {
             OrderCategory::Market => write!(f, "market"),
             OrderCategory::Limit => write!(f, "limit"),
             OrderCategory::Stop => write!(f, "stop"),
+            OrderCategory::StopLimit => write!(f, "stop_limit"),
         }
     }
 }
@@ -288,6 +291,7 @@ impl std::str::FromStr for OrderCategory {
             "market" => Ok(OrderCategory::Market),
             "limit" => Ok(OrderCategory::Limit),
             "stop" => Ok(OrderCategory::Stop),
+            "stop_limit" | "stop-limit" => Ok(OrderCategory::StopLimit),
             _ => Err(OrderCategoryParseError),
         }
     }
@@ -361,6 +365,14 @@ mod tests {
         assert_eq!("market".parse::<OrderCategory>(), Ok(OrderCategory::Market));
         assert_eq!("limit".parse::<OrderCategory>(), Ok(OrderCategory::Limit));
         assert_eq!("stop".parse::<OrderCategory>(), Ok(OrderCategory::Stop));
+        assert_eq!(
+            "stop_limit".parse::<OrderCategory>(),
+            Ok(OrderCategory::StopLimit)
+        );
+        assert_eq!(
+            "stop-limit".parse::<OrderCategory>(),
+            Ok(OrderCategory::StopLimit)
+        );
         assert!("invalid".parse::<OrderCategory>().is_err());
     }
 
@@ -369,6 +381,7 @@ mod tests {
         assert_eq!(format!("{}", OrderCategory::Market), "market");
         assert_eq!(format!("{}", OrderCategory::Limit), "limit");
         assert_eq!(format!("{}", OrderCategory::Stop), "stop");
+        assert_eq!(format!("{}", OrderCategory::StopLimit), "stop_limit");
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- add StopLimit as a persisted order category with a SQLite CHECK-constraint migration
- let trade creation choose stop vs stop-limit safety orders from CLI/dialog flows
- submit Alpaca bracket safety legs as stop-limit orders and map returned stop-limit legs back to local order IDs

## Verification
- cargo test -p trust-model order_category --lib
- cargo test -p alpaca-broker submit_trade::tests --lib
- cargo test -p db-sqlite workers::worker_order::tests --lib
- cargo test -p trust-cli trade_create_dialog -- --test-threads=1
- cargo test -p trust-cli test_create_trade_ -- --test-threads=1
- cargo test -p trust-cli trade_create_parses_non_interactive_fields -- --test-threads=1
- cargo clippy -p trust-model -p db-sqlite -p core -p alpaca-broker -p trust-cli --all-targets --all-features -- -D warnings
- make ci-fast
- cargo test -p trust-cli -- --test-threads=1
- cargo test --locked --no-default-features --workspace
- cargo test --locked --all-features --workspace

Closes #95