### PR TITLE
feat(cli): add zen display mode

### DIFF
--- a/cli/src/dispatcher.rs
+++ b/cli/src/dispatcher.rs
@@ -536,6 +536,14 @@ impl ArgDispatcher {
 
     #[allow(clippy::too_many_lines, clippy::cognitive_complexity)]
     pub fn dispatch(mut self, matches: ArgMatches) -> Result<(), CliError> {
+        let zen_enabled = matches
+            .try_get_one::<bool>("zen")
+            .ok()
+            .flatten()
+            .copied()
+            .unwrap_or(false);
+        crate::zen::set_enabled(zen_enabled);
+
         match parse_top_level_command(&matches) {
             TopLevelCommand::Db(sub_matches) => self.dispatch_db(sub_matches)?,
             TopLevelCommand::Keys(sub_matches) => self.dispatch_keys(sub_matches)?,
@@ -1633,21 +1641,27 @@ impl ArgDispatcher {
                     account.name, account.id, account.account_type
                 );
                 for b in balances {
+                    let basis = b.total_balance;
                     println!(
                         "  {} total={} available={} in_trade={} taxed={} earnings={}",
                         b.currency,
-                        b.total_balance,
-                        b.total_available,
-                        b.total_in_trade,
-                        b.taxed,
-                        b.total_earnings
+                        crate::zen::amount_share(b.total_balance, basis),
+                        crate::zen::amount_share(b.total_available, basis),
+                        crate::zen::amount_share(b.total_in_trade, basis),
+                        crate::zen::amount_share(b.taxed, basis),
+                        crate::zen::amount_share(b.total_earnings, basis)
                     );
                 }
             } else {
                 let total = balances.into_iter().fold(Decimal::ZERO, |acc, b| {
                     acc.checked_add(b.total_balance).unwrap_or(acc)
                 });
-                println!("{} ({}) total={}", account.name, account.id, total);
+                println!(
+                    "{} ({}) total={}",
+                    account.name,
+                    account.id,
+                    crate::zen::amount_share(total, total)
+                );
             }
         }
         Ok(())
@@ -1768,7 +1782,11 @@ impl ArgDispatcher {
             .create_transaction(&account, &category, amount, &currency)
             .map_err(|e| Self::report_error(format, "transaction_create_failed", e.to_string()))?;
 
-        crate::views::TransactionView::display(&transaction, &account.name);
+        crate::views::TransactionView::display_with_basis(
+            &transaction,
+            &account.name,
+            account_balance.total_balance,
+        );
         crate::views::AccountBalanceView::display(account_balance, &account.name);
         Ok(())
     }
@@ -2142,17 +2160,17 @@ impl ArgDispatcher {
                 println!("===============");
                 println!("symbol: {}", snapshot.symbol);
                 println!("as_of: {}", snapshot.as_of.to_rfc3339());
-                println!("last_price: {}", Self::decimal_string(snapshot.last_price));
-                println!("open: {}", Self::decimal_string(snapshot.open));
-                println!("high: {}", Self::decimal_string(snapshot.high));
-                println!("low: {}", Self::decimal_string(snapshot.low));
+                println!("last_price: {}", crate::zen::amount(snapshot.last_price));
+                println!("open: {}", crate::zen::amount(snapshot.open));
+                println!("high: {}", crate::zen::amount(snapshot.high));
+                println!("low: {}", crate::zen::amount(snapshot.low));
                 println!("volume: {}", snapshot.volume);
                 if let Some(quote) = &snapshot.quote {
-                    println!("bid: {}", Self::decimal_string(quote.bid_price));
-                    println!("ask: {}", Self::decimal_string(quote.ask_price));
+                    println!("bid: {}", crate::zen::amount(quote.bid_price));
+                    println!("ask: {}", crate::zen::amount(quote.ask_price));
                 }
                 if let Some(trade) = &snapshot.trade {
-                    println!("last_trade_price: {}", Self::decimal_string(trade.price));
+                    println!("last_trade_price: {}", crate::zen::amount(trade.price));
                     println!("last_trade_size: {}", trade.size);
                 }
                 let source = Self::market_snapshot_source_label(&snapshot.source);
@@ -2223,9 +2241,9 @@ impl ArgDispatcher {
                 println!("============");
                 println!("symbol: {symbol}");
                 println!("as_of: {}", quote.as_of.to_rfc3339());
-                println!("bid_price: {}", Self::decimal_string(quote.bid_price));
+                println!("bid_price: {}", crate::zen::amount(quote.bid_price));
                 println!("bid_size: {}", quote.bid_size);
-                println!("ask_price: {}", Self::decimal_string(quote.ask_price));
+                println!("ask_price: {}", crate::zen::amount(quote.ask_price));
                 println!("ask_size: {}", quote.ask_size);
             }
             ReportOutputFormat::Json => {
@@ -2284,7 +2302,7 @@ impl ArgDispatcher {
                 println!("============");
                 println!("symbol: {symbol}");
                 println!("as_of: {}", trade.as_of.to_rfc3339());
-                println!("price: {}", Self::decimal_string(trade.price));
+                println!("price: {}", crate::zen::amount(trade.price));
                 println!("size: {}", trade.size);
             }
             ReportOutputFormat::Json => {
@@ -2449,7 +2467,7 @@ impl ArgDispatcher {
                         event.as_of.to_rfc3339(),
                         channel,
                         event.symbol,
-                        Self::decimal_string(event.price),
+                        crate::zen::amount(event.price),
                         event.size
                     );
                 }
@@ -2518,10 +2536,10 @@ impl ArgDispatcher {
                     println!(
                         "{} o={} h={} l={} c={} v={}",
                         bar.time.to_rfc3339(),
-                        Self::decimal_string(bar.open),
-                        Self::decimal_string(bar.high),
-                        Self::decimal_string(bar.low),
-                        Self::decimal_string(bar.close),
+                        crate::zen::amount(bar.open),
+                        crate::zen::amount(bar.high),
+                        crate::zen::amount(bar.low),
+                        crate::zen::amount(bar.close),
                         bar.volume
                     );
                 }
@@ -3912,11 +3930,14 @@ impl ArgDispatcher {
             format!("Account: {}", preview.account_id),
             format!(
                 "Entry: {} {} | Stop: {} {} | Risk/Share: {} {}",
-                Self::decimal_string(preview.entry_price),
+                crate::zen::price_relative_to(preview.entry_price, preview.entry_price),
                 preview.currency,
-                Self::decimal_string(preview.stop_price),
+                crate::zen::price_relative_to(preview.stop_price, preview.entry_price),
                 preview.currency,
-                Self::decimal_string(Self::trade_preview_risk_per_share(preview)),
+                crate::zen::amount_share(
+                    Self::trade_preview_risk_per_share(preview),
+                    preview.entry_price,
+                ),
                 preview.currency
             ),
             format!(
@@ -3940,7 +3961,11 @@ impl ArgDispatcher {
                 item["level"].as_u64().unwrap_or(0),
                 item["multiplier"].as_str().unwrap_or("0"),
                 item["quantity"].as_i64().unwrap_or(0),
-                item["risk_amount"].as_str().unwrap_or("0"),
+                if crate::zen::is_enabled() {
+                    "hidden"
+                } else {
+                    item["risk_amount"].as_str().unwrap_or("0")
+                },
                 preview.currency,
                 current_marker
             ));
@@ -4001,42 +4026,42 @@ impl ArgDispatcher {
             format!("Account: {}", args.preview.account_id),
             format!(
                 "Entry: {} {} | Stop: {} {} | Target: {} {} | Quantity: {}",
-                Self::decimal_string(args.preview.entry_price),
+                crate::zen::price_relative_to(args.preview.entry_price, args.preview.entry_price),
                 args.preview.currency,
-                Self::decimal_string(args.preview.stop_price),
+                crate::zen::price_relative_to(args.preview.stop_price, args.preview.entry_price),
                 args.preview.currency,
-                Self::decimal_string(args.target_price),
+                crate::zen::price_relative_to(args.target_price, args.preview.entry_price),
                 args.preview.currency,
                 args.quantity
             ),
             format!(
                 "Available capital: {} {}",
-                Self::decimal_string(report.available_capital),
+                crate::zen::amount_share(report.available_capital, report.available_capital),
                 args.preview.currency
             ),
             format!(
                 "Capital required: {} {} ({})",
-                Self::decimal_string(report.capital_required),
+                crate::zen::amount_share(report.capital_required, report.available_capital),
                 args.preview.currency,
                 Self::format_optional_percentage(report.capital_required_pct_of_available)
             ),
             format!(
                 "Risk/share: {} {} | Reward/share: {} {} | R:R {}",
-                Self::decimal_string(report.risk_per_share),
+                crate::zen::amount_share(report.risk_per_share, args.preview.entry_price),
                 args.preview.currency,
-                Self::decimal_string(report.reward_per_share),
+                crate::zen::amount_share(report.reward_per_share, args.preview.entry_price),
                 args.preview.currency,
                 Self::format_optional_decimal(report.risk_reward_ratio)
             ),
             format!(
                 "Max loss: {} {} ({})",
-                Self::decimal_string(report.max_loss),
+                crate::zen::amount_share(report.max_loss, report.available_capital),
                 args.preview.currency,
                 Self::format_optional_percentage(report.max_loss_pct_of_available)
             ),
             format!(
                 "Max gain: {} {} ({})",
-                Self::decimal_string(report.max_gain),
+                crate::zen::amount_share(report.max_gain, report.available_capital),
                 args.preview.currency,
                 Self::format_optional_percentage(report.max_gain_pct_of_available)
             ),
@@ -4158,21 +4183,20 @@ impl ArgDispatcher {
     }
 
     fn print_trade_autopsy_context(trade: &Trade, grade: &TradeGrade) {
+        let entry_price = trade
+            .entry
+            .average_filled_price
+            .unwrap_or(trade.entry.unit_price);
         println!("Trade autopsy");
         println!("Trade: {} {}", trade.id, trade.trading_vehicle.symbol);
         println!(
             "Entry: {}",
-            Self::decimal_string(
-                trade
-                    .entry
-                    .average_filled_price
-                    .unwrap_or(trade.entry.unit_price)
-            )
+            crate::zen::price_relative_to(entry_price, entry_price)
         );
         println!(
             "Exit: {}",
             Self::trade_exit_price(trade)
-                .map(Self::decimal_string)
+                .map(|value| crate::zen::price_relative_to(value, entry_price))
                 .unwrap_or_else(|| "n/a".to_string())
         );
         println!(
@@ -5181,7 +5205,11 @@ impl ArgDispatcher {
             println!("Trade funded:");
             crate::views::TradeView::display(&funded_trade, &account.name);
             crate::views::TradeBalanceView::display(&trade_balance);
-            crate::views::TransactionView::display(&tx, &account.name);
+            crate::views::TransactionView::display_with_basis(
+                &tx,
+                &account.name,
+                account_balance.total_balance,
+            );
             crate::views::AccountBalanceView::display(account_balance, &account.name);
 
             if auto_submit {
@@ -5237,7 +5265,11 @@ impl ArgDispatcher {
 
         println!("Trade canceled:");
         crate::views::TradeBalanceView::display(&trade_balance);
-        crate::views::TransactionView::display(&transaction, &account.name);
+        crate::views::TransactionView::display_with_basis(
+            &transaction,
+            &account.name,
+            account_balance.total_balance,
+        );
         crate::views::AccountBalanceView::display(account_balance, &account.name);
         Ok(())
     }
@@ -5269,7 +5301,11 @@ impl ArgDispatcher {
         println!("Trade funded:");
         crate::views::TradeView::display(&funded_trade, &account.name);
         crate::views::TradeBalanceView::display(&trade_balance);
-        crate::views::TransactionView::display(&tx, &account.name);
+        crate::views::TransactionView::display_with_basis(
+            &tx,
+            &account.name,
+            account_balance.total_balance,
+        );
         crate::views::AccountBalanceView::display(account_balance, &account.name);
         Ok(())
     }
@@ -6679,7 +6715,10 @@ impl ArgDispatcher {
                     .map(|id| id.to_string())
                     .unwrap_or_else(|| "all_accounts".to_string())
             );
-            println!("Equity: ${:.2}", summary.equity);
+            println!(
+                "Equity: {}",
+                crate::zen::currency_share(summary.equity, summary.equity)
+            );
             println!(
                 "Performance: {} trades ({}W/{}L), win rate {:.1}%, avg R {:.2}",
                 performance.total_trades,
@@ -6689,8 +6728,8 @@ impl ArgDispatcher {
                 performance.average_r_multiple
             );
             println!(
-                "Risk: ${:.2} at risk ({:.2}% of equity), {} open positions",
-                total_risk,
+                "Risk: {} at risk ({:.2}% of equity), {} open positions",
+                crate::zen::currency_share(total_risk, summary.equity),
                 risk_pct,
                 summary.capital_at_risk.len()
             );
@@ -7286,6 +7325,9 @@ impl ArgDispatcher {
             acc.checked_add(trade.balance.total_performance)
                 .unwrap_or(acc)
         });
+        let total_funding = in_window.iter().fold(Decimal::ZERO, |acc, trade| {
+            acc.checked_add(trade.balance.funding).unwrap_or(acc)
+        });
         let mut rows: Vec<(String, u64, Decimal, Decimal)> = groups
             .into_iter()
             .map(|(key, (count, pnl, funding))| (key, count, pnl, funding))
@@ -7300,7 +7342,10 @@ impl ArgDispatcher {
                 println!("from: {from}");
                 println!("to: {to}");
                 println!("closed_trades: {}", in_window.len());
-                println!("total_pnl: {}", Self::decimal_string(total_pnl));
+                println!(
+                    "total_pnl: {}",
+                    crate::zen::amount_share(total_pnl, total_pnl)
+                );
                 for (key, count, pnl, funding) in &rows {
                     let share = if total_pnl == Decimal::ZERO {
                         Decimal::ZERO
@@ -7311,8 +7356,8 @@ impl ArgDispatcher {
                     };
                     println!(
                         "{key}: trades={count} pnl={} funding={} share_pct={}",
-                        Self::decimal_string(*pnl),
-                        Self::decimal_string(*funding),
+                        crate::zen::amount_share(*pnl, total_pnl),
+                        crate::zen::amount_share(*funding, total_funding),
                         Self::decimal_string(share),
                     );
                 }
@@ -7565,11 +7610,14 @@ impl ArgDispatcher {
                 println!("from: {from}");
                 println!("to: {to}");
                 println!("bucket_count: {}", buckets.len());
-                println!("net_cash_flow: {}", Self::decimal_string(total_net));
+                println!(
+                    "net_cash_flow: {}",
+                    crate::zen::amount_share(total_net, total_net)
+                );
                 for (bucket, (count, net)) in &buckets {
                     println!(
                         "{bucket}: events={count} net_cash_flow={}",
-                        Self::decimal_string(*net)
+                        crate::zen::amount_share(*net, total_net)
                     );
                 }
             }
@@ -8392,8 +8440,14 @@ impl ArgDispatcher {
     ) {
         println!("Bond Metrics");
         println!("============");
-        println!("face_value: {}", Self::decimal_string(input.face_value));
-        println!("market_price: {}", Self::decimal_string(input.market_price));
+        println!(
+            "face_value: {}",
+            crate::zen::amount_share(input.face_value, input.face_value)
+        );
+        println!(
+            "market_price: {}",
+            crate::zen::amount_share(input.market_price, input.face_value)
+        );
         println!(
             "coupon_rate: {}%",
             Self::decimal_string(input.annual_coupon_rate_pct)
@@ -8401,27 +8455,39 @@ impl ArgDispatcher {
         println!("quantity: {}", input.quantity);
         println!(
             "position_face_value: {}",
-            Self::decimal_string(analytics.position_face_value)
+            crate::zen::amount_share(analytics.position_face_value, analytics.position_face_value)
         );
         println!(
             "position_market_value: {}",
-            Self::decimal_string(analytics.position_market_value)
+            crate::zen::amount_share(
+                analytics.position_market_value,
+                analytics.position_face_value,
+            )
         );
         println!(
             "accrued_interest: {}",
-            Self::decimal_string(analytics.accrued_interest_total)
+            crate::zen::amount_share(
+                analytics.accrued_interest_total,
+                analytics.position_face_value,
+            )
         );
         println!(
             "dirty_price: {}",
-            Self::decimal_string(analytics.dirty_price)
+            crate::zen::amount_share(analytics.dirty_price, input.face_value)
         );
         println!(
             "position_dirty_value: {}",
-            Self::decimal_string(analytics.position_dirty_value)
+            crate::zen::amount_share(
+                analytics.position_dirty_value,
+                analytics.position_face_value
+            )
         );
         println!(
             "annual_coupon_income: {}",
-            Self::decimal_string(analytics.annual_coupon_income)
+            crate::zen::amount_share(
+                analytics.annual_coupon_income,
+                analytics.position_face_value
+            )
         );
         println!(
             "current_yield: {}%",
@@ -8436,7 +8502,7 @@ impl ArgDispatcher {
         );
         println!(
             "premium_discount: {} ({}%)",
-            Self::decimal_string(analytics.price_premium_discount),
+            crate::zen::amount_share(analytics.price_premium_discount, input.face_value),
             Self::decimal_string(analytics.price_premium_discount_pct)
         );
     }
@@ -9707,7 +9773,7 @@ impl ArgDispatcher {
             .map_err(|e| CliError::new("transfer_failed", e.to_string()))?;
 
         println!("Transfer completed:");
-        println!("  amount: {amount}");
+        println!("  amount: {}", crate::zen::amount(amount));
         println!("  from:   {from_id}");
         println!("  to:     {to_id}");
         println!("  reason: {reason}");
@@ -9769,7 +9835,7 @@ impl ArgDispatcher {
         println!("  earnings: {earnings_pct}");
         println!("  tax: {tax_pct}");
         println!("  reinvestment: {reinvestment_pct}");
-        println!("  minimum_threshold: {threshold}");
+        println!("  minimum_threshold: {}", crate::zen::amount(threshold));
         Ok(())
     }
 
@@ -9790,15 +9856,30 @@ impl ArgDispatcher {
 
         println!("Distribution executed:");
         println!("  source_account_id: {}", result.source_account_id);
-        println!("  original_amount: {}", result.original_amount);
+        println!(
+            "  original_amount: {}",
+            crate::zen::amount_share(result.original_amount, result.original_amount)
+        );
         println!(
             "  earnings_amount: {}",
-            result.earnings_amount.unwrap_or_default()
+            crate::zen::amount_share(
+                result.earnings_amount.unwrap_or_default(),
+                result.original_amount,
+            )
         );
-        println!("  tax_amount: {}", result.tax_amount.unwrap_or_default());
+        println!(
+            "  tax_amount: {}",
+            crate::zen::amount_share(
+                result.tax_amount.unwrap_or_default(),
+                result.original_amount
+            )
+        );
         println!(
             "  reinvestment_amount: {}",
-            result.reinvestment_amount.unwrap_or_default()
+            crate::zen::amount_share(
+                result.reinvestment_amount.unwrap_or_default(),
+                result.original_amount,
+            )
         );
         println!(
             "  transactions_created: {}",
@@ -9828,6 +9909,7 @@ impl ArgDispatcher {
 
         println!("Distribution History (most recent first):");
         for entry in entries {
+            let basis = entry.original_amount;
             println!(
                 "- at={} trade_id={} amount={} earnings={} tax={} reinvestment={}",
                 entry.distribution_date,
@@ -9835,19 +9917,19 @@ impl ArgDispatcher {
                     .trade_id
                     .map(|id| id.to_string())
                     .unwrap_or_else(|| "N/A".to_string()),
-                entry.original_amount,
+                crate::zen::amount_share(entry.original_amount, basis),
                 entry
                     .earnings_amount
-                    .map(|v| v.to_string())
-                    .unwrap_or_else(|| "0".to_string()),
+                    .map(|v| crate::zen::amount_share(v, basis))
+                    .unwrap_or_else(|| crate::zen::amount_share(Decimal::ZERO, basis)),
                 entry
                     .tax_amount
-                    .map(|v| v.to_string())
-                    .unwrap_or_else(|| "0".to_string()),
+                    .map(|v| crate::zen::amount_share(v, basis))
+                    .unwrap_or_else(|| crate::zen::amount_share(Decimal::ZERO, basis)),
                 entry
                     .reinvestment_amount
-                    .map(|v| v.to_string())
-                    .unwrap_or_else(|| "0".to_string()),
+                    .map(|v| crate::zen::amount_share(v, basis))
+                    .unwrap_or_else(|| crate::zen::amount_share(Decimal::ZERO, basis)),
             );
         }
 
@@ -9869,7 +9951,10 @@ impl ArgDispatcher {
         println!("  earnings_percent: {}", rules.earnings_percent);
         println!("  tax_percent: {}", rules.tax_percent);
         println!("  reinvestment_percent: {}", rules.reinvestment_percent);
-        println!("  minimum_threshold: {}", rules.minimum_threshold);
+        println!(
+            "  minimum_threshold: {}",
+            crate::zen::amount(rules.minimum_threshold)
+        );
         Ok(())
     }
 }

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -38,7 +38,7 @@ use crate::commands::{
     TransactionCommandBuilder,
 };
 use crate::dispatcher::ArgDispatcher;
-use clap::Command;
+use clap::{Arg, ArgAction, Command};
 use commands::RuleCommandBuilder;
 mod command_routing;
 mod commands;
@@ -50,6 +50,7 @@ mod protected_keyword;
 mod test_support;
 mod trading_vehicle_import;
 mod views;
+mod zen;
 
 fn build_keys_subcommand() -> Command {
     KeysCommandBuilder::new()
@@ -77,6 +78,15 @@ fn build_cli() -> Command {
         .version(env!("CARGO_PKG_VERSION"))
         .subcommand_required(true)
         .arg_required_else_help(true)
+        .arg(
+            Arg::new("zen")
+                .long("zen")
+                .global(true)
+                .action(ArgAction::SetTrue)
+                .help(
+                    "Hide absolute dollar amounts and show percentage-only output where possible",
+                ),
+        )
         .subcommand(DbCommandBuilder::new().export().import().build())
         .subcommand(build_keys_subcommand())
         .subcommand(
@@ -199,6 +209,7 @@ fn build_cli() -> Command {
 
 fn main() {
     let matches = build_cli().get_matches();
+    crate::zen::set_enabled(matches.get_flag("zen"));
 
     let dispatcher = ArgDispatcher::new_sqlite();
     if let Err(error) = dispatcher.dispatch(matches) {
@@ -266,5 +277,18 @@ mod tests {
             .subcommand()
             .expect("nested report subcommand should exist");
         assert_eq!(nested, "summary");
+    }
+
+    #[test]
+    fn cli_accepts_zen_as_global_flag() {
+        let matches = build_cli()
+            .try_get_matches_from(["trust", "--zen", "report", "summary"])
+            .expect("global zen flag should parse before subcommand");
+        assert!(matches.get_flag("zen"));
+
+        let nested = build_cli()
+            .try_get_matches_from(["trust", "report", "--zen", "summary"])
+            .expect("global zen flag should parse within subcommand tree");
+        assert!(nested.get_flag("zen"));
     }
 }

--- a/cli/src/views/account_view.rs
+++ b/cli/src/views/account_view.rs
@@ -50,12 +50,13 @@ pub struct AccountBalanceView {
 
 impl AccountBalanceView {
     fn new(balance: AccountBalance, account_name: &str) -> AccountBalanceView {
+        let basis = balance.total_balance;
         AccountBalanceView {
             account_name: crate::views::uppercase_first(account_name),
-            total_balance: balance.total_balance.to_string(),
-            total_available: balance.total_available.to_string(),
-            total_in_trade: balance.total_in_trade.to_string(),
-            taxed: balance.taxed.to_string(),
+            total_balance: crate::zen::amount_share(balance.total_balance, basis),
+            total_available: crate::zen::amount_share(balance.total_available, basis),
+            total_in_trade: crate::zen::amount_share(balance.total_in_trade, basis),
+            taxed: crate::zen::amount_share(balance.taxed, basis),
             currency: balance.currency.to_string(),
         }
     }
@@ -103,6 +104,7 @@ mod tests {
 
     #[test]
     fn account_balance_view_new_formats_and_capitalizes() {
+        crate::zen::set_enabled(false);
         let balance = AccountBalance {
             total_balance: dec!(1000),
             total_available: dec!(900),
@@ -120,7 +122,27 @@ mod tests {
     }
 
     #[test]
+    fn account_balance_view_new_uses_percentages_in_zen_mode() {
+        crate::zen::set_enabled(true);
+        let balance = AccountBalance {
+            total_balance: dec!(1000),
+            total_available: dec!(900),
+            total_in_trade: dec!(100),
+            taxed: dec!(10),
+            ..Default::default()
+        };
+
+        let view = AccountBalanceView::new(balance, "main");
+        assert_eq!(view.total_balance, "100.0%");
+        assert_eq!(view.total_available, "90.0%");
+        assert_eq!(view.total_in_trade, "10.0%");
+        assert_eq!(view.taxed, "1.0%");
+        crate::zen::set_enabled(false);
+    }
+
+    #[test]
     fn display_functions_run_for_smoke_coverage() {
+        crate::zen::set_enabled(false);
         AccountView::display_account(Account::default());
         AccountView::display_accounts(vec![Account::default()]);
         AccountBalanceView::display_balances(vec![AccountBalance::default()], "primary");

--- a/cli/src/views/advanced_metrics_view.rs
+++ b/cli/src/views/advanced_metrics_view.rs
@@ -78,7 +78,11 @@ impl AdvancedMetricsView {
             "├─ Average R-Multiple: {:.2}",
             AdvancedMetricsCalculator::calculate_average_r_multiple(trades)
         );
-        println!("├─ Expectancy (EV): ${expectancy:.2} per trade ({expectancy_rating})");
+        if crate::zen::is_enabled() {
+            println!("├─ Expectancy (EV): hidden per trade ({expectancy_rating})");
+        } else {
+            println!("├─ Expectancy (EV): ${expectancy:.2} per trade ({expectancy_rating})");
+        }
         println!(
             "├─ Pareto Profit Share (Top 20% Winners): {:.1}%",
             concentration.top_20pct_profit_share_percentage

--- a/cli/src/views/concentration_view.rs
+++ b/cli/src/views/concentration_view.rs
@@ -1,4 +1,5 @@
 use core::calculators_concentration::{ConcentrationAnalysis, ConcentrationGroup, WarningLevel};
+use rust_decimal::Decimal;
 use rust_decimal_macros::dec;
 
 pub struct ConcentrationView;
@@ -21,7 +22,7 @@ impl ConcentrationView {
         // Display sector concentration
         if !sector_analysis.groups.is_empty() {
             println!("By Sector:");
-            Self::display_groups(&sector_analysis.groups);
+            Self::display_groups(&sector_analysis.groups, sector_analysis.total_risk);
 
             if !sector_analysis.concentration_warnings.is_empty() {
                 println!();
@@ -32,7 +33,10 @@ impl ConcentrationView {
         // Display asset class concentration
         if !asset_class_analysis.groups.is_empty() {
             println!("\nBy Asset Class:");
-            Self::display_groups(&asset_class_analysis.groups);
+            Self::display_groups(
+                &asset_class_analysis.groups,
+                asset_class_analysis.total_risk,
+            );
 
             if !asset_class_analysis.concentration_warnings.is_empty() {
                 println!();
@@ -43,21 +47,23 @@ impl ConcentrationView {
         // Display total risk summary
         if sector_analysis.total_risk > dec!(0) {
             println!(
-                "\nTotal Capital at Risk: ${:.2}",
-                sector_analysis.total_risk
+                "\nTotal Capital at Risk: {}",
+                crate::zen::currency_share(sector_analysis.total_risk, sector_analysis.total_risk)
             );
         }
 
         println!();
     }
 
-    fn display_groups(groups: &[ConcentrationGroup]) {
+    fn display_groups(groups: &[ConcentrationGroup], total_risk: Decimal) {
         // Sort groups by current open risk (descending)
         let mut sorted_groups = groups.to_vec();
         sorted_groups.sort_by_key(|group| std::cmp::Reverse(group.current_open_risk));
 
         for group in sorted_groups {
-            let pnl_display = if group.realized_pnl >= dec!(0) {
+            let pnl_display = if crate::zen::is_enabled() {
+                crate::zen::signed_percentage_of(group.realized_pnl, group.total_capital_deployed)
+            } else if group.realized_pnl >= dec!(0) {
                 format!("+${:.2}", group.realized_pnl)
             } else {
                 format!("-${:.2}", group.realized_pnl.abs())
@@ -79,18 +85,26 @@ impl ConcentrationView {
             } else {
                 format!("{pnl_percentage:.1}%")
             };
+            let deployed_display = if crate::zen::is_enabled() {
+                crate::zen::amount_share(group.total_capital_deployed, group.total_capital_deployed)
+            } else {
+                format!("${:.2}", group.total_capital_deployed)
+            };
 
             println!(
-                "{}: {} trades, ${:.2} deployed, {} P&L ({})",
+                "{}: {} trades, {} deployed, {} P&L ({})",
                 group.name,
                 group.trade_count,
-                group.total_capital_deployed,
+                deployed_display,
                 pnl_display,
                 pnl_percentage_display
             );
 
             if group.current_open_risk > dec!(0) {
-                println!("  └─ Current open risk: ${:.2}", group.current_open_risk);
+                println!(
+                    "  └─ Current open risk: {}",
+                    crate::zen::currency_share(group.current_open_risk, total_risk)
+                );
             }
         }
     }
@@ -147,6 +161,7 @@ mod tests {
 
     #[test]
     fn display_groups_and_warnings_handle_positive_negative_and_zero_deployed() {
+        crate::zen::set_enabled(false);
         let groups = vec![
             group("Tech", dec!(500), dec!(100)),
             group("Energy", dec!(0), dec!(-30)),
@@ -168,12 +183,13 @@ mod tests {
             },
         ];
 
-        ConcentrationView::display_groups(&groups);
+        ConcentrationView::display_groups(&groups, dec!(510));
         ConcentrationView::display_warnings(&warnings);
     }
 
     #[test]
     fn display_handles_open_only_and_all_modes() {
+        crate::zen::set_enabled(false);
         let sector_analysis = ConcentrationAnalysis {
             groups: vec![group("Tech", dec!(250), dec!(50))],
             total_risk: dec!(250),
@@ -209,5 +225,13 @@ mod tests {
             },
             false,
         );
+    }
+
+    #[test]
+    fn display_groups_use_percentages_in_zen_mode() {
+        crate::zen::set_enabled(true);
+        let groups = vec![group("Tech", dec!(500), dec!(100))];
+        ConcentrationView::display_groups(&groups, dec!(1000));
+        crate::zen::set_enabled(false);
     }
 }

--- a/cli/src/views/drawdown_view.rs
+++ b/cli/src/views/drawdown_view.rs
@@ -8,60 +8,99 @@ impl DrawdownView {
     pub fn display(metrics: DrawdownMetrics) {
         println!("\nRealized P&L Drawdown Analysis");
         println!("=============================");
-
-        // Display warning about realized-only limitation
         println!("⚠️  Based on closed trades only - does not include open position losses\n");
 
-        // Display current equity and peak
+        Self::display_equity_header(&metrics);
+        Self::display_current_drawdown(&metrics);
+        println!();
+        Self::display_max_drawdown(&metrics);
+        Self::display_day_metrics(&metrics);
+        println!();
+        Self::display_drawdown_history(&metrics);
+        println!();
+    }
+
+    fn display_equity_header(metrics: &DrawdownMetrics) {
         println!(
             "Current Account Equity: {}",
-            Self::format_currency(metrics.current_equity)
+            Self::format_equity(metrics.current_equity, metrics.peak_equity)
         );
         println!(
             "All-Time Peak Equity: {}",
-            Self::format_currency(metrics.peak_equity)
+            Self::format_equity(metrics.peak_equity, metrics.peak_equity)
         );
+    }
 
-        // Display current drawdown
+    fn display_current_drawdown(metrics: &DrawdownMetrics) {
         if metrics.current_drawdown > dec!(0) {
+            if crate::zen::is_enabled() {
+                println!(
+                    "Current Drawdown: {}",
+                    Self::format_percentage_negative(metrics.current_drawdown_percentage)
+                );
+            } else {
+                println!(
+                    "Current Drawdown: {} ({})",
+                    Self::format_currency_negative(metrics.current_drawdown),
+                    Self::format_percentage_negative(metrics.current_drawdown_percentage)
+                );
+            }
+        } else {
+            println!("Current Drawdown: {}", Self::zero_drawdown_label());
+        }
+    }
+
+    fn display_max_drawdown(metrics: &DrawdownMetrics) {
+        if metrics.max_drawdown > dec!(0) {
+            Self::display_nonzero_max_drawdown(metrics);
+        } else {
+            println!("Maximum Drawdown: {}", Self::zero_drawdown_label());
+        }
+    }
+
+    fn display_nonzero_max_drawdown(metrics: &DrawdownMetrics) {
+        let date_str = metrics
+            .max_drawdown_date
+            .map(|d| d.format("%Y-%m-%d").to_string())
+            .unwrap_or_else(|| "N/A".to_string());
+
+        if crate::zen::is_enabled() {
             println!(
-                "Current Drawdown: {} ({})",
-                Self::format_currency_negative(metrics.current_drawdown),
-                Self::format_percentage_negative(metrics.current_drawdown_percentage)
+                "Maximum Drawdown: {} on {}",
+                Self::format_percentage_negative(metrics.max_drawdown_percentage),
+                date_str
             );
         } else {
-            println!("Current Drawdown: $0.00 (0.0%)");
-        }
-
-        println!();
-
-        // Display maximum drawdown
-        if metrics.max_drawdown > dec!(0) {
-            let date_str = metrics
-                .max_drawdown_date
-                .map(|d| d.format("%Y-%m-%d").to_string())
-                .unwrap_or_else(|| "N/A".to_string());
-
             println!(
                 "Maximum Drawdown: {} ({}) on {}",
                 Self::format_currency_negative(metrics.max_drawdown),
                 Self::format_percentage_negative(metrics.max_drawdown_percentage),
                 date_str
             );
+        }
+        Self::display_recovery_from_max(metrics);
+    }
 
-            // Display recovery information
-            if metrics.recovery_from_max > dec!(0) {
-                println!(
-                    "Recovery from Max DD: {} ({} recovered)",
-                    Self::format_currency_positive(metrics.recovery_from_max),
-                    Self::format_percentage(metrics.recovery_percentage)
-                );
-            }
-        } else {
-            println!("Maximum Drawdown: $0.00 (0.0%)");
+    fn display_recovery_from_max(metrics: &DrawdownMetrics) {
+        if metrics.recovery_from_max <= dec!(0) {
+            return;
         }
 
-        // Display days metrics
+        if crate::zen::is_enabled() {
+            println!(
+                "Recovery from Max DD: {} recovered",
+                Self::format_percentage(metrics.recovery_percentage)
+            );
+        } else {
+            println!(
+                "Recovery from Max DD: {} ({} recovered)",
+                Self::format_currency_positive(metrics.recovery_from_max),
+                Self::format_percentage(metrics.recovery_percentage)
+            );
+        }
+    }
+
+    fn display_day_metrics(metrics: &DrawdownMetrics) {
         if metrics.days_since_peak > 0 {
             println!("Days Since Peak: {}", metrics.days_since_peak);
         }
@@ -69,13 +108,14 @@ impl DrawdownView {
         if metrics.days_in_drawdown > 0 {
             println!("Days in Current Drawdown: {}", metrics.days_in_drawdown);
         }
+    }
 
-        println!();
-
-        // Display drawdown history summary
-        Self::display_drawdown_history(&metrics);
-
-        println!();
+    fn zero_drawdown_label() -> &'static str {
+        if crate::zen::is_enabled() {
+            "0.0%"
+        } else {
+            "$0.00 (0.0%)"
+        }
     }
 
     fn display_drawdown_history(metrics: &DrawdownMetrics) {
@@ -92,8 +132,14 @@ impl DrawdownView {
             .checked_sub(metrics.max_drawdown)
             .unwrap_or(dec!(0));
 
-        print!("Peak: {} ", Self::format_currency(metrics.peak_equity));
-        print!("→ Low: {} ", Self::format_currency(trough_equity));
+        print!(
+            "Peak: {} ",
+            Self::format_equity(metrics.peak_equity, metrics.peak_equity)
+        );
+        print!(
+            "→ Low: {} ",
+            Self::format_equity(trough_equity, metrics.peak_equity)
+        );
 
         if metrics.max_drawdown > dec!(0) {
             print!(
@@ -104,7 +150,7 @@ impl DrawdownView {
 
         print!(
             " → Current: {}",
-            Self::format_currency(metrics.current_equity)
+            Self::format_equity(metrics.current_equity, metrics.peak_equity)
         );
 
         if metrics.current_drawdown > dec!(0) && metrics.current_drawdown < metrics.max_drawdown {
@@ -117,22 +163,28 @@ impl DrawdownView {
     }
 
     fn format_currency(amount: Decimal) -> String {
-        if amount >= dec!(0) {
-            format!("${amount:.2}")
+        crate::zen::currency(amount)
+    }
+
+    fn format_currency_negative(amount: Decimal) -> String {
+        if crate::zen::is_enabled() {
+            "hidden".to_string()
         } else {
             let abs_amount = amount.abs();
             format!("-${abs_amount:.2}")
         }
     }
 
-    fn format_currency_negative(amount: Decimal) -> String {
-        let abs_amount = amount.abs();
-        format!("-${abs_amount:.2}")
+    fn format_currency_positive(amount: Decimal) -> String {
+        crate::zen::signed_currency(amount.abs())
     }
 
-    fn format_currency_positive(amount: Decimal) -> String {
-        let abs_amount = amount.abs();
-        format!("+${abs_amount:.2}")
+    fn format_equity(amount: Decimal, basis: Decimal) -> String {
+        if crate::zen::is_enabled() {
+            crate::zen::percentage_of(amount, basis)
+        } else {
+            Self::format_currency(amount)
+        }
     }
 
     fn format_percentage(value: Decimal) -> String {
@@ -170,6 +222,7 @@ mod tests {
 
     #[test]
     fn currency_and_percentage_formatters_are_consistent() {
+        crate::zen::set_enabled(false);
         assert_eq!(DrawdownView::format_currency(dec!(10)), "$10.00");
         assert_eq!(DrawdownView::format_currency(dec!(-10)), "-$10.00");
         assert_eq!(DrawdownView::format_currency_negative(dec!(10)), "-$10.00");
@@ -182,7 +235,19 @@ mod tests {
     }
 
     #[test]
+    fn equity_formatter_uses_peak_percentages_in_zen_mode() {
+        crate::zen::set_enabled(true);
+        assert_eq!(
+            DrawdownView::format_equity(dec!(9500), dec!(10000)),
+            "95.0%"
+        );
+        assert_eq!(DrawdownView::format_currency(dec!(10)), "hidden");
+        crate::zen::set_enabled(false);
+    }
+
+    #[test]
     fn display_and_history_cover_recovery_and_no_drawdown_paths() {
+        crate::zen::set_enabled(false);
         let metrics = sample_metrics();
         DrawdownView::display_drawdown_history(&metrics);
         DrawdownView::display(metrics);
@@ -206,6 +271,7 @@ mod tests {
 
     #[test]
     fn display_handles_missing_max_date_zero_recovery_and_no_day_counts() {
+        crate::zen::set_enabled(false);
         let metrics = DrawdownMetrics {
             current_equity: dec!(9500),
             peak_equity: dec!(10000),

--- a/cli/src/views/order_view.rs
+++ b/cli/src/views/order_view.rs
@@ -18,10 +18,10 @@ pub struct OrderView {
 impl OrderView {
     fn new(order: Order) -> OrderView {
         OrderView {
-            unit_price: order.unit_price.to_string(),
+            unit_price: crate::zen::amount(order.unit_price),
             average_filled_price: order
                 .average_filled_price
-                .map(|d| d.to_string())
+                .map(crate::zen::amount)
                 .unwrap_or_default(),
             quantity: order.quantity.to_string(),
             category: order.category.to_string(),
@@ -58,6 +58,7 @@ mod tests {
 
     #[test]
     fn new_maps_optional_and_scalar_fields() {
+        crate::zen::set_enabled(false);
         let order = Order {
             unit_price: dec!(101.25),
             average_filled_price: Some(dec!(100.75)),
@@ -82,7 +83,23 @@ mod tests {
     }
 
     #[test]
+    fn new_hides_prices_in_zen_mode() {
+        crate::zen::set_enabled(true);
+        let order = Order {
+            unit_price: dec!(101.25),
+            average_filled_price: Some(dec!(100.75)),
+            ..Default::default()
+        };
+
+        let view = OrderView::new(order);
+        assert_eq!(view.unit_price, "hidden");
+        assert_eq!(view.average_filled_price, "hidden");
+        crate::zen::set_enabled(false);
+    }
+
+    #[test]
     fn display_orders_runs_for_smoke_coverage() {
+        crate::zen::set_enabled(false);
         OrderView::display_orders(vec![Order::default()]);
     }
 }

--- a/cli/src/views/performance_view.rs
+++ b/cli/src/views/performance_view.rs
@@ -43,13 +43,17 @@ impl PerformanceView {
     }
 
     fn display_win_loss_analysis(stats: &PerformanceStats) {
-        let avg_win_display = if stats.average_win > Decimal::ZERO {
+        let avg_win_display = if crate::zen::is_enabled() {
+            "hidden".to_string()
+        } else if stats.average_win > Decimal::ZERO {
             format!("${:.2}", stats.average_win)
         } else {
             "$0.00".to_string()
         };
 
-        let avg_loss_display = if stats.average_loss < Decimal::ZERO {
+        let avg_loss_display = if crate::zen::is_enabled() {
+            "hidden".to_string()
+        } else if stats.average_loss < Decimal::ZERO {
             format!("${:.2}", stats.average_loss)
         } else {
             "$0.00".to_string()
@@ -63,11 +67,19 @@ impl PerformanceView {
         println!("Average R-Multiple: {:.2}", stats.average_r_multiple);
 
         if let Some(best) = stats.best_trade {
-            println!("Best Trade: ${best:.2}");
+            if crate::zen::is_enabled() {
+                println!("Best Trade: hidden");
+            } else {
+                println!("Best Trade: ${best:.2}");
+            }
         }
 
         if let Some(worst) = stats.worst_trade {
-            println!("Worst Trade: ${worst:.2}");
+            if crate::zen::is_enabled() {
+                println!("Worst Trade: hidden");
+            } else {
+                println!("Worst Trade: ${worst:.2}");
+            }
         }
     }
 }
@@ -95,6 +107,7 @@ mod tests {
 
     #[test]
     fn display_helpers_handle_positive_and_zero_edge_cases() {
+        crate::zen::set_enabled(false);
         let mut s = stats();
         PerformanceView::display_trade_summary(&s);
         PerformanceView::display_win_loss_analysis(&s);
@@ -110,6 +123,7 @@ mod tests {
 
     #[test]
     fn display_handles_empty_and_closed_trade_inputs() {
+        crate::zen::set_enabled(false);
         PerformanceView::display(Vec::new());
 
         let mut trade = Trade {
@@ -120,5 +134,14 @@ mod tests {
         trade.balance.funding = dec!(1000);
         trade.balance.capital_in_market = dec!(0);
         PerformanceView::display(vec![trade]);
+    }
+
+    #[test]
+    fn display_helpers_hide_absolute_amounts_in_zen_mode() {
+        crate::zen::set_enabled(true);
+        let s = stats();
+        PerformanceView::display_win_loss_analysis(&s);
+        PerformanceView::display_performance_metrics(&s);
+        crate::zen::set_enabled(false);
     }
 }

--- a/cli/src/views/risk_view.rs
+++ b/cli/src/views/risk_view.rs
@@ -16,13 +16,13 @@ impl RiskView {
         // Display account equity
         println!(
             "Total Account Equity: {}",
-            Self::format_currency(account_equity)
+            Self::format_currency_share(account_equity, account_equity)
         );
 
         // Display capital at risk
         println!(
             "Capital at Risk: {} ({}% of account)",
-            Self::format_currency(total_capital_at_risk),
+            Self::format_currency_share(total_capital_at_risk, account_equity),
             Self::calculate_percentage(total_capital_at_risk, account_equity)
         );
 
@@ -32,7 +32,7 @@ impl RiskView {
             .unwrap_or(dec!(0));
         println!(
             "Safe Capital: {} ({}% of account)",
-            Self::format_currency(safe_capital),
+            Self::format_currency_share(safe_capital, account_equity),
             Self::calculate_percentage(safe_capital, account_equity)
         );
 
@@ -47,7 +47,7 @@ impl RiskView {
                 println!(
                     "{}: {} ({}%) - Funded {}, {}",
                     position.symbol,
-                    Self::format_currency(position.capital_amount),
+                    Self::format_currency_share(position.capital_amount, account_equity),
                     position_percentage,
                     funded_date,
                     Self::format_status(&position.status)
@@ -63,10 +63,14 @@ impl RiskView {
     }
 
     fn format_currency(amount: Decimal) -> String {
-        if amount >= dec!(0) {
-            format!("${amount:.2}")
+        crate::zen::currency(amount)
+    }
+
+    fn format_currency_share(amount: Decimal, basis: Decimal) -> String {
+        if crate::zen::is_enabled() {
+            crate::zen::percentage_of(amount, basis)
         } else {
-            format!("-${:.2}", amount.abs())
+            Self::format_currency(amount)
         }
     }
 
@@ -141,12 +145,24 @@ mod tests {
 
     #[test]
     fn format_currency_covers_positive_and_negative_values() {
+        crate::zen::set_enabled(false);
         assert_eq!(RiskView::format_currency(dec!(1500.5)), "$1500.50");
         assert_eq!(RiskView::format_currency(dec!(-1500.5)), "-$1500.50");
     }
 
     #[test]
+    fn format_currency_share_uses_percentage_in_zen_mode() {
+        crate::zen::set_enabled(true);
+        assert_eq!(
+            RiskView::format_currency_share(dec!(1500), dec!(10000)),
+            "15.0%"
+        );
+        crate::zen::set_enabled(false);
+    }
+
+    #[test]
     fn calculate_percentage_handles_zero_and_regular_totals() {
+        crate::zen::set_enabled(false);
         assert_eq!(RiskView::calculate_percentage(dec!(10), dec!(0)), "0.0");
         assert_eq!(RiskView::calculate_percentage(dec!(25), dec!(200)), "12.5");
     }
@@ -167,6 +183,7 @@ mod tests {
 
     #[test]
     fn display_renders_without_panicking_for_positions_and_empty_state() {
+        crate::zen::set_enabled(false);
         let positions = vec![OpenPosition {
             trade_id: Uuid::new_v4(),
             symbol: "AAPL".to_string(),

--- a/cli/src/views/trade_view.rs
+++ b/cli/src/views/trade_view.rs
@@ -18,15 +18,16 @@ pub struct TradeView {
 
 impl TradeView {
     fn new(trade: Trade, account_name: &str) -> TradeView {
+        let entry_price = trade.entry.unit_price;
         TradeView {
             trading_vehicle: trade.trading_vehicle.clone().symbol,
             category: trade.category.to_string(),
             account: crate::views::uppercase_first(account_name),
             currency: trade.currency.to_string(),
             quantity: trade.entry.quantity.to_string(),
-            stop_price: trade.safety_stop.unit_price.to_string(),
-            entry_price: trade.entry.unit_price.to_string(),
-            target_price: trade.target.unit_price.to_string(),
+            stop_price: crate::zen::price_relative_to(trade.safety_stop.unit_price, entry_price),
+            entry_price: crate::zen::price_relative_to(entry_price, entry_price),
+            target_price: crate::zen::price_relative_to(trade.target.unit_price, entry_price),
             status: trade.status.to_string(),
         }
     }
@@ -61,12 +62,13 @@ pub struct TradeBalanceView {
 
 impl TradeBalanceView {
     fn new(balance: &TradeBalance) -> TradeBalanceView {
+        let basis = balance.funding;
         TradeBalanceView {
-            funding: balance.funding.to_string(),
-            capital_in_market: balance.capital_in_market.to_string(),
-            capital_out_market: balance.capital_out_market.to_string(),
-            taxed: balance.taxed.to_string(),
-            total_performance: balance.total_performance.to_string(),
+            funding: crate::zen::amount_share(balance.funding, basis),
+            capital_in_market: crate::zen::amount_share(balance.capital_in_market, basis),
+            capital_out_market: crate::zen::amount_share(balance.capital_out_market, basis),
+            taxed: crate::zen::amount_share(balance.taxed, basis),
+            total_performance: crate::zen::amount_share(balance.total_performance, basis),
             currency: balance.currency.to_string(),
         }
     }
@@ -92,6 +94,7 @@ mod tests {
 
     #[test]
     fn trade_view_new_maps_trade_snapshot_fields() {
+        crate::zen::set_enabled(false);
         let mut trade = Trade::default();
         trade.trading_vehicle.symbol = "tsla".to_string();
         trade.category = TradeCategory::Short;
@@ -114,6 +117,7 @@ mod tests {
 
     #[test]
     fn trade_balance_view_new_maps_balance_values() {
+        crate::zen::set_enabled(false);
         let balance = TradeBalance {
             funding: dec!(1000),
             capital_in_market: dec!(500),
@@ -132,7 +136,38 @@ mod tests {
     }
 
     #[test]
+    fn trade_views_use_percentages_in_zen_mode() {
+        crate::zen::set_enabled(true);
+        let mut trade = Trade::default();
+        trade.safety_stop.unit_price = dec!(90);
+        trade.entry.unit_price = dec!(100);
+        trade.target.unit_price = dec!(120);
+
+        let trade_view = TradeView::new(trade, "paper");
+        assert_eq!(trade_view.stop_price, "90.0%");
+        assert_eq!(trade_view.entry_price, "100.0%");
+        assert_eq!(trade_view.target_price, "120.0%");
+
+        let balance = TradeBalance {
+            funding: dec!(1000),
+            capital_in_market: dec!(250),
+            capital_out_market: dec!(750),
+            taxed: dec!(50),
+            total_performance: dec!(120),
+            ..Default::default()
+        };
+        let balance_view = TradeBalanceView::new(&balance);
+        assert_eq!(balance_view.funding, "100.0%");
+        assert_eq!(balance_view.capital_in_market, "25.0%");
+        assert_eq!(balance_view.capital_out_market, "75.0%");
+        assert_eq!(balance_view.taxed, "5.0%");
+        assert_eq!(balance_view.total_performance, "12.0%");
+        crate::zen::set_enabled(false);
+    }
+
+    #[test]
     fn display_helpers_run_for_smoke_coverage() {
+        crate::zen::set_enabled(false);
         let trade = Trade::default();
         TradeView::display_trades(vec![trade.clone()], "main");
         TradeView::display(&trade, "main");

--- a/cli/src/views/transaction_view.rs
+++ b/cli/src/views/transaction_view.rs
@@ -1,4 +1,5 @@
 use model::Transaction;
+use rust_decimal::Decimal;
 use tabled::settings::style::Style;
 use tabled::Table;
 use tabled::Tabled;
@@ -13,10 +14,20 @@ pub struct TransactionView {
 
 impl TransactionView {
     fn new(tx: &Transaction, account_name: &str) -> TransactionView {
+        Self::new_with_basis(tx, account_name, None)
+    }
+
+    fn new_with_basis(
+        tx: &Transaction,
+        account_name: &str,
+        basis: Option<Decimal>,
+    ) -> TransactionView {
         TransactionView {
             account_name: crate::views::uppercase_first(account_name),
             category: tx.category.to_string(),
-            amount: tx.amount.to_string(),
+            amount: basis
+                .map(|value| crate::zen::amount_share(tx.amount, value))
+                .unwrap_or_else(|| crate::zen::amount(tx.amount)),
             currency: tx.currency.to_string(),
         }
     }
@@ -28,10 +39,31 @@ impl TransactionView {
         println!();
     }
 
+    pub fn display_with_basis(tx: &Transaction, account_name: &str, basis: Decimal) {
+        println!();
+        println!("Transaction: {}", tx.id);
+        TransactionView::display_transactions_with_basis(vec![tx], account_name, basis);
+        println!();
+    }
+
     pub fn display_transactions(txs: Vec<&Transaction>, account_name: &str) {
         let views: Vec<TransactionView> = txs
             .into_iter()
             .map(|x: &Transaction| TransactionView::new(x, account_name))
+            .collect();
+        let mut table = Table::new(views);
+        table.with(Style::modern());
+        println!("{table}");
+    }
+
+    pub fn display_transactions_with_basis(
+        txs: Vec<&Transaction>,
+        account_name: &str,
+        basis: Decimal,
+    ) {
+        let views: Vec<TransactionView> = txs
+            .into_iter()
+            .map(|x: &Transaction| TransactionView::new_with_basis(x, account_name, Some(basis)))
             .collect();
         let mut table = Table::new(views);
         table.with(Style::modern());
@@ -48,6 +80,7 @@ mod tests {
 
     #[test]
     fn new_maps_transaction_fields() {
+        crate::zen::set_enabled(false);
         let trade_id = Uuid::new_v4();
         let tx = Transaction::new(
             Uuid::new_v4(),
@@ -64,7 +97,26 @@ mod tests {
     }
 
     #[test]
+    fn new_uses_percentage_or_hidden_amount_in_zen_mode() {
+        crate::zen::set_enabled(true);
+        let tx = Transaction::new(
+            Uuid::new_v4(),
+            TransactionCategory::Deposit,
+            &Currency::USD,
+            dec!(25),
+        );
+
+        let with_basis = TransactionView::new_with_basis(&tx, "main", Some(dec!(100)));
+        assert_eq!(with_basis.amount, "25.0%");
+
+        let without_basis = TransactionView::new(&tx, "main");
+        assert_eq!(without_basis.amount, "hidden");
+        crate::zen::set_enabled(false);
+    }
+
+    #[test]
     fn display_transactions_runs_for_smoke_coverage() {
+        crate::zen::set_enabled(false);
         let tx = Transaction::new(
             Uuid::new_v4(),
             TransactionCategory::Deposit,
@@ -72,5 +124,6 @@ mod tests {
             dec!(1),
         );
         TransactionView::display_transactions(vec![&tx], "paper");
+        TransactionView::display_transactions_with_basis(vec![&tx], "paper", dec!(10));
     }
 }

--- a/cli/src/zen.rs
+++ b/cli/src/zen.rs
@@ -1,0 +1,129 @@
+use rust_decimal::Decimal;
+use rust_decimal_macros::dec;
+use std::cell::Cell;
+
+thread_local! {
+    static ENABLED: Cell<bool> = const { Cell::new(false) };
+}
+
+pub(crate) fn set_enabled(enabled: bool) {
+    ENABLED.with(|flag| flag.set(enabled));
+}
+
+pub(crate) fn is_enabled() -> bool {
+    ENABLED.with(Cell::get)
+}
+
+pub(crate) fn decimal_string(value: Decimal) -> String {
+    value.round_dp(8).normalize().to_string()
+}
+
+pub(crate) fn amount(value: Decimal) -> String {
+    if is_enabled() {
+        "hidden".to_string()
+    } else {
+        decimal_string(value)
+    }
+}
+
+pub(crate) fn amount_share(value: Decimal, basis: Decimal) -> String {
+    if is_enabled() {
+        percentage_of(value, basis)
+    } else {
+        decimal_string(value)
+    }
+}
+
+pub(crate) fn price_relative_to(value: Decimal, basis: Decimal) -> String {
+    if is_enabled() {
+        percentage_of(value, basis)
+    } else {
+        decimal_string(value)
+    }
+}
+
+pub(crate) fn currency(value: Decimal) -> String {
+    if is_enabled() {
+        "hidden".to_string()
+    } else if value >= dec!(0) {
+        format!("${value:.2}")
+    } else {
+        format!("-${:.2}", value.abs())
+    }
+}
+
+pub(crate) fn currency_share(value: Decimal, basis: Decimal) -> String {
+    if is_enabled() {
+        percentage_of(value, basis)
+    } else {
+        currency(value)
+    }
+}
+
+pub(crate) fn signed_currency(value: Decimal) -> String {
+    if is_enabled() {
+        "hidden".to_string()
+    } else if value >= dec!(0) {
+        format!("+${value:.2}")
+    } else {
+        format!("-${:.2}", value.abs())
+    }
+}
+
+pub(crate) fn percentage_of(value: Decimal, basis: Decimal) -> String {
+    if basis == Decimal::ZERO {
+        "0.0%".to_string()
+    } else {
+        let percentage = value
+            .checked_mul(dec!(100))
+            .and_then(|v| v.checked_div(basis))
+            .unwrap_or(Decimal::ZERO);
+        format!("{percentage:.1}%")
+    }
+}
+
+pub(crate) fn signed_percentage_of(value: Decimal, basis: Decimal) -> String {
+    if basis == Decimal::ZERO {
+        "0.0%".to_string()
+    } else {
+        let percentage = value
+            .checked_mul(dec!(100))
+            .and_then(|v| v.checked_div(basis))
+            .unwrap_or(Decimal::ZERO);
+        if percentage > Decimal::ZERO {
+            format!("+{percentage:.1}%")
+        } else {
+            format!("{percentage:.1}%")
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{amount, amount_share, currency, price_relative_to, set_enabled, signed_currency};
+    use rust_decimal_macros::dec;
+
+    #[test]
+    fn formatters_keep_amounts_visible_when_disabled() {
+        set_enabled(false);
+
+        assert_eq!(amount(dec!(12.3400)), "12.34");
+        assert_eq!(amount_share(dec!(25), dec!(100)), "25");
+        assert_eq!(price_relative_to(dec!(110), dec!(100)), "110");
+        assert_eq!(currency(dec!(12.3)), "$12.30");
+        assert_eq!(signed_currency(dec!(-12.3)), "-$12.30");
+    }
+
+    #[test]
+    fn formatters_hide_amounts_or_show_percentages_when_enabled() {
+        set_enabled(true);
+
+        assert_eq!(amount(dec!(12.34)), "hidden");
+        assert_eq!(amount_share(dec!(25), dec!(100)), "25.0%");
+        assert_eq!(price_relative_to(dec!(110), dec!(100)), "110.0%");
+        assert_eq!(currency(dec!(12.3)), "hidden");
+        assert_eq!(amount_share(dec!(1), dec!(0)), "0.0%");
+
+        set_enabled(false);
+    }
+}


### PR DESCRIPTION
## Summary
- add a global --zen flag and CLI display state for privacy-safe output
- render balances, trade/order views, reports, and command confirmations without absolute dollar amounts where possible
- add focused zen-mode formatting tests

Closes #96

## Verification
- cargo test -p trust-cli zen -- --test-threads=1
- cargo clippy -p trust-cli --all-targets --all-features -- -D warnings
- cargo test -p trust-cli -- --test-threads=1
- make ci-fast
- cargo test --locked --no-default-features --workspace