### PR TITLE
feat(core): add wash sale detection and report

### DIFF
--- a/cli/src/command_routing.rs
+++ b/cli/src/command_routing.rs
@@ -102,6 +102,7 @@ pub enum ReportSubcommand<'a> {
     Benchmark(&'a ArgMatches),
     Timeline(&'a ArgMatches),
     BiasSummary(&'a ArgMatches),
+    WashSales(&'a ArgMatches),
 }
 
 pub enum MarketDataSubcommand<'a> {
@@ -296,6 +297,7 @@ pub fn parse_report_subcommand(sub_matches: &ArgMatches) -> ReportSubcommand<'_>
         Some(("benchmark", sub_sub_matches)) => ReportSubcommand::Benchmark(sub_sub_matches),
         Some(("timeline", sub_sub_matches)) => ReportSubcommand::Timeline(sub_sub_matches),
         Some(("bias-summary", sub_sub_matches)) => ReportSubcommand::BiasSummary(sub_sub_matches),
+        Some(("wash-sales", sub_sub_matches)) => ReportSubcommand::WashSales(sub_sub_matches),
         _ => unreachable!("No subcommand provided"),
     }
 }
@@ -794,7 +796,8 @@ mod tests {
                 .subcommand(Command::new("attribution"))
                 .subcommand(Command::new("benchmark"))
                 .subcommand(Command::new("timeline"))
-                .subcommand(Command::new("bias-summary")),
+                .subcommand(Command::new("bias-summary"))
+                .subcommand(Command::new("wash-sales")),
         );
         for (sub, expected) in [
             ("drawdown", "drawdown"),
@@ -807,6 +810,7 @@ mod tests {
             ("benchmark", "benchmark"),
             ("timeline", "timeline"),
             ("bias-summary", "bias-summary"),
+            ("wash-sales", "wash-sales"),
         ] {
             let m = report.clone().get_matches_from(["trust", "report", sub]);
             let (_, sm) = m.subcommand().expect("expected report");
@@ -821,6 +825,7 @@ mod tests {
                 ReportSubcommand::Benchmark(_) => "benchmark",
                 ReportSubcommand::Timeline(_) => "timeline",
                 ReportSubcommand::BiasSummary(_) => "bias-summary",
+                ReportSubcommand::WashSales(_) => "wash-sales",
             };
             assert_eq!(got, expected);
         }

--- a/cli/src/commands/report_command.rs
+++ b/cli/src/commands/report_command.rs
@@ -274,6 +274,21 @@ impl ReportCommandBuilder {
         );
         self
     }
+
+    pub fn wash_sales(mut self) -> Self {
+        self.subcommands.push(
+            Command::new("wash-sales")
+                .about("Detect potential wash sales and replacement cost-basis adjustments")
+                .arg(
+                    Arg::new("account")
+                        .long("account")
+                        .value_name("ACCOUNT_ID_OR_NAME")
+                        .help("Filter by account ID or name")
+                        .required(false),
+                ),
+        );
+        self
+    }
 }
 
 impl Default for ReportCommandBuilder {
@@ -299,6 +314,7 @@ mod tests {
             .benchmark()
             .timeline()
             .bias_summary()
+            .wash_sales()
             .build();
         for name in [
             "performance",
@@ -311,6 +327,7 @@ mod tests {
             "benchmark",
             "timeline",
             "bias-summary",
+            "wash-sales",
         ] {
             assert!(cmd.get_subcommands().any(|c| c.get_name() == name));
         }
@@ -528,5 +545,27 @@ mod tests {
             Some("acc-1")
         );
         assert_eq!(sub.get_one::<i32>("days"), Some(&14));
+    }
+
+    #[test]
+    fn report_wash_sales_parses_optional_account() {
+        let cmd = ReportCommandBuilder::new().wash_sales().build();
+        let matches = cmd
+            .try_get_matches_from([
+                "report",
+                "--format",
+                "json",
+                "wash-sales",
+                "--account",
+                "paper-main",
+            ])
+            .expect("wash-sales should parse");
+        let sub = matches
+            .subcommand_matches("wash-sales")
+            .expect("wash-sales subcommand");
+        assert_eq!(
+            sub.get_one::<String>("account").map(String::as_str),
+            Some("paper-main")
+        );
     }
 }

--- a/cli/src/dispatcher.rs
+++ b/cli/src/dispatcher.rs
@@ -44,7 +44,9 @@ use core::services::leveling::{
     LevelCriterionProgress, LevelEvaluationOutcome, LevelPathProgress, LevelPerformanceSnapshot,
     LevelProgressReport,
 };
-use core::services::{AdvisoryThresholds, TradeProposal};
+use core::services::{
+    AdvisoryThresholds, TradeProposal, WashSaleMatch, WashSaleReplacementAdjustment, WashSaleReport,
+};
 use core::TrustFacade;
 use db_sqlite::SqliteDatabase;
 use db_sqlite::{ImportMode, ImportOptions};
@@ -286,6 +288,7 @@ struct AttributionReportCommand;
 struct BenchmarkReportCommand;
 struct TimelineReportCommand;
 struct BiasSummaryReportCommand;
+struct WashSalesReportCommand;
 
 impl MarketDataCommandHandler for MarketDataSnapshotCommand {
     fn execute(
@@ -460,6 +463,17 @@ impl ReportCommandHandler for BiasSummaryReportCommand {
         format: ReportOutputFormat,
     ) -> Result<(), CliError> {
         dispatcher.bias_summary_report(sub_matches, format)
+    }
+}
+
+impl ReportCommandHandler for WashSalesReportCommand {
+    fn execute(
+        &self,
+        dispatcher: &mut ArgDispatcher,
+        sub_matches: &ArgMatches,
+        format: ReportOutputFormat,
+    ) -> Result<(), CliError> {
+        dispatcher.wash_sales_report(sub_matches, format)
     }
 }
 
@@ -736,6 +750,7 @@ impl ArgDispatcher {
         static BENCHMARK: BenchmarkReportCommand = BenchmarkReportCommand;
         static TIMELINE: TimelineReportCommand = TimelineReportCommand;
         static BIAS_SUMMARY: BiasSummaryReportCommand = BiasSummaryReportCommand;
+        static WASH_SALES: WashSalesReportCommand = WashSalesReportCommand;
 
         match subcommand {
             ReportSubcommand::Performance(sub_matches) => (&PERFORMANCE, sub_matches),
@@ -748,6 +763,7 @@ impl ArgDispatcher {
             ReportSubcommand::Benchmark(sub_matches) => (&BENCHMARK, sub_matches),
             ReportSubcommand::Timeline(sub_matches) => (&TIMELINE, sub_matches),
             ReportSubcommand::BiasSummary(sub_matches) => (&BIAS_SUMMARY, sub_matches),
+            ReportSubcommand::WashSales(sub_matches) => (&WASH_SALES, sub_matches),
         }
     }
 
@@ -7408,6 +7424,115 @@ impl ArgDispatcher {
         }
 
         Ok(())
+    }
+
+    fn wash_sales_report(
+        &mut self,
+        sub_matches: &ArgMatches,
+        format: ReportOutputFormat,
+    ) -> Result<(), CliError> {
+        let account_id = if let Some(raw) = sub_matches.get_one::<String>("account") {
+            Some(self.resolve_account_arg(raw, format)?.id)
+        } else {
+            None
+        };
+        let report = self
+            .trust
+            .wash_sale_report(account_id)
+            .map_err(|error| Self::report_error(format, "report_failed", error.to_string()))?;
+
+        match format {
+            ReportOutputFormat::Text => Self::print_wash_sales_text(&report, account_id),
+            ReportOutputFormat::Json => {
+                let payload = json!({
+                    "report": "wash_sales",
+                    "format_version": 1,
+                    "generated_at": Utc::now().to_rfc3339(),
+                    "scope": { "account_id": account_id.map(|id| id.to_string()) },
+                    "data": {
+                        "scanned_trade_count": report.scanned_trade_count,
+                        "eligible_loss_trade_count": report.eligible_loss_trade_count,
+                        "wash_sale_count": report.wash_sale_count,
+                        "total_disallowed_loss": Self::decimal_string(report.total_disallowed_loss),
+                        "total_basis_adjustment": Self::decimal_string(report.total_basis_adjustment),
+                        "matches": report.matches.iter().map(Self::wash_sale_match_json).collect::<Vec<Value>>(),
+                        "replacement_adjustments": report.replacement_adjustments.iter().map(Self::wash_sale_adjustment_json).collect::<Vec<Value>>()
+                    },
+                    "consistency": {
+                        "basis_adjustments_match_disallowed_loss": report.total_basis_adjustment == report.total_disallowed_loss,
+                        "match_count_balanced": report.wash_sale_count == report.matches.len(),
+                    }
+                });
+                Self::print_json(&payload)?;
+            }
+        }
+
+        Ok(())
+    }
+
+    fn print_wash_sales_text(report: &WashSaleReport, account_id: Option<Uuid>) {
+        println!("Wash sale report");
+        println!("================");
+        match account_id {
+            Some(id) => println!("account_id: {id}"),
+            None => println!("account_id: all"),
+        }
+        println!("trades_scanned: {}", report.scanned_trade_count);
+        println!("eligible_loss_trades: {}", report.eligible_loss_trade_count);
+        println!("wash_sales: {}", report.wash_sale_count);
+        println!(
+            "total_disallowed_loss: {}",
+            Self::decimal_string(report.total_disallowed_loss)
+        );
+        println!(
+            "total_basis_adjustment: {}",
+            Self::decimal_string(report.total_basis_adjustment)
+        );
+        if report.matches.is_empty() {
+            println!("No wash sales detected.");
+            return;
+        }
+        for wash_sale in &report.matches {
+            println!(
+                "{} sale={} replacement={} qty={} disallowed_loss={} adjusted_basis={}",
+                wash_sale.symbol,
+                wash_sale.loss_trade_id,
+                wash_sale.replacement_trade_id,
+                Self::decimal_string(wash_sale.matched_quantity),
+                Self::decimal_string(wash_sale.disallowed_loss),
+                Self::decimal_string(wash_sale.adjusted_replacement_cost_basis)
+            );
+        }
+    }
+
+    fn wash_sale_match_json(wash_sale: &WashSaleMatch) -> Value {
+        json!({
+            "account_id": wash_sale.account_id.to_string(),
+            "symbol": wash_sale.symbol.clone(),
+            "loss_trade_id": wash_sale.loss_trade_id.to_string(),
+            "replacement_trade_id": wash_sale.replacement_trade_id.to_string(),
+            "sale_date": wash_sale.sale_date.to_string(),
+            "replacement_purchase_date": wash_sale.replacement_purchase_date.to_string(),
+            "loss_quantity": Self::decimal_string(wash_sale.loss_quantity),
+            "matched_quantity": Self::decimal_string(wash_sale.matched_quantity),
+            "realized_loss": Self::decimal_string(wash_sale.realized_loss),
+            "disallowed_loss": Self::decimal_string(wash_sale.disallowed_loss),
+            "replacement_cost_basis": Self::decimal_string(wash_sale.replacement_cost_basis),
+            "adjusted_replacement_cost_basis": Self::decimal_string(wash_sale.adjusted_replacement_cost_basis),
+        })
+    }
+
+    fn wash_sale_adjustment_json(adjustment: &WashSaleReplacementAdjustment) -> Value {
+        json!({
+            "replacement_trade_id": adjustment.replacement_trade_id.to_string(),
+            "account_id": adjustment.account_id.to_string(),
+            "symbol": adjustment.symbol.clone(),
+            "replacement_purchase_date": adjustment.replacement_purchase_date.to_string(),
+            "matched_quantity": Self::decimal_string(adjustment.matched_quantity),
+            "original_cost_basis": Self::decimal_string(adjustment.original_cost_basis),
+            "basis_adjustment": Self::decimal_string(adjustment.basis_adjustment),
+            "adjusted_cost_basis": Self::decimal_string(adjustment.adjusted_cost_basis),
+        })
     }
 
     #[allow(clippy::too_many_lines)]

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -164,6 +164,7 @@ fn build_cli() -> Command {
                 .benchmark()
                 .timeline()
                 .bias_summary()
+                .wash_sales()
                 .build(),
         )
         .subcommand(

--- a/cli/tests/integration_test_report_json_contract.rs
+++ b/cli/tests/integration_test_report_json_contract.rs
@@ -1,7 +1,8 @@
+use chrono::{NaiveDate, NaiveDateTime};
 use core::TrustFacade;
 use db_sqlite::SqliteDatabase;
 use model::{
-    Currency, DatabaseFactory, DraftTrade, Environment, Status, TradeCategory,
+    Currency, DatabaseFactory, DraftTrade, Environment, Order, OrderStatus, Status, TradeCategory,
     TradingVehicleCategory,
 };
 use rust_decimal::Decimal;
@@ -279,6 +280,160 @@ fn seed_account_with_adjusted_metrics_history(database_url: &str) -> Uuid {
     )
 }
 
+fn report_test_datetime(year: i32, month: u32, day: u32) -> NaiveDateTime {
+    NaiveDate::from_ymd_opt(year, month, day)
+        .expect("valid report test date")
+        .and_hms_opt(14, 30, 0)
+        .expect("valid report test time")
+}
+
+fn persist_filled_order(
+    database_url: &str,
+    order: &Order,
+    quantity: Decimal,
+    price: Decimal,
+    filled_at: NaiveDateTime,
+) {
+    let database = SqliteDatabase::new(database_url);
+    let mut filled = order.clone();
+    filled.status = OrderStatus::Filled;
+    filled.filled_quantity = quantity;
+    filled.average_filled_price = Some(price);
+    filled.filled_at = Some(filled_at);
+    database
+        .order_write()
+        .update(&filled)
+        .expect("filled order should be persisted");
+}
+
+fn seed_account_with_wash_sale(database_url: &str) -> Uuid {
+    let database = SqliteDatabase::new(database_url);
+    let mut trust = TrustFacade::new(Box::new(database), Box::new(alpaca_broker::AlpacaBroker));
+
+    let account = trust
+        .create_account(
+            "Wash Sale Account",
+            "wash sale contract test",
+            Environment::Paper,
+            dec!(25.0),
+            dec!(10.0),
+        )
+        .expect("create account");
+    trust
+        .create_transaction(
+            &account,
+            &model::TransactionCategory::Deposit,
+            dec!(50000),
+            &Currency::USD,
+        )
+        .expect("deposit funds");
+    let vehicle = trust
+        .create_trading_vehicle(
+            "AAPL",
+            Some("US0378331005"),
+            &TradingVehicleCategory::Stock,
+            "alpaca",
+        )
+        .expect("create trading vehicle");
+
+    let loss = trust
+        .create_trade(
+            DraftTrade {
+                account: account.clone(),
+                trading_vehicle: vehicle.clone(),
+                quantity: dec!(10),
+                category: TradeCategory::Long,
+                currency: Currency::USD,
+                sector: Some("Technology".to_string()),
+                asset_class: Some("Stocks".to_string()),
+                thesis: Some("wash sale loss".to_string()),
+                context: None,
+            },
+            dec!(100),
+            dec!(90),
+            dec!(120),
+        )
+        .expect("create loss trade");
+    let (funded_loss, _, _, _) = trust.fund_trade(&loss).expect("fund loss trade");
+    persist_filled_order(
+        database_url,
+        &funded_loss.entry,
+        dec!(10),
+        dec!(100),
+        report_test_datetime(2026, 1, 2),
+    );
+    persist_filled_order(
+        database_url,
+        &funded_loss.safety_stop,
+        dec!(10),
+        dec!(90),
+        report_test_datetime(2026, 1, 10),
+    );
+    let database = SqliteDatabase::new(database_url);
+    let closed_loss = database
+        .trade_write()
+        .update_trade_status(Status::ClosedStopLoss, &funded_loss)
+        .expect("close loss trade");
+    database
+        .trade_balance_write()
+        .update_trade_balance(
+            &closed_loss,
+            funded_loss.balance.funding,
+            dec!(0),
+            dec!(900),
+            dec!(0),
+            dec!(-100),
+        )
+        .expect("persist loss balance");
+
+    let replacement = trust
+        .create_trade(
+            DraftTrade {
+                account: account.clone(),
+                trading_vehicle: vehicle,
+                quantity: dec!(5),
+                category: TradeCategory::Long,
+                currency: Currency::USD,
+                sector: Some("Technology".to_string()),
+                asset_class: Some("Stocks".to_string()),
+                thesis: Some("replacement buy".to_string()),
+                context: None,
+            },
+            dec!(95),
+            dec!(88),
+            dec!(115),
+        )
+        .expect("create replacement trade");
+    let (funded_replacement, _, _, _) = trust
+        .fund_trade(&replacement)
+        .expect("fund replacement trade");
+    persist_filled_order(
+        database_url,
+        &funded_replacement.entry,
+        dec!(5),
+        dec!(95),
+        report_test_datetime(2026, 1, 20),
+    );
+    let database = SqliteDatabase::new(database_url);
+    let filled_replacement = database
+        .trade_write()
+        .update_trade_status(Status::Filled, &funded_replacement)
+        .expect("fill replacement trade");
+    database
+        .trade_balance_write()
+        .update_trade_balance(
+            &filled_replacement,
+            funded_replacement.balance.funding,
+            funded_replacement.balance.funding,
+            dec!(0),
+            dec!(0),
+            dec!(0),
+        )
+        .expect("persist replacement balance");
+
+    account.id
+}
+
 #[test]
 fn test_risk_report_json_math_consistency() {
     let database_url = format!("file:test_risk_report_json_{}.db", Uuid::new_v4().simple());
@@ -526,6 +681,61 @@ fn test_performance_report_json_has_balanced_counts() {
     assert_report_envelope(&payload, "performance");
     assert_eq!(payload["consistency"]["trade_count_balanced"], true);
     assert!(payload["data"]["total_trades"].is_number());
+}
+
+#[test]
+fn test_wash_sales_report_json_flags_loss_trade_and_basis_adjustment() {
+    let database_url = format!(
+        "file:test_wash_sales_report_json_{}.db",
+        Uuid::new_v4().simple()
+    );
+    let _cleanup = TestDatabaseCleanup::new(&database_url);
+    let account_id = seed_account_with_wash_sale(&database_url);
+
+    let output = run_report(
+        &database_url,
+        &[
+            "report",
+            "wash-sales",
+            "--format",
+            "json",
+            "--account",
+            &account_id.to_string(),
+        ],
+    );
+
+    assert!(output.status.success(), "wash-sales report should succeed");
+
+    let payload = parse_stdout_json(&output);
+    assert_report_envelope(&payload, "wash_sales");
+    assert_eq!(payload["scope"]["account_id"], account_id.to_string());
+    assert_eq!(payload["data"]["eligible_loss_trade_count"], 1);
+    assert_eq!(payload["data"]["wash_sale_count"], 1);
+    assert_eq!(payload["data"]["total_disallowed_loss"], "50");
+    assert_eq!(payload["data"]["total_basis_adjustment"], "50");
+    assert_eq!(
+        payload["consistency"]["basis_adjustments_match_disallowed_loss"],
+        true
+    );
+
+    let matches = payload["data"]["matches"]
+        .as_array()
+        .expect("wash sale matches should be an array");
+    let first_match = matches.first().expect("one wash sale match");
+    assert_eq!(first_match["symbol"], "AAPL");
+    assert_eq!(first_match["loss_quantity"], "10");
+    assert_eq!(first_match["matched_quantity"], "5");
+    assert_eq!(first_match["realized_loss"], "100");
+    assert_eq!(first_match["disallowed_loss"], "50");
+    assert_eq!(first_match["replacement_cost_basis"], "475");
+    assert_eq!(first_match["adjusted_replacement_cost_basis"], "525");
+
+    let adjustments = payload["data"]["replacement_adjustments"]
+        .as_array()
+        .expect("replacement adjustments should be an array");
+    let adjustment = adjustments.first().expect("one replacement adjustment");
+    assert_eq!(adjustment["basis_adjustment"], "50");
+    assert_eq!(adjustment["adjusted_cost_basis"], "525");
 }
 
 #[test]

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -32,7 +32,8 @@
 
 use crate::services::{
     AdvisoryHistoryEntry, AdvisoryResult, AdvisoryThresholds, FundTransferService,
-    PortfolioAdvisoryStatus, ProfitDistributionService, TradeProposal,
+    PortfolioAdvisoryStatus, ProfitDistributionService, TradeProposal, WashSaleReport,
+    WashSaleService,
 };
 use advisor::{
     CalendarCredentials, CatalystScanRequest, CatalystScanResult, CatalystScanner,
@@ -1245,6 +1246,48 @@ impl TrustFacade {
         }
 
         Ok(all_trades)
+    }
+
+    /// Calculate wash sale matches and replacement basis adjustments.
+    ///
+    /// The report is computed from the trade ledger at read time. It flags
+    /// loss trades and replacement purchases without mutating historical trade
+    /// records, so downstream tax reports can consume the adjusted basis data
+    /// deterministically.
+    pub fn wash_sale_report(
+        &mut self,
+        account_id: Option<Uuid>,
+    ) -> Result<WashSaleReport, Box<dyn std::error::Error>> {
+        let trades = self.search_all_trades_for_tax(account_id)?;
+        WashSaleService::detect(&trades).map_err(|error| Box::new(error) as Box<dyn StdError>)
+    }
+
+    fn search_all_trades_for_tax(
+        &mut self,
+        account_id: Option<Uuid>,
+    ) -> Result<Vec<Trade>, Box<dyn std::error::Error>> {
+        let mut all_trades = Vec::new();
+        if let Some(id) = account_id {
+            self.append_all_status_trades(id, &mut all_trades)?;
+            return Ok(all_trades);
+        }
+
+        for account in self.search_all_accounts()? {
+            self.append_all_status_trades(account.id, &mut all_trades)?;
+        }
+        Ok(all_trades)
+    }
+
+    fn append_all_status_trades(
+        &mut self,
+        account_id: Uuid,
+        all_trades: &mut Vec<Trade>,
+    ) -> Result<(), Box<dyn std::error::Error>> {
+        for status in Status::all() {
+            let mut status_trades = self.search_trades(account_id, status)?;
+            all_trades.append(&mut status_trades);
+        }
+        Ok(())
     }
 
     // Trade Steps

--- a/core/src/services/mod.rs
+++ b/core/src/services/mod.rs
@@ -15,6 +15,8 @@ pub mod grading;
 pub mod leveling;
 /// Profit distribution service for handling account hierarchy and fund transfers
 pub mod profit_distribution_service;
+/// Wash sale detection and basis adjustment reporting
+pub mod wash_sale;
 
 pub use advisory::{
     AdvisoryAlertLevel, AdvisoryHistoryEntry, AdvisoryResult, AdvisoryThresholds,
@@ -23,3 +25,6 @@ pub use advisory::{
 pub use event_distribution_service::EventDistributionService;
 pub use fund_transfer_service::FundTransferService;
 pub use profit_distribution_service::ProfitDistributionService;
+pub use wash_sale::{
+    WashSaleError, WashSaleMatch, WashSaleReplacementAdjustment, WashSaleReport, WashSaleService,
+};

--- a/core/src/services/wash_sale.rs
+++ b/core/src/services/wash_sale.rs
@@ -1,0 +1,778 @@
+//! Wash sale detection and basis adjustment reporting.
+
+use chrono::{Days, NaiveDate};
+use model::{Status, Trade, TradeCategory, TradingVehicleCategory};
+use rust_decimal::Decimal;
+use std::collections::BTreeMap;
+use std::error::Error;
+use std::fmt::{Display, Formatter};
+use uuid::Uuid;
+
+const WASH_SALE_WINDOW_DAYS: u64 = 30;
+
+/// Error returned when wash sale analysis cannot be computed safely.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct WashSaleError {
+    context: &'static str,
+}
+
+impl WashSaleError {
+    fn calculation(context: &'static str) -> Self {
+        Self { context }
+    }
+}
+
+impl Display for WashSaleError {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(f, "wash sale calculation failed: {}", self.context)
+    }
+}
+
+impl Error for WashSaleError {}
+
+/// A single loss-sale to replacement-purchase wash sale allocation.
+#[derive(Debug, Clone, PartialEq)]
+pub struct WashSaleMatch {
+    /// Account owning both the loss sale and replacement trade.
+    pub account_id: Uuid,
+    /// Normalized symbol that matched between the sale and replacement.
+    pub symbol: String,
+    /// Trade that realized the loss.
+    pub loss_trade_id: Uuid,
+    /// Trade that bought replacement shares or units.
+    pub replacement_trade_id: Uuid,
+    /// Loss sale date.
+    pub sale_date: NaiveDate,
+    /// Replacement purchase date.
+    pub replacement_purchase_date: NaiveDate,
+    /// Quantity sold at a loss.
+    pub loss_quantity: Decimal,
+    /// Quantity matched to this replacement.
+    pub matched_quantity: Decimal,
+    /// Total realized loss on the loss trade before wash-sale allocation.
+    pub realized_loss: Decimal,
+    /// Loss disallowed for this matched replacement quantity.
+    pub disallowed_loss: Decimal,
+    /// Replacement cost basis before wash-sale adjustment for the matched quantity.
+    pub replacement_cost_basis: Decimal,
+    /// Adjusted replacement cost basis for the matched quantity.
+    pub adjusted_replacement_cost_basis: Decimal,
+}
+
+/// Aggregated cost-basis adjustment for one replacement trade.
+#[derive(Debug, Clone, PartialEq)]
+pub struct WashSaleReplacementAdjustment {
+    /// Replacement trade whose cost basis is adjusted.
+    pub replacement_trade_id: Uuid,
+    /// Account owning the replacement trade.
+    pub account_id: Uuid,
+    /// Symbol for the replacement trade.
+    pub symbol: String,
+    /// Purchase date for the replacement trade.
+    pub replacement_purchase_date: NaiveDate,
+    /// Quantity matched across all loss-sale allocations.
+    pub matched_quantity: Decimal,
+    /// Original cost basis for the matched replacement quantity.
+    pub original_cost_basis: Decimal,
+    /// Disallowed loss added to replacement basis.
+    pub basis_adjustment: Decimal,
+    /// Adjusted cost basis for the matched replacement quantity.
+    pub adjusted_cost_basis: Decimal,
+}
+
+/// Wash sale analysis result for a trade set.
+#[derive(Debug, Clone, PartialEq)]
+pub struct WashSaleReport {
+    /// Number of trades scanned.
+    pub scanned_trade_count: usize,
+    /// Number of eligible loss trades found before allocation.
+    pub eligible_loss_trade_count: usize,
+    /// Number of loss-sale to replacement-purchase allocations.
+    pub wash_sale_count: usize,
+    /// Sum of all disallowed losses.
+    pub total_disallowed_loss: Decimal,
+    /// Sum of all replacement basis adjustments.
+    pub total_basis_adjustment: Decimal,
+    /// Individual wash sale allocations.
+    pub matches: Vec<WashSaleMatch>,
+    /// Replacement-trade cost-basis adjustments.
+    pub replacement_adjustments: Vec<WashSaleReplacementAdjustment>,
+}
+
+/// Stateless wash sale detector.
+#[derive(Debug, Default)]
+pub struct WashSaleService;
+
+impl WashSaleService {
+    /// Detect wash sale allocations for the provided trade ledger.
+    pub fn detect(trades: &[Trade]) -> Result<WashSaleReport, WashSaleError> {
+        let mut losses = loss_lots(trades)?;
+        let mut replacements = replacement_lots(trades);
+        losses.sort_by_key(|lot| (lot.sale_date, lot.trade_id));
+        replacements.sort_by_key(|lot| (lot.purchase_date, lot.trade_id));
+
+        let mut matches = Vec::new();
+        for loss in &mut losses {
+            allocate_loss_to_replacements(loss, &mut replacements, &mut matches)?;
+        }
+
+        let replacement_adjustments = aggregate_replacement_adjustments(&matches)?;
+        let total_disallowed_loss = sum_decimal(matches.iter().map(|item| item.disallowed_loss))?;
+        let total_basis_adjustment = sum_decimal(
+            replacement_adjustments
+                .iter()
+                .map(|item| item.basis_adjustment),
+        )?;
+        let wash_sale_count = matches.len();
+
+        Ok(WashSaleReport {
+            scanned_trade_count: trades.len(),
+            eligible_loss_trade_count: losses.len(),
+            wash_sale_count,
+            total_disallowed_loss,
+            total_basis_adjustment,
+            matches,
+            replacement_adjustments,
+        })
+    }
+}
+
+#[derive(Debug, Clone)]
+struct LossLot {
+    account_id: Uuid,
+    trade_id: Uuid,
+    symbol: String,
+    sale_date: NaiveDate,
+    quantity: Decimal,
+    remaining_quantity: Decimal,
+    realized_loss: Decimal,
+}
+
+#[derive(Debug, Clone)]
+struct ReplacementLot {
+    account_id: Uuid,
+    trade_id: Uuid,
+    symbol: String,
+    purchase_date: NaiveDate,
+    exit_date: Option<NaiveDate>,
+    remaining_quantity: Decimal,
+    cost_basis_per_unit: Decimal,
+}
+
+fn loss_lots(trades: &[Trade]) -> Result<Vec<LossLot>, WashSaleError> {
+    trades
+        .iter()
+        .filter_map(loss_lot)
+        .collect::<Result<Vec<_>, _>>()
+}
+
+fn loss_lot(trade: &Trade) -> Option<Result<LossLot, WashSaleError>> {
+    if !is_wash_sale_eligible_trade(trade) || trade.category != TradeCategory::Long {
+        return None;
+    }
+    if !matches!(trade.status, Status::ClosedStopLoss | Status::ClosedTarget) {
+        return None;
+    }
+    if trade.balance.total_performance >= Decimal::ZERO {
+        return None;
+    }
+
+    let quantity = exit_quantity(trade);
+    if quantity <= Decimal::ZERO {
+        return None;
+    }
+
+    let sale_date = exit_date(trade)?;
+
+    Some(
+        Decimal::ZERO
+            .checked_sub(trade.balance.total_performance)
+            .ok_or_else(|| WashSaleError::calculation("realized loss overflow"))
+            .map(|realized_loss| LossLot {
+                account_id: trade.account_id,
+                trade_id: trade.id,
+                symbol: normalized_symbol(trade),
+                sale_date,
+                quantity,
+                remaining_quantity: quantity,
+                realized_loss,
+            }),
+    )
+}
+
+fn replacement_lots(trades: &[Trade]) -> Vec<ReplacementLot> {
+    trades.iter().filter_map(replacement_lot).collect()
+}
+
+fn replacement_lot(trade: &Trade) -> Option<ReplacementLot> {
+    if !is_wash_sale_eligible_trade(trade) || trade.category != TradeCategory::Long {
+        return None;
+    }
+
+    let quantity = entry_quantity(trade);
+    if quantity <= Decimal::ZERO {
+        return None;
+    }
+
+    let purchase_date = entry_date(trade)?;
+    let price = trade
+        .entry
+        .average_filled_price
+        .unwrap_or(trade.entry.unit_price);
+    if price <= Decimal::ZERO {
+        return None;
+    }
+
+    Some(ReplacementLot {
+        account_id: trade.account_id,
+        trade_id: trade.id,
+        symbol: normalized_symbol(trade),
+        purchase_date,
+        exit_date: exit_date(trade),
+        remaining_quantity: quantity,
+        cost_basis_per_unit: price,
+    })
+}
+
+fn allocate_loss_to_replacements(
+    loss: &mut LossLot,
+    replacements: &mut [ReplacementLot],
+    matches: &mut Vec<WashSaleMatch>,
+) -> Result<(), WashSaleError> {
+    for replacement in replacements {
+        if loss.remaining_quantity <= Decimal::ZERO {
+            break;
+        }
+        if !can_match(loss, replacement)? {
+            continue;
+        }
+
+        let matched_quantity = min_decimal(loss.remaining_quantity, replacement.remaining_quantity);
+        if matched_quantity <= Decimal::ZERO {
+            continue;
+        }
+
+        let disallowed_loss = prorate_loss(loss.realized_loss, loss.quantity, matched_quantity)?;
+        let replacement_cost_basis = checked_mul(
+            replacement.cost_basis_per_unit,
+            matched_quantity,
+            "replacement basis",
+        )?;
+        let adjusted_replacement_cost_basis = checked_add(
+            replacement_cost_basis,
+            disallowed_loss,
+            "adjusted replacement basis",
+        )?;
+
+        loss.remaining_quantity = checked_sub(
+            loss.remaining_quantity,
+            matched_quantity,
+            "loss remaining quantity",
+        )?;
+        replacement.remaining_quantity = checked_sub(
+            replacement.remaining_quantity,
+            matched_quantity,
+            "replacement remaining quantity",
+        )?;
+
+        matches.push(WashSaleMatch {
+            account_id: loss.account_id,
+            symbol: loss.symbol.clone(),
+            loss_trade_id: loss.trade_id,
+            replacement_trade_id: replacement.trade_id,
+            sale_date: loss.sale_date,
+            replacement_purchase_date: replacement.purchase_date,
+            loss_quantity: loss.quantity,
+            matched_quantity,
+            realized_loss: loss.realized_loss,
+            disallowed_loss,
+            replacement_cost_basis,
+            adjusted_replacement_cost_basis,
+        });
+    }
+    Ok(())
+}
+
+fn can_match(loss: &LossLot, replacement: &ReplacementLot) -> Result<bool, WashSaleError> {
+    if loss.account_id != replacement.account_id
+        || loss.trade_id == replacement.trade_id
+        || loss.symbol != replacement.symbol
+        || replacement.remaining_quantity <= Decimal::ZERO
+    {
+        return Ok(false);
+    }
+
+    let start = loss
+        .sale_date
+        .checked_sub_days(Days::new(WASH_SALE_WINDOW_DAYS))
+        .ok_or_else(|| WashSaleError::calculation("wash sale window start overflow"))?;
+    let end = loss
+        .sale_date
+        .checked_add_days(Days::new(WASH_SALE_WINDOW_DAYS))
+        .ok_or_else(|| WashSaleError::calculation("wash sale window end overflow"))?;
+    if replacement.purchase_date < start || replacement.purchase_date > end {
+        return Ok(false);
+    }
+
+    if replacement.purchase_date <= loss.sale_date {
+        return Ok(replacement
+            .exit_date
+            .map(|exit| exit >= loss.sale_date)
+            .unwrap_or(true));
+    }
+
+    Ok(true)
+}
+
+fn aggregate_replacement_adjustments(
+    matches: &[WashSaleMatch],
+) -> Result<Vec<WashSaleReplacementAdjustment>, WashSaleError> {
+    let mut grouped: BTreeMap<Uuid, WashSaleReplacementAdjustment> = BTreeMap::new();
+    for wash_sale in matches {
+        let entry = grouped.entry(wash_sale.replacement_trade_id).or_insert(
+            WashSaleReplacementAdjustment {
+                replacement_trade_id: wash_sale.replacement_trade_id,
+                account_id: wash_sale.account_id,
+                symbol: wash_sale.symbol.clone(),
+                replacement_purchase_date: wash_sale.replacement_purchase_date,
+                matched_quantity: Decimal::ZERO,
+                original_cost_basis: Decimal::ZERO,
+                basis_adjustment: Decimal::ZERO,
+                adjusted_cost_basis: Decimal::ZERO,
+            },
+        );
+        entry.matched_quantity = checked_add(
+            entry.matched_quantity,
+            wash_sale.matched_quantity,
+            "aggregate matched quantity",
+        )?;
+        entry.original_cost_basis = checked_add(
+            entry.original_cost_basis,
+            wash_sale.replacement_cost_basis,
+            "aggregate original basis",
+        )?;
+        entry.basis_adjustment = checked_add(
+            entry.basis_adjustment,
+            wash_sale.disallowed_loss,
+            "aggregate basis adjustment",
+        )?;
+        entry.adjusted_cost_basis = checked_add(
+            entry.adjusted_cost_basis,
+            wash_sale.adjusted_replacement_cost_basis,
+            "aggregate adjusted basis",
+        )?;
+    }
+    Ok(grouped.into_values().collect())
+}
+
+fn is_wash_sale_eligible_trade(trade: &Trade) -> bool {
+    matches!(
+        trade.trading_vehicle.category,
+        TradingVehicleCategory::Stock | TradingVehicleCategory::Etf | TradingVehicleCategory::Bond
+    )
+}
+
+fn normalized_symbol(trade: &Trade) -> String {
+    trade.trading_vehicle.symbol.trim().to_uppercase()
+}
+
+fn entry_date(trade: &Trade) -> Option<NaiveDate> {
+    trade.entry.filled_at.map(|filled_at| filled_at.date())
+}
+
+fn exit_date(trade: &Trade) -> Option<NaiveDate> {
+    match trade.status {
+        Status::ClosedTarget => trade.target.filled_at.map(|filled_at| filled_at.date()),
+        Status::ClosedStopLoss => trade
+            .safety_stop
+            .filled_at
+            .map(|filled_at| filled_at.date()),
+        _ => None,
+    }
+}
+
+fn entry_quantity(trade: &Trade) -> Decimal {
+    if trade.entry.filled_quantity > Decimal::ZERO {
+        trade.entry.filled_quantity
+    } else {
+        Decimal::ZERO
+    }
+}
+
+fn exit_quantity(trade: &Trade) -> Decimal {
+    let order = match trade.status {
+        Status::ClosedTarget => &trade.target,
+        Status::ClosedStopLoss => &trade.safety_stop,
+        _ => return Decimal::ZERO,
+    };
+    if order.filled_quantity > Decimal::ZERO {
+        order.filled_quantity
+    } else {
+        Decimal::ZERO
+    }
+}
+
+fn prorate_loss(
+    realized_loss: Decimal,
+    loss_quantity: Decimal,
+    matched_quantity: Decimal,
+) -> Result<Decimal, WashSaleError> {
+    let ratio = matched_quantity
+        .checked_div(loss_quantity)
+        .ok_or_else(|| WashSaleError::calculation("loss quantity division"))?;
+    checked_mul(realized_loss, ratio, "prorated loss")
+}
+
+fn sum_decimal(mut values: impl Iterator<Item = Decimal>) -> Result<Decimal, WashSaleError> {
+    values.try_fold(Decimal::ZERO, |acc, value| {
+        checked_add(acc, value, "decimal sum")
+    })
+}
+
+fn min_decimal(left: Decimal, right: Decimal) -> Decimal {
+    if left <= right {
+        left
+    } else {
+        right
+    }
+}
+
+fn checked_add(
+    left: Decimal,
+    right: Decimal,
+    context: &'static str,
+) -> Result<Decimal, WashSaleError> {
+    left.checked_add(right)
+        .ok_or_else(|| WashSaleError::calculation(context))
+}
+
+fn checked_sub(
+    left: Decimal,
+    right: Decimal,
+    context: &'static str,
+) -> Result<Decimal, WashSaleError> {
+    left.checked_sub(right)
+        .ok_or_else(|| WashSaleError::calculation(context))
+}
+
+fn checked_mul(
+    left: Decimal,
+    right: Decimal,
+    context: &'static str,
+) -> Result<Decimal, WashSaleError> {
+    left.checked_mul(right)
+        .ok_or_else(|| WashSaleError::calculation(context))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::WashSaleService;
+    use chrono::{NaiveDate, NaiveDateTime};
+    use model::{
+        Currency, Order, OrderStatus, Status, Trade, TradeCategory, TradingVehicle,
+        TradingVehicleCategory,
+    };
+    use rust_decimal::Decimal;
+    use rust_decimal_macros::dec;
+    use uuid::Uuid;
+
+    fn date(year: i32, month: u32, day: u32) -> chrono::NaiveDateTime {
+        NaiveDate::from_ymd_opt(year, month, day)
+            .expect("valid test date")
+            .and_hms_opt(14, 30, 0)
+            .expect("valid test time")
+    }
+
+    fn vehicle(symbol: &str, category: TradingVehicleCategory) -> TradingVehicle {
+        TradingVehicle {
+            symbol: symbol.to_string(),
+            category,
+            ..Default::default()
+        }
+    }
+
+    fn filled_entry(quantity: Decimal, price: Decimal) -> Order {
+        Order {
+            quantity,
+            filled_quantity: quantity,
+            average_filled_price: Some(price),
+            unit_price: price,
+            status: OrderStatus::Filled,
+            filled_at: Some(date(2026, 1, 1)),
+            currency: Currency::USD,
+            ..Default::default()
+        }
+    }
+
+    struct TradeSpec {
+        account_id: Uuid,
+        symbol: &'static str,
+        vehicle_category: TradingVehicleCategory,
+        status: Status,
+        quantity: Decimal,
+        entry_price: Decimal,
+        entry_day: NaiveDateTime,
+        exit_price: Option<Decimal>,
+        exit_day: Option<NaiveDateTime>,
+        pnl: Decimal,
+    }
+
+    fn trade(spec: TradeSpec) -> Trade {
+        let mut entry = filled_entry(spec.quantity, spec.entry_price);
+        entry.filled_at = Some(spec.entry_day);
+        let mut safety_stop = Order {
+            quantity: spec.quantity,
+            unit_price: spec.exit_price.unwrap_or(dec!(0)),
+            currency: Currency::USD,
+            ..Default::default()
+        };
+        let mut target = safety_stop.clone();
+        if let (Some(price), Some(closed_at)) = (spec.exit_price, spec.exit_day) {
+            let exit_order = Order {
+                quantity: spec.quantity,
+                filled_quantity: spec.quantity,
+                average_filled_price: Some(price),
+                unit_price: price,
+                status: OrderStatus::Filled,
+                filled_at: Some(closed_at),
+                currency: Currency::USD,
+                ..Default::default()
+            };
+            if spec.status == Status::ClosedTarget {
+                target = exit_order;
+            } else if spec.status == Status::ClosedStopLoss {
+                safety_stop = exit_order;
+            }
+        }
+
+        Trade {
+            id: Uuid::new_v4(),
+            account_id: spec.account_id,
+            trading_vehicle: vehicle(spec.symbol, spec.vehicle_category),
+            category: TradeCategory::Long,
+            status: spec.status,
+            currency: Currency::USD,
+            entry,
+            safety_stop,
+            target,
+            balance: model::TradeBalance {
+                total_performance: spec.pnl,
+                ..Default::default()
+            },
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn detects_same_symbol_repurchase_after_loss_and_adjusts_basis() {
+        let account_id = Uuid::new_v4();
+        let loss = trade(TradeSpec {
+            account_id,
+            symbol: "AAPL",
+            vehicle_category: TradingVehicleCategory::Stock,
+            status: Status::ClosedStopLoss,
+            quantity: dec!(100),
+            entry_price: dec!(50),
+            entry_day: date(2026, 1, 1),
+            exit_price: Some(dec!(45)),
+            exit_day: Some(date(2026, 1, 10)),
+            pnl: dec!(-500),
+        });
+        let replacement = trade(TradeSpec {
+            account_id,
+            symbol: "aapl",
+            vehicle_category: TradingVehicleCategory::Stock,
+            status: Status::Filled,
+            quantity: dec!(100),
+            entry_price: dec!(47),
+            entry_day: date(2026, 1, 20),
+            exit_price: None,
+            exit_day: None,
+            pnl: dec!(0),
+        });
+
+        let report = WashSaleService::detect(&[loss, replacement]).expect("report");
+
+        assert_eq!(report.wash_sale_count, 1);
+        assert_eq!(report.total_disallowed_loss, dec!(500));
+        assert_eq!(report.total_basis_adjustment, dec!(500));
+        let wash_sale = report.matches.first().expect("match");
+        assert_eq!(wash_sale.symbol, "AAPL");
+        assert_eq!(wash_sale.matched_quantity, dec!(100));
+        assert_eq!(wash_sale.replacement_cost_basis, dec!(4700));
+        assert_eq!(wash_sale.adjusted_replacement_cost_basis, dec!(5200));
+        let adjustment = report
+            .replacement_adjustments
+            .first()
+            .expect("replacement adjustment");
+        assert_eq!(adjustment.basis_adjustment, dec!(500));
+        assert_eq!(adjustment.adjusted_cost_basis, dec!(5200));
+    }
+
+    #[test]
+    fn prorates_disallowed_loss_for_partial_replacement_quantity() {
+        let account_id = Uuid::new_v4();
+        let loss = trade(TradeSpec {
+            account_id,
+            symbol: "MSFT",
+            vehicle_category: TradingVehicleCategory::Etf,
+            status: Status::ClosedStopLoss,
+            quantity: dec!(100),
+            entry_price: dec!(100),
+            entry_day: date(2026, 2, 1),
+            exit_price: Some(dec!(90)),
+            exit_day: Some(date(2026, 2, 5)),
+            pnl: dec!(-1000),
+        });
+        let replacement = trade(TradeSpec {
+            account_id,
+            symbol: "MSFT",
+            vehicle_category: TradingVehicleCategory::Etf,
+            status: Status::Filled,
+            quantity: dec!(40),
+            entry_price: dec!(92),
+            entry_day: date(2026, 2, 10),
+            exit_price: None,
+            exit_day: None,
+            pnl: dec!(0),
+        });
+
+        let report = WashSaleService::detect(&[loss, replacement]).expect("report");
+
+        assert_eq!(report.wash_sale_count, 1);
+        assert_eq!(
+            report.matches.first().expect("match").matched_quantity,
+            dec!(40)
+        );
+        assert_eq!(report.total_disallowed_loss, dec!(400.0));
+        assert_eq!(
+            report
+                .replacement_adjustments
+                .first()
+                .expect("adjustment")
+                .adjusted_cost_basis,
+            dec!(4080.0)
+        );
+    }
+
+    #[test]
+    fn detects_pre_sale_replacement_only_when_still_held_on_loss_sale_date() {
+        let account_id = Uuid::new_v4();
+        let loss = trade(TradeSpec {
+            account_id,
+            symbol: "TSLA",
+            vehicle_category: TradingVehicleCategory::Stock,
+            status: Status::ClosedStopLoss,
+            quantity: dec!(50),
+            entry_price: dec!(250),
+            entry_day: date(2026, 3, 1),
+            exit_price: Some(dec!(240)),
+            exit_day: Some(date(2026, 3, 20)),
+            pnl: dec!(-500),
+        });
+        let held_replacement = trade(TradeSpec {
+            account_id,
+            symbol: "TSLA",
+            vehicle_category: TradingVehicleCategory::Stock,
+            status: Status::Filled,
+            quantity: dec!(30),
+            entry_price: dec!(245),
+            entry_day: date(2026, 3, 10),
+            exit_price: None,
+            exit_day: None,
+            pnl: dec!(0),
+        });
+        let closed_before_sale = trade(TradeSpec {
+            account_id,
+            symbol: "TSLA",
+            vehicle_category: TradingVehicleCategory::Stock,
+            status: Status::ClosedTarget,
+            quantity: dec!(30),
+            entry_price: dec!(230),
+            entry_day: date(2026, 3, 5),
+            exit_price: Some(dec!(235)),
+            exit_day: Some(date(2026, 3, 15)),
+            pnl: dec!(150),
+        });
+
+        let report =
+            WashSaleService::detect(&[loss, held_replacement, closed_before_sale]).expect("report");
+
+        assert_eq!(report.wash_sale_count, 1);
+        assert_eq!(report.total_disallowed_loss, dec!(300.0));
+    }
+
+    #[test]
+    fn ignores_out_of_window_profit_crypto_short_and_cross_account_trades() {
+        let account_id = Uuid::new_v4();
+        let other_account_id = Uuid::new_v4();
+        let loss = trade(TradeSpec {
+            account_id,
+            symbol: "QQQ",
+            vehicle_category: TradingVehicleCategory::Stock,
+            status: Status::ClosedStopLoss,
+            quantity: dec!(10),
+            entry_price: dec!(400),
+            entry_day: date(2026, 4, 1),
+            exit_price: Some(dec!(390)),
+            exit_day: Some(date(2026, 4, 5)),
+            pnl: dec!(-100),
+        });
+        let late_replacement = trade(TradeSpec {
+            account_id,
+            symbol: "SPY",
+            vehicle_category: TradingVehicleCategory::Stock,
+            status: Status::Filled,
+            quantity: dec!(10),
+            entry_price: dec!(395),
+            entry_day: date(2026, 5, 10),
+            exit_price: None,
+            exit_day: None,
+            pnl: dec!(0),
+        });
+        let cross_account = trade(TradeSpec {
+            account_id: other_account_id,
+            symbol: "SPY",
+            vehicle_category: TradingVehicleCategory::Stock,
+            status: Status::Filled,
+            quantity: dec!(10),
+            entry_price: dec!(395),
+            entry_day: date(2026, 4, 10),
+            exit_price: None,
+            exit_day: None,
+            pnl: dec!(0),
+        });
+        let crypto_loss = trade(TradeSpec {
+            account_id,
+            symbol: "BTCUSD",
+            vehicle_category: TradingVehicleCategory::Crypto,
+            status: Status::ClosedStopLoss,
+            quantity: dec!(1),
+            entry_price: dec!(60000),
+            entry_day: date(2026, 4, 1),
+            exit_price: Some(dec!(59000)),
+            exit_day: Some(date(2026, 4, 5)),
+            pnl: dec!(-1000),
+        });
+        let profit = trade(TradeSpec {
+            account_id,
+            symbol: "SPY",
+            vehicle_category: TradingVehicleCategory::Stock,
+            status: Status::ClosedTarget,
+            quantity: dec!(10),
+            entry_price: dec!(400),
+            entry_day: date(2026, 4, 1),
+            exit_price: Some(dec!(410)),
+            exit_day: Some(date(2026, 4, 5)),
+            pnl: dec!(100),
+        });
+
+        let report =
+            WashSaleService::detect(&[loss, late_replacement, cross_account, crypto_loss, profit])
+                .expect("report");
+
+        assert_eq!(report.eligible_loss_trade_count, 1);
+        assert_eq!(report.wash_sale_count, 0);
+        assert_eq!(report.total_disallowed_loss, dec!(0));
+    }
+}


### PR DESCRIPTION
## Summary
- add a core wash sale detector for same-symbol loss sales and replacement purchases within the 30-day window
- report disallowed loss allocations and adjusted replacement cost basis through TrustFacade
- add `report wash-sales` with text and JSON output plus CLI contract coverage

Closes #98

## Verification
- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `cargo test --locked --all-features --workspace`
- `cargo test --locked --no-default-features --workspace`