### PR TITLE
feat(core): add realized gains tax summary

### DIFF
--- a/cli/src/command_routing.rs
+++ b/cli/src/command_routing.rs
@@ -103,6 +103,7 @@ pub enum ReportSubcommand<'a> {
     Timeline(&'a ArgMatches),
     BiasSummary(&'a ArgMatches),
     WashSales(&'a ArgMatches),
+    Tax(&'a ArgMatches),
 }
 
 pub enum MarketDataSubcommand<'a> {
@@ -298,6 +299,7 @@ pub fn parse_report_subcommand(sub_matches: &ArgMatches) -> ReportSubcommand<'_>
         Some(("timeline", sub_sub_matches)) => ReportSubcommand::Timeline(sub_sub_matches),
         Some(("bias-summary", sub_sub_matches)) => ReportSubcommand::BiasSummary(sub_sub_matches),
         Some(("wash-sales", sub_sub_matches)) => ReportSubcommand::WashSales(sub_sub_matches),
+        Some(("tax", sub_sub_matches)) => ReportSubcommand::Tax(sub_sub_matches),
         _ => unreachable!("No subcommand provided"),
     }
 }
@@ -797,7 +799,8 @@ mod tests {
                 .subcommand(Command::new("benchmark"))
                 .subcommand(Command::new("timeline"))
                 .subcommand(Command::new("bias-summary"))
-                .subcommand(Command::new("wash-sales")),
+                .subcommand(Command::new("wash-sales"))
+                .subcommand(Command::new("tax")),
         );
         for (sub, expected) in [
             ("drawdown", "drawdown"),
@@ -811,6 +814,7 @@ mod tests {
             ("timeline", "timeline"),
             ("bias-summary", "bias-summary"),
             ("wash-sales", "wash-sales"),
+            ("tax", "tax"),
         ] {
             let m = report.clone().get_matches_from(["trust", "report", sub]);
             let (_, sm) = m.subcommand().expect("expected report");
@@ -826,6 +830,7 @@ mod tests {
                 ReportSubcommand::Timeline(_) => "timeline",
                 ReportSubcommand::BiasSummary(_) => "bias-summary",
                 ReportSubcommand::WashSales(_) => "wash-sales",
+                ReportSubcommand::Tax(_) => "tax",
             };
             assert_eq!(got, expected);
         }

--- a/cli/src/commands/report_command.rs
+++ b/cli/src/commands/report_command.rs
@@ -289,6 +289,35 @@ impl ReportCommandBuilder {
         );
         self
     }
+
+    pub fn tax(mut self) -> Self {
+        self.subcommands.push(
+            Command::new("tax")
+                .about("Calculate realized gains tax summaries for closed trades")
+                .arg(
+                    Arg::new("account")
+                        .long("account")
+                        .value_name("ACCOUNT_ID_OR_NAME")
+                        .help("Filter by account ID or name")
+                        .required(false),
+                )
+                .arg(
+                    Arg::new("short-term-rate")
+                        .long("short-term-rate")
+                        .value_name("PERCENT")
+                        .help("Override short-term capital gains tax rate, e.g. 35 for 35%")
+                        .required(false),
+                )
+                .arg(
+                    Arg::new("long-term-rate")
+                        .long("long-term-rate")
+                        .value_name("PERCENT")
+                        .help("Override long-term capital gains tax rate, e.g. 15 for 15%")
+                        .required(false),
+                ),
+        );
+        self
+    }
 }
 
 impl Default for ReportCommandBuilder {
@@ -315,6 +344,7 @@ mod tests {
             .timeline()
             .bias_summary()
             .wash_sales()
+            .tax()
             .build();
         for name in [
             "performance",
@@ -328,6 +358,7 @@ mod tests {
             "timeline",
             "bias-summary",
             "wash-sales",
+            "tax",
         ] {
             assert!(cmd.get_subcommands().any(|c| c.get_name() == name));
         }
@@ -566,6 +597,36 @@ mod tests {
         assert_eq!(
             sub.get_one::<String>("account").map(String::as_str),
             Some("paper-main")
+        );
+    }
+
+    #[test]
+    fn report_tax_parses_optional_rates() {
+        let cmd = ReportCommandBuilder::new().tax().build();
+        let matches = cmd
+            .try_get_matches_from([
+                "report",
+                "tax",
+                "--account",
+                "paper-main",
+                "--short-term-rate",
+                "35",
+                "--long-term-rate",
+                "15",
+            ])
+            .expect("tax should parse");
+        let sub = matches.subcommand_matches("tax").expect("tax subcommand");
+        assert_eq!(
+            sub.get_one::<String>("account").map(String::as_str),
+            Some("paper-main")
+        );
+        assert_eq!(
+            sub.get_one::<String>("short-term-rate").map(String::as_str),
+            Some("35")
+        );
+        assert_eq!(
+            sub.get_one::<String>("long-term-rate").map(String::as_str),
+            Some("15")
         );
     }
 }

--- a/cli/src/dispatcher.rs
+++ b/cli/src/dispatcher.rs
@@ -45,7 +45,8 @@ use core::services::leveling::{
     LevelProgressReport,
 };
 use core::services::{
-    AdvisoryThresholds, TradeProposal, WashSaleMatch, WashSaleReplacementAdjustment, WashSaleReport,
+    AdvisoryThresholds, TaxAccountSummary, TaxRateOverrides, TaxReport, TaxTradeLine,
+    TradeProposal, WashSaleMatch, WashSaleReplacementAdjustment, WashSaleReport,
 };
 use core::TrustFacade;
 use db_sqlite::SqliteDatabase;
@@ -289,6 +290,7 @@ struct BenchmarkReportCommand;
 struct TimelineReportCommand;
 struct BiasSummaryReportCommand;
 struct WashSalesReportCommand;
+struct TaxReportCommand;
 
 impl MarketDataCommandHandler for MarketDataSnapshotCommand {
     fn execute(
@@ -474,6 +476,17 @@ impl ReportCommandHandler for WashSalesReportCommand {
         format: ReportOutputFormat,
     ) -> Result<(), CliError> {
         dispatcher.wash_sales_report(sub_matches, format)
+    }
+}
+
+impl ReportCommandHandler for TaxReportCommand {
+    fn execute(
+        &self,
+        dispatcher: &mut ArgDispatcher,
+        sub_matches: &ArgMatches,
+        format: ReportOutputFormat,
+    ) -> Result<(), CliError> {
+        dispatcher.tax_report(sub_matches, format)
     }
 }
 
@@ -751,6 +764,7 @@ impl ArgDispatcher {
         static TIMELINE: TimelineReportCommand = TimelineReportCommand;
         static BIAS_SUMMARY: BiasSummaryReportCommand = BiasSummaryReportCommand;
         static WASH_SALES: WashSalesReportCommand = WashSalesReportCommand;
+        static TAX: TaxReportCommand = TaxReportCommand;
 
         match subcommand {
             ReportSubcommand::Performance(sub_matches) => (&PERFORMANCE, sub_matches),
@@ -764,6 +778,7 @@ impl ArgDispatcher {
             ReportSubcommand::Timeline(sub_matches) => (&TIMELINE, sub_matches),
             ReportSubcommand::BiasSummary(sub_matches) => (&BIAS_SUMMARY, sub_matches),
             ReportSubcommand::WashSales(sub_matches) => (&WASH_SALES, sub_matches),
+            ReportSubcommand::Tax(sub_matches) => (&TAX, sub_matches),
         }
     }
 
@@ -963,6 +978,39 @@ impl ArgDispatcher {
                         format!("Invalid decimal value for --{key}: {raw}"),
                     )
                 })
+            })
+            .transpose()
+    }
+
+    fn parse_optional_percent_arg(
+        sub_matches: &ArgMatches,
+        key: &'static str,
+        format: ReportOutputFormat,
+    ) -> Result<Option<Decimal>, CliError> {
+        Self::parse_optional_decimal_arg(sub_matches, key, format)?
+            .map(|value| {
+                if value < Decimal::ZERO {
+                    return Err(Self::report_error(
+                        format,
+                        "invalid_percentage",
+                        format!("Invalid percentage for --{key}: value cannot be negative"),
+                    ));
+                }
+                let rate = value.checked_div(dec!(100)).ok_or_else(|| {
+                    Self::report_error(
+                        format,
+                        "invalid_percentage",
+                        format!("Invalid percentage for --{key}: {value}"),
+                    )
+                })?;
+                if rate > Decimal::ONE {
+                    return Err(Self::report_error(
+                        format,
+                        "invalid_percentage",
+                        format!("Invalid percentage for --{key}: value cannot exceed 100"),
+                    ));
+                }
+                Ok(rate)
             })
             .transpose()
     }
@@ -7535,6 +7583,133 @@ impl ArgDispatcher {
         })
     }
 
+    fn tax_report(
+        &mut self,
+        sub_matches: &ArgMatches,
+        format: ReportOutputFormat,
+    ) -> Result<(), CliError> {
+        let account_id = if let Some(raw) = sub_matches.get_one::<String>("account") {
+            Some(self.resolve_account_arg(raw, format)?.id)
+        } else {
+            None
+        };
+        let rate_overrides = TaxRateOverrides {
+            short_term: Self::parse_optional_percent_arg(sub_matches, "short-term-rate", format)?,
+            long_term: Self::parse_optional_percent_arg(sub_matches, "long-term-rate", format)?,
+        };
+        let report = self
+            .trust
+            .tax_report(account_id, rate_overrides)
+            .map_err(|error| Self::report_error(format, "report_failed", error.to_string()))?;
+
+        match format {
+            ReportOutputFormat::Text => Self::print_tax_text(&report, account_id),
+            ReportOutputFormat::Json => {
+                let account_trade_count = report
+                    .account_summaries
+                    .iter()
+                    .try_fold(0usize, |acc, summary| acc.checked_add(summary.trade_count))
+                    .unwrap_or(usize::MAX);
+                let payload = json!({
+                    "report": "tax",
+                    "format_version": 1,
+                    "generated_at": Utc::now().to_rfc3339(),
+                    "scope": {
+                        "account_id": account_id.map(|id| id.to_string()),
+                        "short_term_rate_override": rate_overrides.short_term.map(Self::decimal_string),
+                        "long_term_rate_override": rate_overrides.long_term.map(Self::decimal_string),
+                    },
+                    "data": {
+                        "scanned_trade_count": report.scanned_trade_count,
+                        "taxable_trade_count": report.taxable_trade_count,
+                        "unclassified_trade_count": report.unclassified_trade_count,
+                        "wash_sale_adjustment_count": report.wash_sale_adjustment_count,
+                        "gross_realized_gain": Self::decimal_string(report.gross_realized_gain),
+                        "gross_realized_loss": Self::decimal_string(report.gross_realized_loss),
+                        "wash_sale_disallowed_loss": Self::decimal_string(report.wash_sale_disallowed_loss),
+                        "replacement_basis_adjustment": Self::decimal_string(report.replacement_basis_adjustment),
+                        "short_term_taxable_gain": Self::decimal_string(report.short_term_taxable_gain),
+                        "long_term_taxable_gain": Self::decimal_string(report.long_term_taxable_gain),
+                        "net_taxable_gain": Self::decimal_string(report.net_taxable_gain),
+                        "estimated_gross_tax_liability": Self::decimal_string(report.estimated_gross_tax_liability),
+                        "estimated_net_tax_liability": Self::decimal_string(report.estimated_net_tax_liability),
+                        "accounts": report.account_summaries.iter().map(Self::tax_account_summary_json).collect::<Vec<Value>>(),
+                        "trades": report.trades.iter().map(Self::tax_trade_line_json).collect::<Vec<Value>>(),
+                    },
+                    "consistency": {
+                        "account_trade_count_matches_total": account_trade_count == report.taxable_trade_count,
+                        "net_gain_matches_components": report.short_term_taxable_gain
+                            .checked_add(report.long_term_taxable_gain)
+                            .map(|value| value == report.net_taxable_gain)
+                            .unwrap_or(false),
+                    }
+                });
+                Self::print_json(&payload)?;
+            }
+        }
+
+        Ok(())
+    }
+
+    fn print_tax_text(report: &TaxReport, account_id: Option<Uuid>) {
+        println!("Tax report");
+        println!("==========");
+        match account_id {
+            Some(id) => println!("account_id: {id}"),
+            None => println!("account_id: all"),
+        }
+        println!("closed_trades_scanned: {}", report.scanned_trade_count);
+        println!("classified_trades: {}", report.taxable_trade_count);
+        println!(
+            "net_taxable_gain: {}",
+            Self::decimal_string(report.net_taxable_gain)
+        );
+        println!(
+            "estimated_net_tax_liability: {}",
+            Self::decimal_string(report.estimated_net_tax_liability)
+        );
+        println!(
+            "wash_sale_disallowed_loss: {}",
+            Self::decimal_string(report.wash_sale_disallowed_loss)
+        );
+    }
+
+    fn tax_account_summary_json(summary: &TaxAccountSummary) -> Value {
+        json!({
+            "account_id": summary.account_id.to_string(),
+            "short_term_rate": Self::decimal_string(summary.short_term_rate),
+            "long_term_rate": Self::decimal_string(summary.long_term_rate),
+            "trade_count": summary.trade_count,
+            "gross_realized_gain": Self::decimal_string(summary.gross_realized_gain),
+            "gross_realized_loss": Self::decimal_string(summary.gross_realized_loss),
+            "wash_sale_disallowed_loss": Self::decimal_string(summary.wash_sale_disallowed_loss),
+            "replacement_basis_adjustment": Self::decimal_string(summary.replacement_basis_adjustment),
+            "short_term_taxable_gain": Self::decimal_string(summary.short_term_taxable_gain),
+            "long_term_taxable_gain": Self::decimal_string(summary.long_term_taxable_gain),
+            "net_taxable_gain": Self::decimal_string(summary.net_taxable_gain),
+            "estimated_gross_tax_liability": Self::decimal_string(summary.estimated_gross_tax_liability),
+            "estimated_net_tax_liability": Self::decimal_string(summary.estimated_net_tax_liability),
+        })
+    }
+
+    fn tax_trade_line_json(line: &TaxTradeLine) -> Value {
+        json!({
+            "account_id": line.account_id.to_string(),
+            "trade_id": line.trade_id.to_string(),
+            "symbol": line.symbol.clone(),
+            "opened_date": line.opened_date.to_string(),
+            "closed_date": line.closed_date.to_string(),
+            "holding_days": line.holding_days,
+            "holding_period": line.holding_period.as_str(),
+            "realized_gain_loss": Self::decimal_string(line.realized_gain_loss),
+            "wash_sale_disallowed_loss": Self::decimal_string(line.wash_sale_disallowed_loss),
+            "replacement_basis_adjustment": Self::decimal_string(line.replacement_basis_adjustment),
+            "taxable_gain_loss": Self::decimal_string(line.taxable_gain_loss),
+            "tax_rate": Self::decimal_string(line.tax_rate),
+            "estimated_tax_liability": Self::decimal_string(line.estimated_tax_liability),
+        })
+    }
+
     #[allow(clippy::too_many_lines)]
     fn benchmark_report(
         &mut self,
@@ -12170,6 +12345,7 @@ mod tests {
                 "--days",
                 "7",
             ],
+            vec!["report", "tax", "--account", invalid_account],
         ];
 
         for argv in commands {
@@ -12184,6 +12360,7 @@ mod tests {
                 .benchmark()
                 .timeline()
                 .bias_summary()
+                .tax()
                 .build()
                 .get_matches_from(argv);
 
@@ -21228,6 +21405,18 @@ mod tests {
         dispatcher
             .dispatch_report(&timeline_text)
             .expect("timeline text should dispatch");
+
+        let tax_json = ReportCommandBuilder::new().tax().build().get_matches_from([
+            "report",
+            "--format",
+            "json",
+            "tax",
+            "--account",
+            &account_id,
+        ]);
+        dispatcher
+            .dispatch_report(&tax_json)
+            .expect("tax json should dispatch");
 
         let benchmark = ReportCommandBuilder::new()
             .benchmark()

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -165,6 +165,7 @@ fn build_cli() -> Command {
                 .timeline()
                 .bias_summary()
                 .wash_sales()
+                .tax()
                 .build(),
         )
         .subcommand(

--- a/cli/tests/integration_test_report_json_contract.rs
+++ b/cli/tests/integration_test_report_json_contract.rs
@@ -2,8 +2,8 @@ use chrono::{NaiveDate, NaiveDateTime};
 use core::TrustFacade;
 use db_sqlite::SqliteDatabase;
 use model::{
-    Currency, DatabaseFactory, DraftTrade, Environment, Order, OrderStatus, Status, TradeCategory,
-    TradingVehicleCategory,
+    Account, Currency, DatabaseFactory, DraftTrade, Environment, Order, OrderStatus, Status,
+    TradeCategory, TradingVehicle, TradingVehicleCategory,
 };
 use rust_decimal::Decimal;
 use rust_decimal_macros::dec;
@@ -434,6 +434,212 @@ fn seed_account_with_wash_sale(database_url: &str) -> Uuid {
     account.id
 }
 
+struct TaxSeedTradeSpec {
+    trading_vehicle: TradingVehicle,
+    quantity: Decimal,
+    entry_price: Decimal,
+    stop_price: Decimal,
+    target_price: Decimal,
+    status: Status,
+    entry_at: NaiveDateTime,
+    exit_at: NaiveDateTime,
+    exit_price: Decimal,
+    total_performance: Decimal,
+    thesis: &'static str,
+}
+
+fn seed_closed_tax_trade(
+    database_url: &str,
+    trust: &mut TrustFacade,
+    account: &Account,
+    spec: TaxSeedTradeSpec,
+) {
+    let trade = trust
+        .create_trade(
+            DraftTrade {
+                account: account.clone(),
+                trading_vehicle: spec.trading_vehicle,
+                quantity: spec.quantity,
+                category: TradeCategory::Long,
+                currency: Currency::USD,
+                sector: Some("Technology".to_string()),
+                asset_class: Some("Stocks".to_string()),
+                thesis: Some(spec.thesis.to_string()),
+                context: None,
+            },
+            spec.entry_price,
+            spec.stop_price,
+            spec.target_price,
+        )
+        .expect("create tax trade");
+    let (funded, _, _, _) = trust.fund_trade(&trade).expect("fund tax trade");
+    persist_filled_order(
+        database_url,
+        &funded.entry,
+        spec.quantity,
+        spec.entry_price,
+        spec.entry_at,
+    );
+    let exit_order = if spec.status == Status::ClosedTarget {
+        &funded.target
+    } else {
+        &funded.safety_stop
+    };
+    persist_filled_order(
+        database_url,
+        exit_order,
+        spec.quantity,
+        spec.exit_price,
+        spec.exit_at,
+    );
+
+    let database = SqliteDatabase::new(database_url);
+    let closed = database
+        .trade_write()
+        .update_trade_status(spec.status, &funded)
+        .expect("close tax trade");
+    let capital_out_market = funded
+        .balance
+        .funding
+        .checked_add(spec.total_performance)
+        .expect("tax trade capital out");
+    database
+        .trade_balance_write()
+        .update_trade_balance(
+            &closed,
+            funded.balance.funding,
+            dec!(0),
+            capital_out_market,
+            dec!(0),
+            spec.total_performance,
+        )
+        .expect("persist tax trade balance");
+}
+
+fn seed_account_with_tax_scenarios(database_url: &str) -> Uuid {
+    let database = SqliteDatabase::new(database_url);
+    let mut trust = TrustFacade::new(Box::new(database), Box::new(alpaca_broker::AlpacaBroker));
+
+    let account = trust
+        .create_account(
+            "Tax Report Account",
+            "tax report contract test",
+            Environment::Paper,
+            dec!(25.0),
+            dec!(10.0),
+        )
+        .expect("create account");
+    trust
+        .create_transaction(
+            &account,
+            &model::TransactionCategory::Deposit,
+            dec!(50000),
+            &Currency::USD,
+        )
+        .expect("deposit funds");
+
+    let aapl = trust
+        .create_trading_vehicle(
+            "AAPL",
+            Some("US0378331005"),
+            &TradingVehicleCategory::Stock,
+            "alpaca",
+        )
+        .expect("create AAPL vehicle");
+    seed_closed_tax_trade(
+        database_url,
+        &mut trust,
+        &account,
+        TaxSeedTradeSpec {
+            trading_vehicle: aapl,
+            quantity: dec!(10),
+            entry_price: dec!(100),
+            stop_price: dec!(90),
+            target_price: dec!(110),
+            status: Status::ClosedTarget,
+            entry_at: report_test_datetime(2026, 1, 1),
+            exit_at: report_test_datetime(2026, 2, 1),
+            exit_price: dec!(110),
+            total_performance: dec!(100),
+            thesis: "short-term gain",
+        },
+    );
+
+    let msft = trust
+        .create_trading_vehicle(
+            "MSFT",
+            Some("US5949181045"),
+            &TradingVehicleCategory::Stock,
+            "alpaca",
+        )
+        .expect("create MSFT vehicle");
+    seed_closed_tax_trade(
+        database_url,
+        &mut trust,
+        &account,
+        TaxSeedTradeSpec {
+            trading_vehicle: msft,
+            quantity: dec!(10),
+            entry_price: dec!(100),
+            stop_price: dec!(90),
+            target_price: dec!(120),
+            status: Status::ClosedTarget,
+            entry_at: report_test_datetime(2024, 1, 1),
+            exit_at: report_test_datetime(2025, 1, 3),
+            exit_price: dec!(120),
+            total_performance: dec!(200),
+            thesis: "long-term gain",
+        },
+    );
+
+    let tsla = trust
+        .create_trading_vehicle(
+            "TSLA",
+            Some("US88160R1014"),
+            &TradingVehicleCategory::Stock,
+            "alpaca",
+        )
+        .expect("create TSLA vehicle");
+    seed_closed_tax_trade(
+        database_url,
+        &mut trust,
+        &account,
+        TaxSeedTradeSpec {
+            trading_vehicle: tsla.clone(),
+            quantity: dec!(10),
+            entry_price: dec!(100),
+            stop_price: dec!(90),
+            target_price: dec!(120),
+            status: Status::ClosedStopLoss,
+            entry_at: report_test_datetime(2026, 1, 5),
+            exit_at: report_test_datetime(2026, 1, 10),
+            exit_price: dec!(90),
+            total_performance: dec!(-100),
+            thesis: "wash sale loss",
+        },
+    );
+    seed_closed_tax_trade(
+        database_url,
+        &mut trust,
+        &account,
+        TaxSeedTradeSpec {
+            trading_vehicle: tsla,
+            quantity: dec!(5),
+            entry_price: dec!(95),
+            stop_price: dec!(88),
+            target_price: dec!(140),
+            status: Status::ClosedTarget,
+            entry_at: report_test_datetime(2026, 1, 20),
+            exit_at: report_test_datetime(2026, 2, 20),
+            exit_price: dec!(140),
+            total_performance: dec!(225),
+            thesis: "wash sale replacement",
+        },
+    );
+
+    account.id
+}
+
 #[test]
 fn test_risk_report_json_math_consistency() {
     let database_url = format!("file:test_risk_report_json_{}.db", Uuid::new_v4().simple());
@@ -736,6 +942,68 @@ fn test_wash_sales_report_json_flags_loss_trade_and_basis_adjustment() {
     let adjustment = adjustments.first().expect("one replacement adjustment");
     assert_eq!(adjustment["basis_adjustment"], "50");
     assert_eq!(adjustment["adjusted_cost_basis"], "525");
+}
+
+#[test]
+fn test_tax_report_json_classifies_terms_and_applies_wash_sales() {
+    let database_url = format!("file:test_tax_report_json_{}.db", Uuid::new_v4().simple());
+    let _cleanup = TestDatabaseCleanup::new(&database_url);
+    let account_id = seed_account_with_tax_scenarios(&database_url);
+
+    let output = run_report(
+        &database_url,
+        &[
+            "report",
+            "tax",
+            "--format",
+            "json",
+            "--account",
+            &account_id.to_string(),
+            "--short-term-rate",
+            "30",
+            "--long-term-rate",
+            "15",
+        ],
+    );
+
+    assert!(output.status.success(), "tax report should succeed");
+
+    let payload = parse_stdout_json(&output);
+    assert_report_envelope(&payload, "tax");
+    assert_eq!(payload["scope"]["account_id"], account_id.to_string());
+    assert_eq!(payload["scope"]["short_term_rate_override"], "0.3");
+    assert_eq!(payload["scope"]["long_term_rate_override"], "0.15");
+    assert_eq!(payload["data"]["taxable_trade_count"], 4);
+    assert_eq!(payload["data"]["wash_sale_adjustment_count"], 1);
+    assert_eq!(payload["data"]["gross_realized_gain"], "525");
+    assert_eq!(payload["data"]["gross_realized_loss"], "-100");
+    assert_eq!(payload["data"]["wash_sale_disallowed_loss"], "50");
+    assert_eq!(payload["data"]["replacement_basis_adjustment"], "50");
+    assert_eq!(payload["data"]["short_term_taxable_gain"], "225");
+    assert_eq!(payload["data"]["long_term_taxable_gain"], "200");
+    assert_eq!(payload["data"]["net_taxable_gain"], "425");
+    assert_eq!(payload["data"]["estimated_net_tax_liability"], "97.5");
+    assert_eq!(
+        payload["consistency"]["account_trade_count_matches_total"],
+        true
+    );
+
+    let trades = payload["data"]["trades"]
+        .as_array()
+        .expect("tax trades should be an array");
+    assert!(trades
+        .iter()
+        .any(|trade| trade["symbol"] == "MSFT" && trade["holding_period"] == "long_term"));
+    assert!(trades.iter().any(|trade| {
+        trade["symbol"] == "TSLA"
+            && trade["wash_sale_disallowed_loss"] == "50"
+            && trade["taxable_gain_loss"] == "-50"
+    }));
+    assert!(trades.iter().any(|trade| {
+        trade["symbol"] == "TSLA"
+            && trade["replacement_basis_adjustment"] == "50"
+            && trade["taxable_gain_loss"] == "175"
+    }));
 }
 
 #[test]

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -32,8 +32,8 @@
 
 use crate::services::{
     AdvisoryHistoryEntry, AdvisoryResult, AdvisoryThresholds, FundTransferService,
-    PortfolioAdvisoryStatus, ProfitDistributionService, TradeProposal, WashSaleReport,
-    WashSaleService,
+    PortfolioAdvisoryStatus, ProfitDistributionService, TaxRateOverrides, TaxRates, TaxReport,
+    TaxService, TradeProposal, WashSaleReport, WashSaleService,
 };
 use advisor::{
     CalendarCredentials, CatalystScanRequest, CatalystScanResult, CatalystScanner,
@@ -70,7 +70,7 @@ use {
         DefaultLevelTransitionPolicy, LevelEvaluationOutcome, LevelPerformanceSnapshot,
         LevelingService,
     },
-    std::collections::HashMap,
+    std::collections::{BTreeMap, HashMap},
     std::error::Error as StdError,
 };
 
@@ -1262,6 +1262,23 @@ impl TrustFacade {
         WashSaleService::detect(&trades).map_err(|error| Box::new(error) as Box<dyn StdError>)
     }
 
+    /// Calculate realized-gains tax lines and account summaries.
+    ///
+    /// Rates default to the account's configured distribution tax percentage
+    /// when present, falling back to the account tax percentage. Optional
+    /// overrides apply across every account in the report.
+    pub fn tax_report(
+        &mut self,
+        account_id: Option<Uuid>,
+        rate_overrides: TaxRateOverrides,
+    ) -> Result<TaxReport, Box<dyn std::error::Error>> {
+        let trades = self.search_all_trades_for_tax(account_id)?;
+        let wash_sales = WashSaleService::detect(&trades)?;
+        let rates = self.tax_rates_for_scope(account_id, rate_overrides)?;
+        TaxService::calculate(&trades, &rates, &wash_sales)
+            .map_err(|error| Box::new(error) as Box<dyn StdError>)
+    }
+
     fn search_all_trades_for_tax(
         &mut self,
         account_id: Option<Uuid>,
@@ -1288,6 +1305,32 @@ impl TrustFacade {
             all_trades.append(&mut status_trades);
         }
         Ok(())
+    }
+
+    fn tax_rates_for_scope(
+        &mut self,
+        account_id: Option<Uuid>,
+        overrides: TaxRateOverrides,
+    ) -> Result<BTreeMap<Uuid, TaxRates>, Box<dyn std::error::Error>> {
+        let accounts = if let Some(id) = account_id {
+            vec![self.factory.account_read().id(id)?]
+        } else {
+            self.search_all_accounts()?
+        };
+
+        let mut rates = BTreeMap::new();
+        for account in accounts {
+            let configured_tax_rate =
+                if let Some(rules) = self.cached_distribution_rules(account.id)? {
+                    rules.tax_percent
+                } else {
+                    normalize_account_tax_rate(account.taxes_percentage)?
+                };
+            let short_term = overrides.short_term.unwrap_or(configured_tax_rate);
+            let long_term = overrides.long_term.unwrap_or(configured_tax_rate);
+            rates.insert(account.id, TaxRates::new(short_term, long_term)?);
+        }
+        Ok(rates)
     }
 
     // Trade Steps
@@ -2291,6 +2334,22 @@ impl TrustFacade {
 
         Ok((earnings_account, tax_account, reinvestment_account))
     }
+}
+
+fn normalize_account_tax_rate(rate: Decimal) -> Result<Decimal, Box<dyn std::error::Error>> {
+    if rate < Decimal::ZERO {
+        return Err("Account tax percentage cannot be negative".into());
+    }
+    let normalized = if rate > Decimal::ONE {
+        rate.checked_div(dec!(100))
+            .ok_or("Account tax percentage normalization overflow")?
+    } else {
+        rate
+    };
+    if normalized > Decimal::ONE {
+        return Err("Account tax percentage cannot exceed 100%".into());
+    }
+    Ok(normalized)
 }
 
 fn hash_distribution_password(password: &str) -> Result<String, Box<dyn std::error::Error>> {

--- a/core/src/services/mod.rs
+++ b/core/src/services/mod.rs
@@ -15,6 +15,8 @@ pub mod grading;
 pub mod leveling;
 /// Profit distribution service for handling account hierarchy and fund transfers
 pub mod profit_distribution_service;
+/// Realized gains tax reporting
+pub mod tax;
 /// Wash sale detection and basis adjustment reporting
 pub mod wash_sale;
 
@@ -25,6 +27,10 @@ pub use advisory::{
 pub use event_distribution_service::EventDistributionService;
 pub use fund_transfer_service::FundTransferService;
 pub use profit_distribution_service::ProfitDistributionService;
+pub use tax::{
+    TaxAccountSummary, TaxHoldingPeriod, TaxRateOverrides, TaxRates, TaxReport, TaxReportError,
+    TaxService, TaxTradeLine,
+};
 pub use wash_sale::{
     WashSaleError, WashSaleMatch, WashSaleReplacementAdjustment, WashSaleReport, WashSaleService,
 };

--- a/core/src/services/tax.rs
+++ b/core/src/services/tax.rs
@@ -1,0 +1,806 @@
+//! Realized gains tax reporting.
+
+use crate::services::wash_sale::WashSaleReport;
+use chrono::{Days, NaiveDate};
+use model::{Status, Trade};
+use rust_decimal::Decimal;
+use std::collections::BTreeMap;
+use std::error::Error;
+use std::fmt::{Display, Formatter};
+use uuid::Uuid;
+
+const LONG_TERM_THRESHOLD_DAYS: u64 = 366;
+
+/// Error returned when tax analysis cannot be computed safely.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TaxReportError {
+    context: &'static str,
+}
+
+impl TaxReportError {
+    fn calculation(context: &'static str) -> Self {
+        Self { context }
+    }
+}
+
+impl Display for TaxReportError {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(f, "tax report calculation failed: {}", self.context)
+    }
+}
+
+impl Error for TaxReportError {}
+
+/// Holding-period tax bucket for a closed trade.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TaxHoldingPeriod {
+    /// Position held one year or less.
+    ShortTerm,
+    /// Position held more than one year.
+    LongTerm,
+}
+
+impl TaxHoldingPeriod {
+    /// Stable JSON/text representation.
+    pub fn as_str(self) -> &'static str {
+        match self {
+            TaxHoldingPeriod::ShortTerm => "short_term",
+            TaxHoldingPeriod::LongTerm => "long_term",
+        }
+    }
+}
+
+/// Short-term and long-term tax rates expressed as decimals between 0 and 1.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct TaxRates {
+    /// Rate applied to short-term taxable gains.
+    pub short_term: Decimal,
+    /// Rate applied to long-term taxable gains.
+    pub long_term: Decimal,
+}
+
+impl TaxRates {
+    /// Create tax rates after validating the 0..=1 range.
+    pub fn new(short_term: Decimal, long_term: Decimal) -> Result<Self, TaxReportError> {
+        validate_rate(short_term)?;
+        validate_rate(long_term)?;
+        Ok(Self {
+            short_term,
+            long_term,
+        })
+    }
+}
+
+/// Optional report-time rate overrides.
+#[derive(Debug, Clone, Copy, Default, PartialEq)]
+pub struct TaxRateOverrides {
+    /// Override short-term rates for every account in the report.
+    pub short_term: Option<Decimal>,
+    /// Override long-term rates for every account in the report.
+    pub long_term: Option<Decimal>,
+}
+
+/// Per-trade tax line.
+#[derive(Debug, Clone, PartialEq)]
+pub struct TaxTradeLine {
+    /// Account that owns the trade.
+    pub account_id: Uuid,
+    /// Trade identifier.
+    pub trade_id: Uuid,
+    /// Normalized symbol.
+    pub symbol: String,
+    /// Entry fill date.
+    pub opened_date: NaiveDate,
+    /// Exit fill date.
+    pub closed_date: NaiveDate,
+    /// Number of calendar days between entry and exit fills.
+    pub holding_days: i64,
+    /// Short-term or long-term bucket.
+    pub holding_period: TaxHoldingPeriod,
+    /// Persisted realized P&L before tax adjustments.
+    pub realized_gain_loss: Decimal,
+    /// Wash-sale loss disallowed on this trade.
+    pub wash_sale_disallowed_loss: Decimal,
+    /// Replacement basis adjustment applied when this trade is a closed replacement.
+    pub replacement_basis_adjustment: Decimal,
+    /// Realized P&L after wash-sale and replacement-basis adjustments.
+    pub taxable_gain_loss: Decimal,
+    /// Tax rate applied to this line's holding-period bucket.
+    pub tax_rate: Decimal,
+    /// Line-level estimated liability for positive taxable gains.
+    pub estimated_tax_liability: Decimal,
+}
+
+/// Aggregated account tax summary.
+#[derive(Debug, Clone, PartialEq)]
+pub struct TaxAccountSummary {
+    /// Account identifier.
+    pub account_id: Uuid,
+    /// Short-term tax rate used for this account.
+    pub short_term_rate: Decimal,
+    /// Long-term tax rate used for this account.
+    pub long_term_rate: Decimal,
+    /// Number of classified closed trades.
+    pub trade_count: usize,
+    /// Gross realized gains before adjustments.
+    pub gross_realized_gain: Decimal,
+    /// Gross realized losses before adjustments.
+    pub gross_realized_loss: Decimal,
+    /// Wash-sale losses disallowed for this account.
+    pub wash_sale_disallowed_loss: Decimal,
+    /// Replacement basis adjustments applied to closed replacement trades.
+    pub replacement_basis_adjustment: Decimal,
+    /// Net taxable short-term gain/loss.
+    pub short_term_taxable_gain: Decimal,
+    /// Net taxable long-term gain/loss.
+    pub long_term_taxable_gain: Decimal,
+    /// Net taxable gain/loss across holding-period buckets.
+    pub net_taxable_gain: Decimal,
+    /// Sum of positive line-level tax estimates before category loss netting.
+    pub estimated_gross_tax_liability: Decimal,
+    /// Estimated liability after netting losses inside each holding-period bucket.
+    pub estimated_net_tax_liability: Decimal,
+}
+
+/// Realized gains tax report.
+#[derive(Debug, Clone, PartialEq)]
+pub struct TaxReport {
+    /// Number of trades scanned.
+    pub scanned_trade_count: usize,
+    /// Number of closed trades that could be classified by holding period.
+    pub taxable_trade_count: usize,
+    /// Number of closed trades skipped because fill dates were missing.
+    pub unclassified_trade_count: usize,
+    /// Number of wash-sale allocation rows considered.
+    pub wash_sale_adjustment_count: usize,
+    /// Gross realized gains before adjustments.
+    pub gross_realized_gain: Decimal,
+    /// Gross realized losses before adjustments.
+    pub gross_realized_loss: Decimal,
+    /// Wash-sale losses disallowed across loss trades.
+    pub wash_sale_disallowed_loss: Decimal,
+    /// Replacement basis adjustments applied to closed replacement trades.
+    pub replacement_basis_adjustment: Decimal,
+    /// Net taxable short-term gain/loss.
+    pub short_term_taxable_gain: Decimal,
+    /// Net taxable long-term gain/loss.
+    pub long_term_taxable_gain: Decimal,
+    /// Net taxable gain/loss across holding-period buckets.
+    pub net_taxable_gain: Decimal,
+    /// Sum of positive line-level tax estimates before category loss netting.
+    pub estimated_gross_tax_liability: Decimal,
+    /// Estimated liability after netting losses inside each holding-period bucket.
+    pub estimated_net_tax_liability: Decimal,
+    /// Per-account summaries.
+    pub account_summaries: Vec<TaxAccountSummary>,
+    /// Per-trade tax lines.
+    pub trades: Vec<TaxTradeLine>,
+}
+
+/// Stateless tax report calculator.
+#[derive(Debug, Default)]
+pub struct TaxService;
+
+impl TaxService {
+    /// Calculate tax lines and summaries from a trade ledger and wash-sale report.
+    pub fn calculate(
+        trades: &[Trade],
+        account_rates: &BTreeMap<Uuid, TaxRates>,
+        wash_sales: &WashSaleReport,
+    ) -> Result<TaxReport, TaxReportError> {
+        let disallowed_by_loss_trade = disallowed_loss_by_trade(wash_sales)?;
+        let replacement_basis_by_trade = replacement_basis_adjustment_by_trade(wash_sales)?;
+        let closed_trade_count = trades.iter().filter(|trade| is_closed(trade)).count();
+
+        let mut lines = Vec::new();
+        let mut unclassified_trade_count: usize = 0;
+        for trade in trades.iter().filter(|trade| is_closed(trade)) {
+            match tax_line(
+                trade,
+                account_rates,
+                &disallowed_by_loss_trade,
+                &replacement_basis_by_trade,
+            )? {
+                Some(line) => lines.push(line),
+                None => {
+                    unclassified_trade_count =
+                        unclassified_trade_count.checked_add(1).ok_or_else(|| {
+                            TaxReportError::calculation("unclassified trade count overflow")
+                        })?;
+                }
+            }
+        }
+
+        lines.sort_by_key(|line| (line.closed_date, line.account_id, line.trade_id));
+        let account_summaries = summarize_accounts(&lines, account_rates)?;
+        let totals = summarize_lines(&lines)?;
+        let net_taxable_gain = totals.net_taxable_gain()?;
+        let estimated_net_tax_liability = sum_decimal(
+            account_summaries
+                .iter()
+                .map(|summary| summary.estimated_net_tax_liability),
+        )?;
+
+        Ok(TaxReport {
+            scanned_trade_count: closed_trade_count,
+            taxable_trade_count: lines.len(),
+            unclassified_trade_count,
+            wash_sale_adjustment_count: wash_sales.matches.len(),
+            gross_realized_gain: totals.gross_realized_gain,
+            gross_realized_loss: totals.gross_realized_loss,
+            wash_sale_disallowed_loss: totals.wash_sale_disallowed_loss,
+            replacement_basis_adjustment: totals.replacement_basis_adjustment,
+            short_term_taxable_gain: totals.short_term_taxable_gain,
+            long_term_taxable_gain: totals.long_term_taxable_gain,
+            net_taxable_gain,
+            estimated_gross_tax_liability: totals.estimated_gross_tax_liability,
+            estimated_net_tax_liability,
+            account_summaries,
+            trades: lines,
+        })
+    }
+}
+
+#[derive(Debug, Clone)]
+struct TaxSummaryAccumulator {
+    gross_realized_gain: Decimal,
+    gross_realized_loss: Decimal,
+    wash_sale_disallowed_loss: Decimal,
+    replacement_basis_adjustment: Decimal,
+    short_term_taxable_gain: Decimal,
+    long_term_taxable_gain: Decimal,
+    estimated_gross_tax_liability: Decimal,
+}
+
+impl Default for TaxSummaryAccumulator {
+    fn default() -> Self {
+        Self {
+            gross_realized_gain: Decimal::ZERO,
+            gross_realized_loss: Decimal::ZERO,
+            wash_sale_disallowed_loss: Decimal::ZERO,
+            replacement_basis_adjustment: Decimal::ZERO,
+            short_term_taxable_gain: Decimal::ZERO,
+            long_term_taxable_gain: Decimal::ZERO,
+            estimated_gross_tax_liability: Decimal::ZERO,
+        }
+    }
+}
+
+impl TaxSummaryAccumulator {
+    fn add_line(&mut self, line: &TaxTradeLine) -> Result<(), TaxReportError> {
+        if line.realized_gain_loss >= Decimal::ZERO {
+            self.gross_realized_gain = checked_add(
+                self.gross_realized_gain,
+                line.realized_gain_loss,
+                "gross realized gain",
+            )?;
+        } else {
+            self.gross_realized_loss = checked_add(
+                self.gross_realized_loss,
+                line.realized_gain_loss,
+                "gross realized loss",
+            )?;
+        }
+        self.wash_sale_disallowed_loss = checked_add(
+            self.wash_sale_disallowed_loss,
+            line.wash_sale_disallowed_loss,
+            "wash sale disallowed loss",
+        )?;
+        self.replacement_basis_adjustment = checked_add(
+            self.replacement_basis_adjustment,
+            line.replacement_basis_adjustment,
+            "replacement basis adjustment",
+        )?;
+        match line.holding_period {
+            TaxHoldingPeriod::ShortTerm => {
+                self.short_term_taxable_gain = checked_add(
+                    self.short_term_taxable_gain,
+                    line.taxable_gain_loss,
+                    "short-term taxable gain",
+                )?;
+            }
+            TaxHoldingPeriod::LongTerm => {
+                self.long_term_taxable_gain = checked_add(
+                    self.long_term_taxable_gain,
+                    line.taxable_gain_loss,
+                    "long-term taxable gain",
+                )?;
+            }
+        }
+        self.estimated_gross_tax_liability = checked_add(
+            self.estimated_gross_tax_liability,
+            line.estimated_tax_liability,
+            "gross tax liability",
+        )?;
+        Ok(())
+    }
+
+    fn net_taxable_gain(&self) -> Result<Decimal, TaxReportError> {
+        checked_add(
+            self.short_term_taxable_gain,
+            self.long_term_taxable_gain,
+            "net taxable gain",
+        )
+    }
+
+    fn estimated_net_tax_liability(&self, rates: TaxRates) -> Result<Decimal, TaxReportError> {
+        let short_tax = positive_tax(self.short_term_taxable_gain, rates.short_term)?;
+        let long_tax = positive_tax(self.long_term_taxable_gain, rates.long_term)?;
+        checked_add(short_tax, long_tax, "net tax liability")
+    }
+}
+
+fn tax_line(
+    trade: &Trade,
+    account_rates: &BTreeMap<Uuid, TaxRates>,
+    disallowed_by_loss_trade: &BTreeMap<Uuid, Decimal>,
+    replacement_basis_by_trade: &BTreeMap<Uuid, Decimal>,
+) -> Result<Option<TaxTradeLine>, TaxReportError> {
+    let Some(opened_date) = entry_date(trade) else {
+        return Ok(None);
+    };
+    let Some(closed_date) = exit_date(trade) else {
+        return Ok(None);
+    };
+    let rates = *account_rates.get(&trade.account_id).unwrap_or(&TaxRates {
+        short_term: Decimal::ZERO,
+        long_term: Decimal::ZERO,
+    });
+    let holding_days = closed_date.signed_duration_since(opened_date).num_days();
+    let holding_period = holding_period(opened_date, closed_date)?;
+    let tax_rate = match holding_period {
+        TaxHoldingPeriod::ShortTerm => rates.short_term,
+        TaxHoldingPeriod::LongTerm => rates.long_term,
+    };
+    let wash_sale_disallowed_loss = disallowed_by_loss_trade
+        .get(&trade.id)
+        .copied()
+        .unwrap_or(Decimal::ZERO);
+    let replacement_basis_adjustment = replacement_basis_by_trade
+        .get(&trade.id)
+        .copied()
+        .unwrap_or(Decimal::ZERO);
+    let taxable_gain_loss = checked_sub(
+        checked_add(
+            trade.balance.total_performance,
+            wash_sale_disallowed_loss,
+            "taxable gain wash sale adjustment",
+        )?,
+        replacement_basis_adjustment,
+        "taxable gain replacement basis adjustment",
+    )?;
+    let estimated_tax_liability = positive_tax(taxable_gain_loss, tax_rate)?;
+
+    Ok(Some(TaxTradeLine {
+        account_id: trade.account_id,
+        trade_id: trade.id,
+        symbol: normalized_symbol(trade),
+        opened_date,
+        closed_date,
+        holding_days,
+        holding_period,
+        realized_gain_loss: trade.balance.total_performance,
+        wash_sale_disallowed_loss,
+        replacement_basis_adjustment,
+        taxable_gain_loss,
+        tax_rate,
+        estimated_tax_liability,
+    }))
+}
+
+fn summarize_accounts(
+    lines: &[TaxTradeLine],
+    account_rates: &BTreeMap<Uuid, TaxRates>,
+) -> Result<Vec<TaxAccountSummary>, TaxReportError> {
+    let mut grouped: BTreeMap<Uuid, (TaxSummaryAccumulator, usize)> = BTreeMap::new();
+    for line in lines {
+        let entry = grouped.entry(line.account_id).or_default();
+        entry.0.add_line(line)?;
+        entry.1 = entry
+            .1
+            .checked_add(1)
+            .ok_or_else(|| TaxReportError::calculation("account trade count overflow"))?;
+    }
+
+    grouped
+        .into_iter()
+        .map(|(account_id, (summary, trade_count))| {
+            let rates = *account_rates.get(&account_id).unwrap_or(&TaxRates {
+                short_term: Decimal::ZERO,
+                long_term: Decimal::ZERO,
+            });
+            let net_taxable_gain = summary.net_taxable_gain()?;
+            let estimated_net_tax_liability = summary.estimated_net_tax_liability(rates)?;
+            Ok(TaxAccountSummary {
+                account_id,
+                short_term_rate: rates.short_term,
+                long_term_rate: rates.long_term,
+                trade_count,
+                gross_realized_gain: summary.gross_realized_gain,
+                gross_realized_loss: summary.gross_realized_loss,
+                wash_sale_disallowed_loss: summary.wash_sale_disallowed_loss,
+                replacement_basis_adjustment: summary.replacement_basis_adjustment,
+                short_term_taxable_gain: summary.short_term_taxable_gain,
+                long_term_taxable_gain: summary.long_term_taxable_gain,
+                net_taxable_gain,
+                estimated_gross_tax_liability: summary.estimated_gross_tax_liability,
+                estimated_net_tax_liability,
+            })
+        })
+        .collect()
+}
+
+fn summarize_lines(lines: &[TaxTradeLine]) -> Result<TaxSummaryAccumulator, TaxReportError> {
+    let mut summary = TaxSummaryAccumulator::default();
+    for line in lines {
+        summary.add_line(line)?;
+    }
+    Ok(summary)
+}
+
+fn disallowed_loss_by_trade(
+    wash_sales: &WashSaleReport,
+) -> Result<BTreeMap<Uuid, Decimal>, TaxReportError> {
+    let mut grouped = BTreeMap::new();
+    for wash_sale in &wash_sales.matches {
+        let current = grouped
+            .get(&wash_sale.loss_trade_id)
+            .copied()
+            .unwrap_or(Decimal::ZERO);
+        grouped.insert(
+            wash_sale.loss_trade_id,
+            checked_add(
+                current,
+                wash_sale.disallowed_loss,
+                "wash sale loss grouping",
+            )?,
+        );
+    }
+    Ok(grouped)
+}
+
+fn replacement_basis_adjustment_by_trade(
+    wash_sales: &WashSaleReport,
+) -> Result<BTreeMap<Uuid, Decimal>, TaxReportError> {
+    let mut grouped = BTreeMap::new();
+    for adjustment in &wash_sales.replacement_adjustments {
+        let current = grouped
+            .get(&adjustment.replacement_trade_id)
+            .copied()
+            .unwrap_or(Decimal::ZERO);
+        grouped.insert(
+            adjustment.replacement_trade_id,
+            checked_add(
+                current,
+                adjustment.basis_adjustment,
+                "wash sale replacement basis grouping",
+            )?,
+        );
+    }
+    Ok(grouped)
+}
+
+fn validate_rate(rate: Decimal) -> Result<(), TaxReportError> {
+    if rate < Decimal::ZERO || rate > Decimal::ONE {
+        return Err(TaxReportError::calculation("tax rate outside 0..=1"));
+    }
+    Ok(())
+}
+
+fn is_closed(trade: &Trade) -> bool {
+    matches!(trade.status, Status::ClosedTarget | Status::ClosedStopLoss)
+}
+
+fn normalized_symbol(trade: &Trade) -> String {
+    trade.trading_vehicle.symbol.trim().to_uppercase()
+}
+
+fn entry_date(trade: &Trade) -> Option<NaiveDate> {
+    trade.entry.filled_at.map(|filled_at| filled_at.date())
+}
+
+fn exit_date(trade: &Trade) -> Option<NaiveDate> {
+    match trade.status {
+        Status::ClosedTarget => trade.target.filled_at.map(|filled_at| filled_at.date()),
+        Status::ClosedStopLoss => trade
+            .safety_stop
+            .filled_at
+            .map(|filled_at| filled_at.date()),
+        _ => None,
+    }
+}
+
+fn holding_period(
+    opened_date: NaiveDate,
+    closed_date: NaiveDate,
+) -> Result<TaxHoldingPeriod, TaxReportError> {
+    let long_term_start = opened_date
+        .checked_add_days(Days::new(LONG_TERM_THRESHOLD_DAYS))
+        .ok_or_else(|| TaxReportError::calculation("holding-period date overflow"))?;
+    if closed_date >= long_term_start {
+        Ok(TaxHoldingPeriod::LongTerm)
+    } else {
+        Ok(TaxHoldingPeriod::ShortTerm)
+    }
+}
+
+fn positive_tax(amount: Decimal, rate: Decimal) -> Result<Decimal, TaxReportError> {
+    if amount <= Decimal::ZERO {
+        return Ok(Decimal::ZERO);
+    }
+    checked_mul(amount, rate, "tax liability")
+}
+
+fn checked_add(
+    left: Decimal,
+    right: Decimal,
+    context: &'static str,
+) -> Result<Decimal, TaxReportError> {
+    left.checked_add(right)
+        .ok_or_else(|| TaxReportError::calculation(context))
+}
+
+fn checked_sub(
+    left: Decimal,
+    right: Decimal,
+    context: &'static str,
+) -> Result<Decimal, TaxReportError> {
+    left.checked_sub(right)
+        .ok_or_else(|| TaxReportError::calculation(context))
+}
+
+fn checked_mul(
+    left: Decimal,
+    right: Decimal,
+    context: &'static str,
+) -> Result<Decimal, TaxReportError> {
+    left.checked_mul(right)
+        .ok_or_else(|| TaxReportError::calculation(context))
+}
+
+fn sum_decimal(mut values: impl Iterator<Item = Decimal>) -> Result<Decimal, TaxReportError> {
+    values.try_fold(Decimal::ZERO, |acc, value| {
+        checked_add(acc, value, "decimal sum")
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{TaxHoldingPeriod, TaxRates, TaxService};
+    use crate::services::{
+        WashSaleMatch, WashSaleReplacementAdjustment, WashSaleReport, WashSaleService,
+    };
+    use chrono::{NaiveDate, NaiveDateTime};
+    use model::{
+        Currency, Order, OrderStatus, Status, Trade, TradeCategory, TradingVehicle,
+        TradingVehicleCategory,
+    };
+    use rust_decimal::Decimal;
+    use rust_decimal_macros::dec;
+    use std::collections::BTreeMap;
+    use uuid::Uuid;
+
+    fn date(year: i32, month: u32, day: u32) -> NaiveDateTime {
+        NaiveDate::from_ymd_opt(year, month, day)
+            .expect("valid date")
+            .and_hms_opt(14, 30, 0)
+            .expect("valid time")
+    }
+
+    fn filled_order(quantity: Decimal, price: Decimal, filled_at: NaiveDateTime) -> Order {
+        Order {
+            quantity,
+            filled_quantity: quantity,
+            average_filled_price: Some(price),
+            unit_price: price,
+            status: OrderStatus::Filled,
+            filled_at: Some(filled_at),
+            currency: Currency::USD,
+            ..Default::default()
+        }
+    }
+
+    struct TradeSpec {
+        account_id: Uuid,
+        symbol: &'static str,
+        status: Status,
+        quantity: Decimal,
+        entry_price: Decimal,
+        entry_day: NaiveDateTime,
+        exit_price: Decimal,
+        exit_day: NaiveDateTime,
+        pnl: Decimal,
+    }
+
+    fn trade(spec: TradeSpec) -> Trade {
+        let entry = filled_order(spec.quantity, spec.entry_price, spec.entry_day);
+        let exit = filled_order(spec.quantity, spec.exit_price, spec.exit_day);
+        let (target, safety_stop) = match spec.status {
+            Status::ClosedTarget => (exit, Order::default()),
+            Status::ClosedStopLoss => (Order::default(), exit),
+            _ => (Order::default(), Order::default()),
+        };
+
+        Trade {
+            id: Uuid::new_v4(),
+            account_id: spec.account_id,
+            trading_vehicle: TradingVehicle {
+                symbol: spec.symbol.to_string(),
+                category: TradingVehicleCategory::Stock,
+                ..Default::default()
+            },
+            category: TradeCategory::Long,
+            status: spec.status,
+            currency: Currency::USD,
+            entry,
+            safety_stop,
+            target,
+            balance: model::TradeBalance {
+                total_performance: spec.pnl,
+                ..Default::default()
+            },
+            ..Default::default()
+        }
+    }
+
+    fn rates(account_id: Uuid, short: Decimal, long: Decimal) -> BTreeMap<Uuid, TaxRates> {
+        BTreeMap::from([(account_id, TaxRates::new(short, long).expect("valid rates"))])
+    }
+
+    fn wash_sale_report(
+        account_id: Uuid,
+        loss_trade_id: Uuid,
+        replacement_trade_id: Uuid,
+    ) -> WashSaleReport {
+        WashSaleReport {
+            scanned_trade_count: 2,
+            eligible_loss_trade_count: 1,
+            wash_sale_count: 1,
+            total_disallowed_loss: dec!(50),
+            total_basis_adjustment: dec!(50),
+            matches: vec![WashSaleMatch {
+                account_id,
+                symbol: "AAPL".to_string(),
+                loss_trade_id,
+                replacement_trade_id,
+                sale_date: NaiveDate::from_ymd_opt(2026, 1, 10).expect("sale date"),
+                replacement_purchase_date: NaiveDate::from_ymd_opt(2026, 1, 20)
+                    .expect("replacement date"),
+                loss_quantity: dec!(10),
+                matched_quantity: dec!(5),
+                realized_loss: dec!(100),
+                disallowed_loss: dec!(50),
+                replacement_cost_basis: dec!(475),
+                adjusted_replacement_cost_basis: dec!(525),
+            }],
+            replacement_adjustments: vec![WashSaleReplacementAdjustment {
+                replacement_trade_id,
+                account_id,
+                symbol: "AAPL".to_string(),
+                replacement_purchase_date: NaiveDate::from_ymd_opt(2026, 1, 20)
+                    .expect("replacement date"),
+                matched_quantity: dec!(5),
+                original_cost_basis: dec!(475),
+                basis_adjustment: dec!(50),
+                adjusted_cost_basis: dec!(525),
+            }],
+        }
+    }
+
+    #[test]
+    fn classifies_short_and_long_term_trades_and_nets_losses() {
+        let account_id = Uuid::new_v4();
+        let short_gain = trade(TradeSpec {
+            account_id,
+            symbol: "AAPL",
+            status: Status::ClosedTarget,
+            quantity: dec!(10),
+            entry_price: dec!(100),
+            entry_day: date(2026, 1, 1),
+            exit_price: dec!(110),
+            exit_day: date(2026, 2, 1),
+            pnl: dec!(100),
+        });
+        let short_loss = trade(TradeSpec {
+            account_id,
+            symbol: "MSFT",
+            status: Status::ClosedStopLoss,
+            quantity: dec!(10),
+            entry_price: dec!(100),
+            entry_day: date(2026, 1, 1),
+            exit_price: dec!(95),
+            exit_day: date(2026, 3, 1),
+            pnl: dec!(-50),
+        });
+        let long_gain = trade(TradeSpec {
+            account_id,
+            symbol: "GOOG",
+            status: Status::ClosedTarget,
+            quantity: dec!(10),
+            entry_price: dec!(100),
+            entry_day: date(2024, 1, 1),
+            exit_price: dec!(120),
+            exit_day: date(2025, 1, 3),
+            pnl: dec!(200),
+        });
+        let wash_sales = WashSaleService::detect(&[]).expect("empty wash sale report");
+
+        let report = TaxService::calculate(
+            &[short_gain, short_loss, long_gain],
+            &rates(account_id, dec!(0.30), dec!(0.15)),
+            &wash_sales,
+        )
+        .expect("tax report");
+
+        assert_eq!(report.taxable_trade_count, 3);
+        assert_eq!(report.unclassified_trade_count, 0);
+        assert_eq!(report.short_term_taxable_gain, dec!(50));
+        assert_eq!(report.long_term_taxable_gain, dec!(200));
+        assert_eq!(report.net_taxable_gain, dec!(250));
+        assert_eq!(report.estimated_gross_tax_liability, dec!(60.00));
+        assert_eq!(report.estimated_net_tax_liability, dec!(45.00));
+        let long_line = report
+            .trades
+            .iter()
+            .find(|line| line.symbol == "GOOG")
+            .expect("long-term line");
+        assert_eq!(long_line.holding_period, TaxHoldingPeriod::LongTerm);
+    }
+
+    #[test]
+    fn applies_wash_sale_loss_and_replacement_basis_adjustments() {
+        let account_id = Uuid::new_v4();
+        let loss_trade_id = Uuid::new_v4();
+        let replacement_trade_id = Uuid::new_v4();
+        let mut loss = trade(TradeSpec {
+            account_id,
+            symbol: "AAPL",
+            status: Status::ClosedStopLoss,
+            quantity: dec!(10),
+            entry_price: dec!(100),
+            entry_day: date(2026, 1, 1),
+            exit_price: dec!(90),
+            exit_day: date(2026, 1, 10),
+            pnl: dec!(-100),
+        });
+        loss.id = loss_trade_id;
+        let mut replacement = trade(TradeSpec {
+            account_id,
+            symbol: "AAPL",
+            status: Status::ClosedTarget,
+            quantity: dec!(5),
+            entry_price: dec!(95),
+            entry_day: date(2026, 1, 20),
+            exit_price: dec!(140),
+            exit_day: date(2026, 2, 20),
+            pnl: dec!(225),
+        });
+        replacement.id = replacement_trade_id;
+        let wash_sales = wash_sale_report(account_id, loss_trade_id, replacement_trade_id);
+
+        let report = TaxService::calculate(
+            &[loss, replacement],
+            &rates(account_id, dec!(0.25), dec!(0.15)),
+            &wash_sales,
+        )
+        .expect("tax report");
+
+        let loss_line = report
+            .trades
+            .iter()
+            .find(|line| line.trade_id == loss_trade_id)
+            .expect("loss line");
+        assert_eq!(loss_line.taxable_gain_loss, dec!(-50));
+        assert_eq!(loss_line.wash_sale_disallowed_loss, dec!(50));
+
+        let replacement_line = report
+            .trades
+            .iter()
+            .find(|line| line.trade_id == replacement_trade_id)
+            .expect("replacement line");
+        assert_eq!(replacement_line.replacement_basis_adjustment, dec!(50));
+        assert_eq!(replacement_line.taxable_gain_loss, dec!(175));
+        assert_eq!(report.short_term_taxable_gain, dec!(125));
+        assert_eq!(report.estimated_net_tax_liability, dec!(31.25));
+    }
+}


### PR DESCRIPTION
Closes #99

Summary:
- add realized gains tax calculation with short-term/long-term holding-period buckets
- apply wash sale disallowed loss and replacement basis adjustments
- add `report tax` text/JSON output with optional account and rate overrides
- cover core tax math and CLI JSON report contract

Verification:
- cargo fmt --all -- --check
- git diff --check
- cargo clippy --workspace --all-targets --all-features -- -D warnings
- cargo test --locked --all-features --workspace
- cargo test --locked --no-default-features --workspace