### PR TITLE
feat(core): add insurance profit distribution reserve

### DIFF
--- a/cli/src/command_routing.rs
+++ b/cli/src/command_routing.rs
@@ -88,6 +88,7 @@ pub enum DistributionSubcommand<'a> {
     Configure(&'a ArgMatches),
     Execute(&'a ArgMatches),
     History(&'a ArgMatches),
+    Insurance(&'a ArgMatches),
     Rules(&'a ArgMatches),
 }
 
@@ -279,6 +280,7 @@ pub fn parse_distribution_subcommand(sub_matches: &ArgMatches) -> DistributionSu
         Some(("configure", sub_sub_matches)) => DistributionSubcommand::Configure(sub_sub_matches),
         Some(("execute", sub_sub_matches)) => DistributionSubcommand::Execute(sub_sub_matches),
         Some(("history", sub_sub_matches)) => DistributionSubcommand::History(sub_sub_matches),
+        Some(("insurance", sub_sub_matches)) => DistributionSubcommand::Insurance(sub_sub_matches),
         Some(("rules", sub_sub_matches)) => DistributionSubcommand::Rules(sub_sub_matches),
         _ => unreachable!("No subcommand provided"),
     }

--- a/cli/src/commands/account_command.rs
+++ b/cli/src/commands/account_command.rs
@@ -63,7 +63,7 @@ impl AccountCommandBuilder {
                     Arg::new("type")
                         .long("type")
                         .value_name("TYPE")
-                        .help("Account type: primary|earnings|tax-reserve|reinvestment")
+                        .help("Account type: primary|earnings|tax-reserve|reinvestment|insurance")
                         .required(false),
                 )
                 .arg(

--- a/cli/src/commands/distribution_command.rs
+++ b/cli/src/commands/distribution_command.rs
@@ -56,6 +56,13 @@ impl DistributionCommandBuilder {
                         .required(true),
                 )
                 .arg(
+                    Arg::new("insurance")
+                        .long("insurance")
+                        .value_name("PERCENT")
+                        .help("Percentage for insurance reserve allocation (default: 0.0)")
+                        .required(false),
+                )
+                .arg(
                     Arg::new("threshold")
                         .long("threshold")
                         .short('m')
@@ -123,6 +130,22 @@ impl DistributionCommandBuilder {
         self
     }
 
+    pub fn insurance_status(mut self) -> Self {
+        self.subcommands.push(
+            Command::new("insurance")
+                .about("Show insurance reserve status for an account")
+                .arg(
+                    Arg::new("account-id")
+                        .long("account-id")
+                        .short('a')
+                        .value_name("UUID")
+                        .help("Primary account ID to show insurance status for")
+                        .required(true),
+                ),
+        );
+        self
+    }
+
     pub fn show_rules(mut self) -> Self {
         self.subcommands.push(
             Command::new("rules")
@@ -174,10 +197,21 @@ mod tests {
             "30.0",
             "--reinvestment",
             "30.0",
+            "--insurance",
+            "0.0",
             "--threshold",
             "100.0",
         ]);
 
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn insurance_status_subcommand_parses() {
+        let cmd = DistributionCommandBuilder::new().insurance_status().build();
+        let account_id = "550e8400-e29b-41d4-a716-446655440000";
+        let result =
+            cmd.try_get_matches_from(["distribution", "insurance", "--account-id", account_id]);
         assert!(result.is_ok());
     }
 

--- a/cli/src/dialogs/trade_close_dialog.rs
+++ b/cli/src/dialogs/trade_close_dialog.rs
@@ -629,6 +629,7 @@ mod tests {
                     earnings_amount: Some(dec!(3)),
                     tax_amount: Some(dec!(2)),
                     reinvestment_amount: Some(dec!(5)),
+                    insurance_amount: None,
                     distribution_date: Utc::now().naive_utc(),
                     transactions_created: vec![Uuid::new_v4()],
                 }),

--- a/cli/src/dispatcher.rs
+++ b/cli/src/dispatcher.rs
@@ -731,6 +731,9 @@ impl ArgDispatcher {
             DistributionSubcommand::History(history_matches) => {
                 self.distribution_history(history_matches)?
             }
+            DistributionSubcommand::Insurance(insurance_matches) => {
+                self.distribution_insurance_status(insurance_matches)?
+            }
             DistributionSubcommand::Rules(rules_matches) => {
                 if let Some(("show", nested)) = rules_matches.subcommand() {
                     self.distribution_rules(nested)?
@@ -1768,9 +1771,10 @@ impl ArgDispatcher {
             "earnings" => Ok(AccountType::Earnings),
             "tax-reserve" | "tax_reserve" => Ok(AccountType::TaxReserve),
             "reinvestment" => Ok(AccountType::Reinvestment),
+            "insurance" => Ok(AccountType::Insurance),
             _ => Err(CliError::new(
                 "invalid_account_type",
-                "Invalid --type value (expected primary|earnings|tax-reserve|reinvestment)",
+                "Invalid --type value (expected primary|earnings|tax-reserve|reinvestment|insurance)",
             )),
         }
     }
@@ -10094,6 +10098,10 @@ impl ArgDispatcher {
         let earnings_str = matches.get_one::<String>("earnings").unwrap();
         let tax_str = matches.get_one::<String>("tax").unwrap();
         let reinvestment_str = matches.get_one::<String>("reinvestment").unwrap();
+        let insurance_str = matches
+            .get_one::<String>("insurance")
+            .map(String::as_str)
+            .unwrap_or("0");
         let threshold_str = matches.get_one::<String>("threshold").unwrap();
         let password = if let Some(p) = matches.get_one::<String>("password") {
             p.to_string()
@@ -10120,15 +10128,20 @@ impl ArgDispatcher {
             .map_err(|_| CliError::new("invalid_decimal", "Invalid --reinvestment decimal"))?
             .checked_div(Decimal::new(100, 0))
             .ok_or_else(|| CliError::new("invalid_decimal", "Invalid --reinvestment percentage"))?;
+        let insurance_pct = Decimal::from_str_exact(insurance_str)
+            .map_err(|_| CliError::new("invalid_decimal", "Invalid --insurance decimal"))?
+            .checked_div(Decimal::new(100, 0))
+            .ok_or_else(|| CliError::new("invalid_decimal", "Invalid --insurance percentage"))?;
         let threshold = Decimal::from_str_exact(threshold_str)
             .map_err(|_| CliError::new("invalid_decimal", "Invalid --threshold decimal"))?;
 
         self.trust
-            .configure_distribution(
+            .configure_distribution_with_insurance(
                 account_id,
                 earnings_pct,
                 tax_pct,
                 reinvestment_pct,
+                insurance_pct,
                 threshold,
                 &password,
             )
@@ -10139,6 +10152,7 @@ impl ArgDispatcher {
         println!("  earnings: {earnings_pct}");
         println!("  tax: {tax_pct}");
         println!("  reinvestment: {reinvestment_pct}");
+        println!("  insurance: {insurance_pct}");
         println!("  minimum_threshold: {}", crate::zen::amount(threshold));
         Ok(())
     }
@@ -10186,6 +10200,13 @@ impl ArgDispatcher {
             )
         );
         println!(
+            "  insurance_amount: {}",
+            crate::zen::amount_share(
+                result.insurance_amount.unwrap_or_default(),
+                result.original_amount,
+            )
+        );
+        println!(
             "  transactions_created: {}",
             result.transactions_created.len()
         );
@@ -10215,7 +10236,7 @@ impl ArgDispatcher {
         for entry in entries {
             let basis = entry.original_amount;
             println!(
-                "- at={} trade_id={} amount={} earnings={} tax={} reinvestment={}",
+                "- at={} trade_id={} amount={} earnings={} tax={} reinvestment={} insurance={}",
                 entry.distribution_date,
                 entry
                     .trade_id
@@ -10234,9 +10255,68 @@ impl ArgDispatcher {
                     .reinvestment_amount
                     .map(|v| crate::zen::amount_share(v, basis))
                     .unwrap_or_else(|| crate::zen::amount_share(Decimal::ZERO, basis)),
+                entry
+                    .insurance_amount
+                    .map(|v| crate::zen::amount_share(v, basis))
+                    .unwrap_or_else(|| crate::zen::amount_share(Decimal::ZERO, basis)),
             );
         }
 
+        Ok(())
+    }
+
+    fn distribution_insurance_status(&mut self, matches: &ArgMatches) -> Result<(), CliError> {
+        let account_id_str = matches.get_one::<String>("account-id").unwrap();
+        let source_account_id = Uuid::parse_str(account_id_str)
+            .map_err(|_| CliError::new("invalid_uuid", "Invalid --account-id UUID"))?;
+
+        let accounts = self
+            .trust
+            .search_all_accounts()
+            .map_err(|e| CliError::new("insurance_status_failed", e.to_string()))?;
+        let insurance_account = accounts
+            .iter()
+            .find(|account| {
+                account.parent_account_id == Some(source_account_id)
+                    && account.account_type == AccountType::Insurance
+            })
+            .ok_or_else(|| {
+                CliError::new(
+                    "insurance_account_not_found",
+                    "Missing insurance subaccount for distribution",
+                )
+            })?;
+
+        let transactions = self
+            .trust
+            .get_account_transactions(insurance_account.id)
+            .map_err(|e| CliError::new("insurance_status_failed", e.to_string()))?;
+        let balance = transactions.iter().try_fold(Decimal::ZERO, |total, tx| {
+            total
+                .checked_add(tx.amount)
+                .ok_or_else(|| CliError::new("insurance_status_failed", "Balance overflow"))
+        })?;
+        let history = self
+            .trust
+            .distribution_history(source_account_id)
+            .map_err(|e| CliError::new("insurance_status_failed", e.to_string()))?;
+        let allocated = history.iter().try_fold(Decimal::ZERO, |total, entry| {
+            total
+                .checked_add(entry.insurance_amount.unwrap_or_default())
+                .ok_or_else(|| CliError::new("insurance_status_failed", "Allocation overflow"))
+        })?;
+        let distribution_count = history
+            .iter()
+            .filter(|entry| entry.insurance_amount.unwrap_or_default() > Decimal::ZERO)
+            .count();
+
+        println!("Insurance reserve:");
+        println!("  source_account_id: {source_account_id}");
+        println!("  insurance_account_id: {}", insurance_account.id);
+        println!("  insurance_account_name: {}", insurance_account.name);
+        println!("  balance: {}", crate::zen::amount(balance));
+        println!("  allocated_total: {}", crate::zen::amount(allocated));
+        println!("  distribution_count: {distribution_count}");
         Ok(())
     }
 
@@ -10255,6 +10335,7 @@ impl ArgDispatcher {
         println!("  earnings_percent: {}", rules.earnings_percent);
         println!("  tax_percent: {}", rules.tax_percent);
         println!("  reinvestment_percent: {}", rules.reinvestment_percent);
+        println!("  insurance_percent: {}", rules.insurance_percent);
         println!(
             "  minimum_threshold: {}",
             crate::zen::amount(rules.minimum_threshold)
@@ -10792,6 +10873,7 @@ mod tests {
             .arg(Arg::new("earnings").long("earnings"))
             .arg(Arg::new("tax").long("tax"))
             .arg(Arg::new("reinvestment").long("reinvestment"))
+            .arg(Arg::new("insurance").long("insurance"))
             .arg(Arg::new("threshold").long("threshold"))
             .arg(Arg::new("password").long("password"))
             .get_matches_from(argv)
@@ -10904,6 +10986,7 @@ mod tests {
                     .configure_distribution()
                     .execute_distribution()
                     .history()
+                    .insurance_status()
                     .show_rules()
                     .build(),
             )
@@ -11108,6 +11191,10 @@ mod tests {
             ArgDispatcher::parse_account_type("reinvestment").unwrap(),
             AccountType::Reinvestment
         );
+        assert_eq!(
+            ArgDispatcher::parse_account_type("insurance").unwrap(),
+            AccountType::Insurance
+        );
     }
 
     #[test]
@@ -11144,7 +11231,7 @@ mod tests {
         let error = ArgDispatcher::parse_account_type("savings").unwrap_err();
         assert_eq!(
             error.to_string(),
-            "invalid_account_type: Invalid --type value (expected primary|earnings|tax-reserve|reinvestment)"
+            "invalid_account_type: Invalid --type value (expected primary|earnings|tax-reserve|reinvestment|insurance)"
         );
     }
 
@@ -20076,6 +20163,18 @@ mod tests {
             .expect("create reinvestment account");
         dispatcher
             .trust
+            .create_account_with_hierarchy(
+                "dist-insurance",
+                "insurance",
+                Environment::Paper,
+                dec!(10),
+                dec!(5),
+                AccountType::Insurance,
+                Some(source.id),
+            )
+            .expect("create insurance account");
+        dispatcher
+            .trust
             .create_transaction(
                 &source,
                 &TransactionCategory::Deposit,
@@ -20092,7 +20191,9 @@ mod tests {
             "--tax",
             "30",
             "--reinvestment",
-            "30",
+            "20",
+            "--insurance",
+            "10",
             "--threshold",
             "0",
             "--password",
@@ -20119,6 +20220,11 @@ mod tests {
         dispatcher
             .distribution_history(&history)
             .expect("distribution history should render the truncated latest entry");
+
+        let insurance = distribution_rules_matches(&["--account-id", &source.id.to_string()]);
+        dispatcher
+            .distribution_insurance_status(&insurance)
+            .expect("insurance reserve status should render configured account");
 
         let rules = distribution_rules_matches(&["--account-id", &source.id.to_string()]);
         dispatcher

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -149,6 +149,7 @@ fn build_cli() -> Command {
                 .configure_distribution()
                 .execute_distribution()
                 .history()
+                .insurance_status()
                 .show_rules()
                 .build(),
         )

--- a/cli/src/output.rs
+++ b/cli/src/output.rs
@@ -62,7 +62,8 @@ impl DistributionFormatter {
             │ Distribution Breakdown:                                 \n\
             │ ├─ Earnings:     ${} → Account: {}   \n\
             │ ├─ Tax Reserve:  ${} → Account: {}   \n\
-            │ └─ Reinvestment: ${} → Account: {}   \n\
+            │ ├─ Reinvestment: ${} → Account: {}   \n\
+            │ └─ Insurance:    ${} → Account: {}   \n\
             └─────────────────────────────────────────────────────────┘",
             result.source_account_id,
             result.original_amount,
@@ -71,7 +72,9 @@ impl DistributionFormatter {
             result.tax_amount.unwrap_or_default(),
             "N/A", // tax account ID not available in result
             result.reinvestment_amount.unwrap_or_default(),
-            "N/A" // reinvestment account ID not available in result
+            "N/A", // reinvestment account ID not available in result
+            result.insurance_amount.unwrap_or_default(),
+            "N/A" // insurance account ID not available in result
         )
     }
 
@@ -80,6 +83,7 @@ impl DistributionFormatter {
         earnings_pct: Decimal,
         tax_pct: Decimal,
         reinvestment_pct: Decimal,
+        insurance_pct: Decimal,
         minimum: Decimal,
     ) -> String {
         format!(
@@ -88,7 +92,8 @@ impl DistributionFormatter {
             │ Allocation Rules:                                       \n\
             │ ├─ Earnings:     {}% of profit              \n\
             │ ├─ Tax Reserve:  {}% of profit              \n\
-            │ └─ Reinvestment: {}% of profit              \n\
+            │ ├─ Reinvestment: {}% of profit              \n\
+            │ └─ Insurance:    {}% of profit              \n\
             │                                                         \n\
             │ Minimum Threshold: ${}                     \n\
             │ (Only profits above this amount will be distributed)    \n\
@@ -100,6 +105,9 @@ impl DistributionFormatter {
             reinvestment_pct
                 .checked_mul(Decimal::from(100))
                 .unwrap_or(reinvestment_pct),
+            insurance_pct
+                .checked_mul(Decimal::from(100))
+                .unwrap_or(insurance_pct),
             minimum
         )
     }
@@ -113,7 +121,7 @@ impl DistributionFormatter {
             "📜 Distribution History".to_string(),
             "┌──────────────────────────────────────────────────────────────────────────┐"
                 .to_string(),
-            "│ Date (UTC)           │ Trade      │ Profit    │ Earnings │ Tax    │ Reinv │"
+            "│ Date (UTC)           │ Trade      │ Profit    │ Earnings │ Tax    │ Reinv │ Insur │"
                 .to_string(),
             "├──────────────────────────────────────────────────────────────────────────┤"
                 .to_string(),
@@ -131,13 +139,14 @@ impl DistributionFormatter {
             };
 
             lines.push(format!(
-                "│ {:19} │ {:8} │ {:8} │ {:8} │ {:6} │ {:5} │",
+                "│ {:19} │ {:8} │ {:8} │ {:8} │ {:6} │ {:5} │ {:5} │",
                 entry.distribution_date.format("%Y-%m-%d %H:%M:%S"),
                 trade_short,
                 entry.original_amount,
                 entry.earnings_amount.unwrap_or_default(),
                 entry.tax_amount.unwrap_or_default(),
                 entry.reinvestment_amount.unwrap_or_default(),
+                entry.insurance_amount.unwrap_or_default(),
             ));
         }
 
@@ -279,6 +288,7 @@ mod tests {
             dec!(0.40),
             dec!(0.30),
             dec!(0.30),
+            dec!(0.00),
             dec!(100.0),
         );
 

--- a/core/src/integration_tests.rs
+++ b/core/src/integration_tests.rs
@@ -48,6 +48,7 @@ impl IntegrationTestSuite {
             dec!(0.40),  // 40% earnings
             dec!(0.30),  // 30% tax
             dec!(0.30),  // 30% reinvestment
+            dec!(0.00),  // 0% insurance
             dec!(100.0), // $100 minimum
         );
 
@@ -193,7 +194,14 @@ impl IntegrationTestSuite {
         assert_eq!(total, dec!(1.0)); // Should equal 1.0 (100%)
 
         // Create distribution rules to validate structure
-        let rules = model::DistributionRules::new(account_id, earnings, tax, reinvestment, minimum);
+        let rules = model::DistributionRules::new(
+            account_id,
+            earnings,
+            tax,
+            reinvestment,
+            Decimal::ZERO,
+            minimum,
+        );
 
         // Test validation
         rules.validate()?;
@@ -269,6 +277,7 @@ impl IntegrationTestSuite {
             dec!(0.40),  // 40% earnings
             dec!(0.30),  // 30% tax
             dec!(0.30),  // 30% reinvestment
+            dec!(0.00),  // 0% insurance
             dec!(100.0), // $100 minimum
         );
 
@@ -338,6 +347,7 @@ impl IntegrationTestSuite {
             earnings_pct,
             tax_pct,
             reinvestment_pct,
+            Decimal::ZERO,
             minimum,
         );
         rules.validate()?;
@@ -643,6 +653,7 @@ impl IntegrationTestSuite {
             dec!(0.50), // 50%
             dec!(0.30), // 30%
             dec!(0.30), // 30% = 110% total
+            dec!(0.00),
             dec!(100.0),
         );
 
@@ -656,6 +667,7 @@ impl IntegrationTestSuite {
             dec!(-0.10), // Negative percentage
             dec!(0.60),
             dec!(0.50),
+            dec!(0.00),
             dec!(100.0),
         );
 
@@ -669,6 +681,7 @@ impl IntegrationTestSuite {
             dec!(0.40),
             dec!(0.30),
             dec!(0.30),
+            dec!(0.00),
             dec!(0.0), // Zero minimum
         );
 
@@ -682,6 +695,7 @@ impl IntegrationTestSuite {
             dec!(0.40),
             dec!(0.30),
             dec!(0.30),
+            dec!(0.00),
             dec!(-100.0), // Negative minimum
         );
 
@@ -697,6 +711,7 @@ impl IntegrationTestSuite {
             dec!(0.01), // 1%
             dec!(0.01), // 1%
             dec!(0.98), // 98% = 100% total
+            dec!(0.00),
             dec!(1.0),  // $1 minimum
         );
 

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -114,6 +114,13 @@ struct LevelSnapshotCache {
     last_closed_at: Option<chrono::NaiveDateTime>,
 }
 
+struct DistributionTargetAccounts {
+    earnings: Account,
+    tax: Account,
+    reinvestment: Account,
+    insurance: Option<Account>,
+}
+
 impl LevelSnapshotCache {
     fn new() -> Self {
         Self {
@@ -1755,15 +1762,15 @@ impl TrustFacade {
         }
 
         let source_account = self.factory.account_read().id(trade.account_id)?;
-        let (earnings_account, tax_account, reinvestment_account) =
-            self.resolve_distribution_accounts(source_account.id)?;
+        let target_accounts = self.resolve_distribution_accounts(source_account.id)?;
         let mut distribution_service = ProfitDistributionService::new(&mut *self.factory);
 
         let result = distribution_service.execute_distribution(
             &source_account,
-            &earnings_account,
-            &tax_account,
-            &reinvestment_account,
+            &target_accounts.earnings,
+            &target_accounts.tax,
+            &target_accounts.reinvestment,
+            target_accounts.insurance.as_ref(),
             profit,
             &rules,
             &trade.currency,
@@ -2067,11 +2074,35 @@ impl TrustFacade {
         minimum_threshold: Decimal,
         configuration_password: &str,
     ) -> Result<DistributionRules, Box<dyn std::error::Error>> {
+        self.configure_distribution_with_insurance(
+            account_id,
+            earnings_percent,
+            tax_percent,
+            reinvestment_percent,
+            Decimal::ZERO,
+            minimum_threshold,
+            configuration_password,
+        )
+    }
+
+    /// Configure distribution rules for an account, including insurance reserve allocation.
+    #[allow(clippy::too_many_arguments)]
+    pub fn configure_distribution_with_insurance(
+        &mut self,
+        account_id: Uuid,
+        earnings_percent: Decimal,
+        tax_percent: Decimal,
+        reinvestment_percent: Decimal,
+        insurance_percent: Decimal,
+        minimum_threshold: Decimal,
+        configuration_password: &str,
+    ) -> Result<DistributionRules, Box<dyn std::error::Error>> {
         self.consume_protected_authorization("configure_distribution")?;
         // Validate percentages sum to 100%.
         let total = earnings_percent
             .checked_add(tax_percent)
             .and_then(|sum| sum.checked_add(reinvestment_percent))
+            .and_then(|sum| sum.checked_add(insurance_percent))
             .ok_or("Arithmetic overflow in percentage calculation")?;
         if total != Decimal::ONE {
             return Err("Distribution percentages must sum to 100%".into());
@@ -2082,6 +2113,7 @@ impl TrustFacade {
             earnings_percent,
             tax_percent,
             reinvestment_percent,
+            insurance_percent,
             minimum_threshold,
         );
         rules.validate()?;
@@ -2105,14 +2137,18 @@ impl TrustFacade {
         }
 
         let password_hash = hash_distribution_password(configuration_password)?;
-        let rules = self.factory.distribution_write().create_or_update(
-            account_id,
-            earnings_percent,
-            tax_percent,
-            reinvestment_percent,
-            minimum_threshold,
-            &password_hash,
-        )?;
+        let rules = self
+            .factory
+            .distribution_write()
+            .create_or_update_with_insurance(
+                account_id,
+                earnings_percent,
+                tax_percent,
+                reinvestment_percent,
+                insurance_percent,
+                minimum_threshold,
+                &password_hash,
+            )?;
 
         // Cache for this facade instance to avoid repeated DB reads on high-frequency closes.
         self.distribution_rules_cache
@@ -2134,15 +2170,15 @@ impl TrustFacade {
             .factory
             .distribution_read()
             .for_account(source_account_id)?;
-        let (earnings_account, tax_account, reinvestment_account) =
-            self.resolve_distribution_accounts(source_account_id)?;
+        let target_accounts = self.resolve_distribution_accounts(source_account_id)?;
 
         let mut distribution_service = ProfitDistributionService::new(&mut *self.factory);
         distribution_service.execute_distribution(
             &source_account,
-            &earnings_account,
-            &tax_account,
-            &reinvestment_account,
+            &target_accounts.earnings,
+            &target_accounts.tax,
+            &target_accounts.reinvestment,
+            target_accounts.insurance.as_ref(),
             profit_amount,
             &rules,
             &currency,
@@ -2307,7 +2343,7 @@ impl TrustFacade {
     fn resolve_distribution_accounts(
         &mut self,
         source_account_id: Uuid,
-    ) -> Result<(Account, Account, Account), Box<dyn std::error::Error>> {
+    ) -> Result<DistributionTargetAccounts, Box<dyn std::error::Error>> {
         let child_accounts: Vec<Account> = self
             .factory
             .account_read()
@@ -2331,8 +2367,17 @@ impl TrustFacade {
             .find(|account| account.account_type == AccountType::Reinvestment)
             .cloned()
             .ok_or("Missing reinvestment subaccount for distribution")?;
+        let insurance_account = child_accounts
+            .iter()
+            .find(|account| account.account_type == AccountType::Insurance)
+            .cloned();
 
-        Ok((earnings_account, tax_account, reinvestment_account))
+        Ok(DistributionTargetAccounts {
+            earnings: earnings_account,
+            tax: tax_account,
+            reinvestment: reinvestment_account,
+            insurance: insurance_account,
+        })
     }
 }
 
@@ -2559,6 +2604,7 @@ mod tests {
             ("earnings", AccountType::Earnings),
             ("tax", AccountType::TaxReserve),
             ("reinvestment", AccountType::Reinvestment),
+            ("insurance", AccountType::Insurance),
         ] {
             trust
                 .create_account_with_profile(
@@ -2828,11 +2874,12 @@ mod tests {
         assert!(wrong_password.to_string().contains("Invalid distribution"));
 
         trust
-            .configure_distribution(
+            .configure_distribution_with_insurance(
                 source.id,
-                dec!(0.50),
+                dec!(0.45),
                 dec!(0.25),
-                dec!(0.25),
+                dec!(0.20),
+                dec!(0.10),
                 dec!(50),
                 "distribution-pass",
             )
@@ -2854,7 +2901,8 @@ mod tests {
             .expect("distribution result should be present");
 
         assert_eq!(result.source_account_id, source.id);
-        assert_eq!(result.transactions_created.len(), 3);
+        assert_eq!(result.insurance_amount, Some(dec!(12.0)));
+        assert_eq!(result.transactions_created.len(), 4);
     }
 
     #[test]

--- a/core/src/services/event_distribution_service.rs
+++ b/core/src/services/event_distribution_service.rs
@@ -9,6 +9,14 @@ pub struct EventDistributionService<'a> {
     database: &'a mut dyn DatabaseFactory,
 }
 
+#[derive(Debug)]
+struct DistributionTargetAccounts {
+    earnings: Account,
+    tax: Account,
+    reinvestment: Account,
+    insurance: Option<Account>,
+}
+
 impl<'a> std::fmt::Debug for EventDistributionService<'a> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("EventDistributionService")
@@ -50,15 +58,15 @@ impl<'a> EventDistributionService<'a> {
             return Ok(None);
         }
 
-        let (earnings_account, tax_account, reinvestment_account) =
-            self.find_distribution_accounts(source_account.id)?;
+        let target_accounts = self.find_distribution_accounts(source_account.id)?;
         let mut distribution_service = ProfitDistributionService::new(self.database);
 
         let result = distribution_service.execute_distribution(
             &source_account,
-            &earnings_account,
-            &tax_account,
-            &reinvestment_account,
+            &target_accounts.earnings,
+            &target_accounts.tax,
+            &target_accounts.reinvestment,
+            target_accounts.insurance.as_ref(),
             profit,
             &rules,
             currency,
@@ -77,7 +85,7 @@ impl<'a> EventDistributionService<'a> {
     fn find_distribution_accounts(
         &mut self,
         source_account_id: uuid::Uuid,
-    ) -> Result<(Account, Account, Account), Box<dyn Error>> {
+    ) -> Result<DistributionTargetAccounts, Box<dyn Error>> {
         let child_accounts: Vec<Account> = self
             .database
             .account_read()
@@ -101,8 +109,17 @@ impl<'a> EventDistributionService<'a> {
             .find(|acc| acc.account_type == AccountType::Reinvestment)
             .cloned()
             .ok_or("Reinvestment account not found")?;
+        let insurance_account = child_accounts
+            .iter()
+            .find(|acc| acc.account_type == AccountType::Insurance)
+            .cloned();
 
-        Ok((earnings_account, tax_account, reinvestment_account))
+        Ok(DistributionTargetAccounts {
+            earnings: earnings_account,
+            tax: tax_account,
+            reinvestment: reinvestment_account,
+            insurance: insurance_account,
+        })
     }
 }
 
@@ -433,12 +450,13 @@ mod tests {
         let (source, earnings, tax, reinvestment) = create_sqlite_distribution_hierarchy(&database);
         let mut service = EventDistributionService::new(&mut database);
 
-        let (e, t, r) = service
+        let targets = service
             .find_distribution_accounts(source.id)
             .expect("all distribution child accounts should exist");
-        assert_eq!(e.id, earnings.id);
-        assert_eq!(t.id, tax.id);
-        assert_eq!(r.id, reinvestment.id);
+        assert_eq!(targets.earnings.id, earnings.id);
+        assert_eq!(targets.tax.id, tax.id);
+        assert_eq!(targets.reinvestment.id, reinvestment.id);
+        assert!(targets.insurance.is_none());
     }
 
     #[test]

--- a/core/src/services/profit_distribution_service.rs
+++ b/core/src/services/profit_distribution_service.rs
@@ -12,6 +12,13 @@ pub struct ProfitDistributionService<'a> {
     database: &'a mut dyn DatabaseFactory,
 }
 
+struct DistributionTargetRefs<'a> {
+    earnings: &'a Account,
+    tax: &'a Account,
+    reinvestment: &'a Account,
+    insurance: Option<&'a Account>,
+}
+
 impl<'a> std::fmt::Debug for ProfitDistributionService<'a> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("ProfitDistributionService")
@@ -46,6 +53,7 @@ impl<'a> ProfitDistributionService<'a> {
         earnings_account: &Account,
         tax_account: &Account,
         reinvestment_account: &Account,
+        insurance_account: Option<&Account>,
         profit_amount: Decimal,
         rules: &DistributionRules,
         currency: &Currency,
@@ -57,61 +65,14 @@ impl<'a> ProfitDistributionService<'a> {
         // Update the source account ID to match the provided account
         result.source_account_id = source_account.id;
 
-        let mut legs: Vec<DistributionExecutionLeg> = Vec::new();
-
-        if let Some(amount) = result.earnings_amount {
-            legs.push(DistributionExecutionLeg {
-                to_account_id: earnings_account.id,
-                amount,
-                withdrawal_category: TransactionCategory::Withdrawal,
-                deposit_category: trade_id
-                    .map(TransactionCategory::PaymentEarnings)
-                    .unwrap_or(TransactionCategory::Deposit),
-                forced_withdrawal_tx_id: None,
-                forced_deposit_tx_id: None,
-            });
-        }
-
-        if let Some(amount) = result.tax_amount {
-            legs.push(DistributionExecutionLeg {
-                to_account_id: tax_account.id,
-                amount,
-                withdrawal_category: TransactionCategory::Withdrawal,
-                deposit_category: trade_id
-                    .map(TransactionCategory::PaymentTax)
-                    .unwrap_or(TransactionCategory::Deposit),
-                forced_withdrawal_tx_id: None,
-                forced_deposit_tx_id: None,
-            });
-        }
-
-        if let Some(amount) = result.reinvestment_amount {
-            legs.push(DistributionExecutionLeg {
-                to_account_id: reinvestment_account.id,
-                amount,
-                withdrawal_category: TransactionCategory::Withdrawal,
-                deposit_category: TransactionCategory::Deposit,
-                forced_withdrawal_tx_id: None,
-                forced_deposit_tx_id: None,
-            });
-        }
-
-        // Validate hierarchy constraints before any write.
-        {
-            let transfer_service = FundTransferService::new(self.database);
-            for leg in &legs {
-                let destination = if leg.to_account_id == earnings_account.id {
-                    earnings_account
-                } else if leg.to_account_id == tax_account.id {
-                    tax_account
-                } else if leg.to_account_id == reinvestment_account.id {
-                    reinvestment_account
-                } else {
-                    return Err("Unknown distribution destination account".into());
-                };
-                transfer_service.validate_transfer(source_account, destination, leg.amount)?;
-            }
-        }
+        let target_accounts = DistributionTargetRefs {
+            earnings: earnings_account,
+            tax: tax_account,
+            reinvestment: reinvestment_account,
+            insurance: insurance_account,
+        };
+        let legs = build_distribution_legs(&result, &target_accounts, trade_id)?;
+        validate_distribution_legs(self.database, source_account, &target_accounts, &legs)?;
 
         let plan = DistributionExecutionPlan {
             source_account_id: source_account.id,
@@ -123,6 +84,7 @@ impl<'a> ProfitDistributionService<'a> {
             earnings_amount: result.earnings_amount,
             tax_amount: result.tax_amount,
             reinvestment_amount: result.reinvestment_amount,
+            insurance_amount: result.insurance_amount,
         };
 
         let deposit_ids = self
@@ -150,6 +112,105 @@ impl<'a> ProfitDistributionService<'a> {
         // For now, just validate the input and return success
         // Later this will create actual transactions
         Ok(())
+    }
+}
+
+fn build_distribution_legs(
+    result: &DistributionResult,
+    targets: &DistributionTargetRefs<'_>,
+    trade_id: Option<Uuid>,
+) -> Result<Vec<DistributionExecutionLeg>, Box<dyn Error>> {
+    let mut legs: Vec<DistributionExecutionLeg> = Vec::new();
+
+    if let Some(amount) = result.earnings_amount {
+        push_distribution_leg(
+            &mut legs,
+            targets.earnings.id,
+            amount,
+            trade_id
+                .map(TransactionCategory::PaymentEarnings)
+                .unwrap_or(TransactionCategory::Deposit),
+        );
+    }
+
+    if let Some(amount) = result.tax_amount {
+        push_distribution_leg(
+            &mut legs,
+            targets.tax.id,
+            amount,
+            trade_id
+                .map(TransactionCategory::PaymentTax)
+                .unwrap_or(TransactionCategory::Deposit),
+        );
+    }
+
+    if let Some(amount) = result.reinvestment_amount {
+        push_distribution_leg(
+            &mut legs,
+            targets.reinvestment.id,
+            amount,
+            TransactionCategory::Deposit,
+        );
+    }
+
+    if let Some(amount) = result.insurance_amount {
+        let account = targets
+            .insurance
+            .ok_or("Missing insurance subaccount for distribution")?;
+        push_distribution_leg(&mut legs, account.id, amount, TransactionCategory::Deposit);
+    }
+
+    Ok(legs)
+}
+
+fn push_distribution_leg(
+    legs: &mut Vec<DistributionExecutionLeg>,
+    to_account_id: Uuid,
+    amount: Decimal,
+    deposit_category: TransactionCategory,
+) {
+    legs.push(DistributionExecutionLeg {
+        to_account_id,
+        amount,
+        withdrawal_category: TransactionCategory::Withdrawal,
+        deposit_category,
+        forced_withdrawal_tx_id: None,
+        forced_deposit_tx_id: None,
+    });
+}
+
+fn validate_distribution_legs(
+    database: &mut dyn DatabaseFactory,
+    source_account: &Account,
+    targets: &DistributionTargetRefs<'_>,
+    legs: &[DistributionExecutionLeg],
+) -> Result<(), Box<dyn Error>> {
+    let transfer_service = FundTransferService::new(database);
+    for leg in legs {
+        let destination = distribution_destination(leg, targets)?;
+        transfer_service.validate_transfer(source_account, destination, leg.amount)?;
+    }
+    Ok(())
+}
+
+fn distribution_destination<'a>(
+    leg: &DistributionExecutionLeg,
+    targets: &'a DistributionTargetRefs<'a>,
+) -> Result<&'a Account, Box<dyn Error>> {
+    if leg.to_account_id == targets.earnings.id {
+        Ok(targets.earnings)
+    } else if leg.to_account_id == targets.tax.id {
+        Ok(targets.tax)
+    } else if leg.to_account_id == targets.reinvestment.id {
+        Ok(targets.reinvestment)
+    } else if let Some(account) = targets.insurance {
+        if leg.to_account_id == account.id {
+            Ok(account)
+        } else {
+            Err("Unknown distribution destination account".into())
+        }
+    } else {
+        Err("Unknown distribution destination account".into())
     }
 }
 
@@ -189,6 +250,7 @@ mod tests {
             earnings_percent: dec!(0.40),     // 40%
             tax_percent: dec!(0.30),          // 30%
             reinvestment_percent: dec!(0.30), // 30%
+            insurance_percent: Decimal::ZERO, // 0%
             minimum_threshold: dec!(100),
             configuration_password_hash: "test-password-hash".to_string(),
         }
@@ -253,6 +315,26 @@ mod tests {
             tax_account,
             reinvestment_account,
         )
+    }
+
+    fn create_real_child_account(
+        database: &SqliteDatabase,
+        source_account: &Account,
+        name: &str,
+        account_type: AccountType,
+    ) -> Account {
+        database
+            .account_write()
+            .create_with_hierarchy(
+                name,
+                name,
+                model::Environment::Paper,
+                dec!(0),
+                dec!(0),
+                account_type,
+                Some(source_account.id),
+            )
+            .expect("child account should be created")
     }
 
     #[test]
@@ -435,6 +517,7 @@ mod tests {
                 &earnings_account,
                 &tax_account,
                 &reinvestment_account,
+                None,
                 profit_amount,
                 &rules,
                 &currency,
@@ -537,6 +620,7 @@ mod tests {
             &unrelated_account, // This should fail - no hierarchy relationship
             &tax_account,
             &earnings_account,
+            None,
             profit_amount,
             &rules,
             &currency,
@@ -602,6 +686,7 @@ mod tests {
                 &earnings_account,
                 &tax_account,
                 &reinvestment_account,
+                None,
                 profit_amount,
                 &rules,
                 &currency,
@@ -628,6 +713,61 @@ mod tests {
         assert_eq!(first_history.earnings_amount, Some(dec!(1000)));
         assert_eq!(first_history.tax_amount, None);
         assert_eq!(first_history.reinvestment_amount, None);
+        assert_eq!(first_history.insurance_amount, None);
+    }
+
+    #[test]
+    fn test_execute_distribution_allocates_insurance_amount() {
+        let mut database = SqliteDatabase::new_in_memory();
+        let (source_account, earnings_account, tax_account, reinvestment_account) =
+            create_real_hierarchy(&database, "insurance");
+        let insurance_account = create_real_child_account(
+            &database,
+            &source_account,
+            "insurance-child",
+            AccountType::Insurance,
+        );
+
+        let mut rules = create_test_distribution_rules(source_account.id);
+        rules.earnings_percent = dec!(0.35);
+        rules.tax_percent = dec!(0.25);
+        rules.reinvestment_percent = dec!(0.30);
+        rules.insurance_percent = dec!(0.10);
+
+        let result = {
+            let mut service = ProfitDistributionService::new(&mut database);
+            service.execute_distribution(
+                &source_account,
+                &earnings_account,
+                &tax_account,
+                &reinvestment_account,
+                Some(&insurance_account),
+                dec!(1000),
+                &rules,
+                &Currency::USD,
+                None,
+            )
+        }
+        .expect("insurance distribution should execute");
+
+        assert_eq!(result.insurance_amount, Some(dec!(100)));
+        assert_eq!(result.transactions_created.len(), 4);
+
+        let insurance_transactions =
+            account_transactions(&database, insurance_account.id, &Currency::USD, "insurance");
+        assert_destination_transaction(
+            &insurance_transactions,
+            TransactionCategory::Deposit,
+            dec!(100),
+            "insurance",
+        );
+
+        let history = database
+            .distribution_read()
+            .history_for_account(source_account.id)
+            .expect("history should be readable");
+        let history = history.first().expect("history row should exist");
+        assert_eq!(history.insurance_amount, Some(dec!(100)));
     }
 
     #[test]
@@ -649,6 +789,7 @@ mod tests {
                     &earnings_account,
                     &tax_account,
                     &reinvestment_account,
+                    None,
                     profit_amount,
                     &rules,
                     &currency,
@@ -710,5 +851,6 @@ mod tests {
         assert_eq!(history.earnings_amount, Some(dec!(400)));
         assert_eq!(history.tax_amount, Some(dec!(300)));
         assert_eq!(history.reinvestment_amount, Some(dec!(300)));
+        assert_eq!(history.insurance_amount, None);
     }
 }

--- a/db-sqlite/migrations/2026-05-11-150000_add_insurance_distribution/down.sql
+++ b/db-sqlite/migrations/2026-05-11-150000_add_insurance_distribution/down.sql
@@ -1,0 +1,92 @@
+DROP INDEX IF EXISTS idx_distribution_rules_account_id_unique;
+DROP INDEX IF EXISTS idx_distribution_rules_account_id;
+
+CREATE TABLE distribution_rules_tmp (
+    id TEXT NOT NULL PRIMARY KEY,
+    created_at DATETIME NOT NULL,
+    updated_at DATETIME NOT NULL,
+    account_id TEXT NOT NULL REFERENCES accounts(id),
+    earnings_percent TEXT NOT NULL,
+    tax_percent TEXT NOT NULL,
+    reinvestment_percent TEXT NOT NULL,
+    minimum_threshold TEXT NOT NULL,
+    configuration_password_hash TEXT NOT NULL
+);
+
+INSERT INTO distribution_rules_tmp (
+    id,
+    created_at,
+    updated_at,
+    account_id,
+    earnings_percent,
+    tax_percent,
+    reinvestment_percent,
+    minimum_threshold,
+    configuration_password_hash
+)
+SELECT
+    id,
+    created_at,
+    updated_at,
+    account_id,
+    earnings_percent,
+    tax_percent,
+    reinvestment_percent,
+    minimum_threshold,
+    configuration_password_hash
+FROM distribution_rules;
+
+DROP TABLE distribution_rules;
+ALTER TABLE distribution_rules_tmp RENAME TO distribution_rules;
+
+CREATE INDEX idx_distribution_rules_account_id ON distribution_rules(account_id);
+CREATE UNIQUE INDEX idx_distribution_rules_account_id_unique ON distribution_rules(account_id);
+
+DROP INDEX IF EXISTS idx_distribution_history_date;
+DROP INDEX IF EXISTS idx_distribution_history_trade;
+DROP INDEX IF EXISTS idx_distribution_history_source_account;
+
+CREATE TABLE distribution_history_tmp (
+    id TEXT NOT NULL PRIMARY KEY,
+    created_at DATETIME NOT NULL,
+    updated_at DATETIME NOT NULL,
+    source_account_id TEXT NOT NULL REFERENCES accounts(id),
+    trade_id TEXT REFERENCES trades(id),
+    original_amount TEXT NOT NULL,
+    distribution_date DATETIME NOT NULL,
+    earnings_amount TEXT,
+    tax_amount TEXT,
+    reinvestment_amount TEXT
+);
+
+INSERT INTO distribution_history_tmp (
+    id,
+    created_at,
+    updated_at,
+    source_account_id,
+    trade_id,
+    original_amount,
+    distribution_date,
+    earnings_amount,
+    tax_amount,
+    reinvestment_amount
+)
+SELECT
+    id,
+    created_at,
+    updated_at,
+    source_account_id,
+    trade_id,
+    original_amount,
+    distribution_date,
+    earnings_amount,
+    tax_amount,
+    reinvestment_amount
+FROM distribution_history;
+
+DROP TABLE distribution_history;
+ALTER TABLE distribution_history_tmp RENAME TO distribution_history;
+
+CREATE INDEX idx_distribution_history_source_account ON distribution_history(source_account_id);
+CREATE INDEX idx_distribution_history_trade ON distribution_history(trade_id);
+CREATE INDEX idx_distribution_history_date ON distribution_history(distribution_date);

--- a/db-sqlite/migrations/2026-05-11-150000_add_insurance_distribution/up.sql
+++ b/db-sqlite/migrations/2026-05-11-150000_add_insurance_distribution/up.sql
@@ -1,0 +1,5 @@
+ALTER TABLE distribution_rules
+ADD COLUMN insurance_percent TEXT NOT NULL DEFAULT '0';
+
+ALTER TABLE distribution_history
+ADD COLUMN insurance_amount TEXT;

--- a/db-sqlite/src/database.rs
+++ b/db-sqlite/src/database.rs
@@ -1248,6 +1248,7 @@ mod tests {
             .expect("distribution history should read");
 
         assert_eq!(read_rules.id, rules.id);
+        assert_eq!(read_rules.insurance_percent, Decimal::ZERO);
         assert!(read_history.iter().any(|entry| entry.id == history.id));
     }
 

--- a/db-sqlite/src/schema.rs
+++ b/db-sqlite/src/schema.rs
@@ -58,6 +58,7 @@ diesel::table! {
         earnings_amount -> Nullable<Text>,
         tax_amount -> Nullable<Text>,
         reinvestment_amount -> Nullable<Text>,
+        insurance_amount -> Nullable<Text>,
     }
 }
 
@@ -72,6 +73,7 @@ diesel::table! {
         reinvestment_percent -> Text,
         minimum_threshold -> Text,
         configuration_password_hash -> Text,
+        insurance_percent -> Text,
     }
 }
 

--- a/db-sqlite/src/workers/accounts.rs
+++ b/db-sqlite/src/workers/accounts.rs
@@ -374,6 +374,7 @@ impl TryFrom<AccountSQLite> for Account {
             "earnings" => AccountType::Earnings,
             "tax_reserve" => AccountType::TaxReserve,
             "reinvestment" => AccountType::Reinvestment,
+            "insurance" => AccountType::Insurance,
             _ => {
                 return Err(ConversionError::new(
                     "account_type",

--- a/db-sqlite/src/workers/worker_distribution.rs
+++ b/db-sqlite/src/workers/worker_distribution.rs
@@ -87,6 +87,27 @@ impl DistributionWrite for DistributionDB {
         minimum_threshold: Decimal,
         configuration_password_hash: &str,
     ) -> Result<DistributionRules, Box<dyn Error>> {
+        self.create_or_update_with_insurance(
+            account_id,
+            earnings_percent,
+            tax_percent,
+            reinvestment_percent,
+            Decimal::ZERO,
+            minimum_threshold,
+            configuration_password_hash,
+        )
+    }
+
+    fn create_or_update_with_insurance(
+        &mut self,
+        account_id: Uuid,
+        earnings_percent: Decimal,
+        tax_percent: Decimal,
+        reinvestment_percent: Decimal,
+        insurance_percent: Decimal,
+        minimum_threshold: Decimal,
+        configuration_password_hash: &str,
+    ) -> Result<DistributionRules, Box<dyn Error>> {
         let uuid = Uuid::new_v4().to_string();
         let now = Utc::now().naive_utc();
 
@@ -98,6 +119,7 @@ impl DistributionWrite for DistributionDB {
             earnings_percent: earnings_percent.to_string(),
             tax_percent: tax_percent.to_string(),
             reinvestment_percent: reinvestment_percent.to_string(),
+            insurance_percent: insurance_percent.to_string(),
             minimum_threshold: minimum_threshold.to_string(),
             configuration_password_hash: configuration_password_hash.to_string(),
         };
@@ -123,6 +145,7 @@ impl DistributionWrite for DistributionDB {
                 distribution_rules::earnings_percent.eq(&new_rules.earnings_percent),
                 distribution_rules::tax_percent.eq(&new_rules.tax_percent),
                 distribution_rules::reinvestment_percent.eq(&new_rules.reinvestment_percent),
+                distribution_rules::insurance_percent.eq(&new_rules.insurance_percent),
                 distribution_rules::minimum_threshold.eq(&new_rules.minimum_threshold),
                 distribution_rules::configuration_password_hash
                     .eq(&new_rules.configuration_password_hash),
@@ -156,6 +179,29 @@ impl DistributionWrite for DistributionDB {
         tax_amount: Option<Decimal>,
         reinvestment_amount: Option<Decimal>,
     ) -> Result<DistributionHistory, Box<dyn Error>> {
+        self.create_history_with_insurance(
+            source_account_id,
+            trade_id,
+            original_amount,
+            distribution_date,
+            earnings_amount,
+            tax_amount,
+            reinvestment_amount,
+            None,
+        )
+    }
+
+    fn create_history_with_insurance(
+        &mut self,
+        source_account_id: Uuid,
+        trade_id: Option<Uuid>,
+        original_amount: Decimal,
+        distribution_date: NaiveDateTime,
+        earnings_amount: Option<Decimal>,
+        tax_amount: Option<Decimal>,
+        reinvestment_amount: Option<Decimal>,
+        insurance_amount: Option<Decimal>,
+    ) -> Result<DistributionHistory, Box<dyn Error>> {
         let mut guard = self.connection_guard()?;
         let connection: &mut SqliteConnection = &mut guard;
 
@@ -171,6 +217,7 @@ impl DistributionWrite for DistributionDB {
             earnings_amount: earnings_amount.map(|amount| amount.to_string()),
             tax_amount: tax_amount.map(|amount| amount.to_string()),
             reinvestment_amount: reinvestment_amount.map(|amount| amount.to_string()),
+            insurance_amount: insurance_amount.map(|amount| amount.to_string()),
         };
 
         diesel::insert_into(distribution_history::table)
@@ -242,6 +289,7 @@ impl DistributionWrite for DistributionDB {
                 earnings_amount: plan.earnings_amount.map(|amount| amount.to_string()),
                 tax_amount: plan.tax_amount.map(|amount| amount.to_string()),
                 reinvestment_amount: plan.reinvestment_amount.map(|amount| amount.to_string()),
+                insurance_amount: plan.insurance_amount.map(|amount| amount.to_string()),
             };
 
             diesel::insert_into(distribution_history::table)
@@ -271,6 +319,7 @@ pub struct DistributionRulesSQLite {
     pub reinvestment_percent: String,
     pub minimum_threshold: String,
     pub configuration_password_hash: String,
+    pub insurance_percent: String,
 }
 
 impl TryFrom<DistributionRulesSQLite> for DistributionRules {
@@ -300,6 +349,9 @@ impl TryFrom<DistributionRulesSQLite> for DistributionRules {
                 ConversionError::new("minimum_threshold", "Failed to parse minimum threshold")
             })?,
             configuration_password_hash: value.configuration_password_hash,
+            insurance_percent: Decimal::from_str(&value.insurance_percent).map_err(|_| {
+                ConversionError::new("insurance_percent", "Failed to parse insurance percentage")
+            })?,
         })
     }
 }
@@ -323,6 +375,7 @@ struct NewDistributionRules {
     reinvestment_percent: String,
     minimum_threshold: String,
     configuration_password_hash: String,
+    insurance_percent: String,
 }
 
 #[derive(Debug, Queryable, Identifiable, AsChangeset, Insertable)]
@@ -340,6 +393,7 @@ pub struct DistributionHistorySQLite {
     pub earnings_amount: Option<String>,
     pub tax_amount: Option<String>,
     pub reinvestment_amount: Option<String>,
+    pub insurance_amount: Option<String>,
 }
 
 impl TryFrom<DistributionHistorySQLite> for DistributionHistory {
@@ -387,6 +441,14 @@ impl TryFrom<DistributionHistorySQLite> for DistributionHistory {
                         "Failed to parse reinvestment amount",
                     )
                 })?,
+            insurance_amount: value
+                .insurance_amount
+                .as_deref()
+                .map(Decimal::from_str)
+                .transpose()
+                .map_err(|_| {
+                    ConversionError::new("insurance_amount", "Failed to parse insurance amount")
+                })?,
             created_at: value.created_at,
             updated_at: value.updated_at,
         })
@@ -413,6 +475,7 @@ struct NewDistributionHistory {
     earnings_amount: Option<String>,
     tax_amount: Option<String>,
     reinvestment_amount: Option<String>,
+    insurance_amount: Option<String>,
 }
 
 #[cfg(test)]
@@ -514,6 +577,7 @@ mod tests {
             earnings_amount: Some(amount),
             tax_amount: None,
             reinvestment_amount: None,
+            insurance_amount: None,
         }
     }
 
@@ -652,6 +716,7 @@ mod tests {
             earnings_percent: dec!(0.40).to_string(),
             tax_percent: dec!(0.30).to_string(),
             reinvestment_percent: dec!(0.30).to_string(),
+            insurance_percent: Decimal::ZERO.to_string(),
             minimum_threshold: dec!(100).to_string(),
             configuration_password_hash: "hash".to_string(),
         }
@@ -675,6 +740,7 @@ mod tests {
             earnings_amount: Some(dec!(400).to_string()),
             tax_amount: Some(dec!(300).to_string()),
             reinvestment_amount: Some(dec!(300).to_string()),
+            insurance_amount: None,
         }
     }
 
@@ -1064,6 +1130,7 @@ mod tests {
             earnings_amount: Some(dec!(40)),
             tax_amount: Some(dec!(30)),
             reinvestment_amount: Some(dec!(30)),
+            insurance_amount: None,
         };
 
         let deposit_ids = database
@@ -1127,6 +1194,7 @@ mod tests {
         assert_eq!(history.earnings_amount, Some(dec!(40)));
         assert_eq!(history.tax_amount, Some(dec!(30)));
         assert_eq!(history.reinvestment_amount, Some(dec!(30)));
+        assert_eq!(history.insurance_amount, None);
     }
 
     #[test]
@@ -1169,6 +1237,10 @@ mod tests {
         assert_rules_conversion_error(row, "reinvestment_percent");
 
         let mut row = rules_row();
+        row.insurance_percent = "not-decimal".to_string();
+        assert_rules_conversion_error(row, "insurance_percent");
+
+        let mut row = rules_row();
         row.minimum_threshold = "not-decimal".to_string();
         assert_rules_conversion_error(row, "minimum_threshold");
     }
@@ -1202,5 +1274,9 @@ mod tests {
         let mut row = history_row();
         row.reinvestment_amount = Some("not-decimal".to_string());
         assert_history_conversion_error(row, "reinvestment_amount");
+
+        let mut row = history_row();
+        row.insurance_amount = Some("not-decimal".to_string());
+        assert_history_conversion_error(row, "insurance_amount");
     }
 }

--- a/db-sqlite/tests/test_distribution_atomicity.rs
+++ b/db-sqlite/tests/test_distribution_atomicity.rs
@@ -87,6 +87,7 @@ fn test_execute_distribution_plan_atomic_rolls_back_on_midway_failure() {
         earnings_amount: Some(dec!(400)),
         tax_amount: Some(dec!(600)),
         reinvestment_amount: None,
+        insurance_amount: None,
     };
 
     let err = db
@@ -156,6 +157,7 @@ fn test_execute_distribution_plan_atomic_happy_path_writes_transfers_and_history
         earnings_amount: Some(dec!(400)),
         tax_amount: Some(dec!(600)),
         reinvestment_amount: None,
+        insurance_amount: None,
     };
 
     let deposit_ids = db

--- a/model/src/account.rs
+++ b/model/src/account.rs
@@ -17,6 +17,8 @@ pub enum AccountType {
     TaxReserve,
     /// Additional trading capital
     Reinvestment,
+    /// Safety-net reserve funded from trade profits
+    Insurance,
 }
 
 /// Error type for account hierarchy validation failures
@@ -233,6 +235,7 @@ impl Display for AccountType {
             AccountType::Earnings => write!(f, "earnings"),
             AccountType::TaxReserve => write!(f, "tax_reserve"),
             AccountType::Reinvestment => write!(f, "reinvestment"),
+            AccountType::Insurance => write!(f, "insurance"),
         }
     }
 }
@@ -308,6 +311,14 @@ mod tests {
     fn test_account_type_reinvestment() {
         let account_type = AccountType::Reinvestment;
         assert_eq!(account_type.to_string(), "reinvestment");
+        assert!(!account_type.can_have_children());
+        assert!(account_type.requires_parent());
+    }
+
+    #[test]
+    fn test_account_type_insurance() {
+        let account_type = AccountType::Insurance;
+        assert_eq!(account_type.to_string(), "insurance");
         assert!(!account_type.can_have_children());
         assert!(account_type.requires_parent());
     }

--- a/model/src/database.rs
+++ b/model/src/database.rs
@@ -759,7 +759,44 @@ pub trait DistributionWrite {
         reinvestment_percent: Decimal,
         minimum_threshold: Decimal,
         configuration_password_hash: &str,
-    ) -> Result<DistributionRules, Box<dyn Error>>;
+    ) -> Result<DistributionRules, Box<dyn Error>> {
+        self.create_or_update_with_insurance(
+            account_id,
+            earnings_percent,
+            tax_percent,
+            reinvestment_percent,
+            Decimal::ZERO,
+            minimum_threshold,
+            configuration_password_hash,
+        )
+    }
+
+    /// Creates or updates distribution rules for an account, including insurance allocation.
+    #[allow(clippy::too_many_arguments)]
+    fn create_or_update_with_insurance(
+        &mut self,
+        account_id: Uuid,
+        earnings_percent: Decimal,
+        tax_percent: Decimal,
+        reinvestment_percent: Decimal,
+        insurance_percent: Decimal,
+        minimum_threshold: Decimal,
+        configuration_password_hash: &str,
+    ) -> Result<DistributionRules, Box<dyn Error>> {
+        if insurance_percent != Decimal::ZERO {
+            return Err(
+                "insurance distribution is not supported by this database implementation".into(),
+            );
+        }
+        self.create_or_update(
+            account_id,
+            earnings_percent,
+            tax_percent,
+            reinvestment_percent,
+            minimum_threshold,
+            configuration_password_hash,
+        )
+    }
 
     /// Persists an execution event for distribution audit/history.
     #[allow(clippy::too_many_arguments)]
@@ -772,7 +809,48 @@ pub trait DistributionWrite {
         earnings_amount: Option<Decimal>,
         tax_amount: Option<Decimal>,
         reinvestment_amount: Option<Decimal>,
-    ) -> Result<DistributionHistory, Box<dyn Error>>;
+    ) -> Result<DistributionHistory, Box<dyn Error>> {
+        self.create_history_with_insurance(
+            source_account_id,
+            trade_id,
+            original_amount,
+            distribution_date,
+            earnings_amount,
+            tax_amount,
+            reinvestment_amount,
+            None,
+        )
+    }
+
+    /// Persists an execution event for distribution audit/history, including insurance.
+    #[allow(clippy::too_many_arguments)]
+    fn create_history_with_insurance(
+        &mut self,
+        source_account_id: Uuid,
+        trade_id: Option<Uuid>,
+        original_amount: Decimal,
+        distribution_date: chrono::NaiveDateTime,
+        earnings_amount: Option<Decimal>,
+        tax_amount: Option<Decimal>,
+        reinvestment_amount: Option<Decimal>,
+        insurance_amount: Option<Decimal>,
+    ) -> Result<DistributionHistory, Box<dyn Error>> {
+        if insurance_amount.is_some() {
+            return Err(
+                "insurance distribution history is not supported by this database implementation"
+                    .into(),
+            );
+        }
+        self.create_history(
+            source_account_id,
+            trade_id,
+            original_amount,
+            distribution_date,
+            earnings_amount,
+            tax_amount,
+            reinvestment_amount,
+        )
+    }
 
     /// Executes all distribution transfers and writes a history row atomically.
     ///

--- a/model/src/distribution.rs
+++ b/model/src/distribution.rs
@@ -16,6 +16,8 @@ pub struct DistributionRules {
     pub tax_percent: Decimal,
     /// Percentage for reinvestment allocation (0-1)  
     pub reinvestment_percent: Decimal,
+    /// Percentage for insurance reserve allocation (0-1)
+    pub insurance_percent: Decimal,
     /// Minimum profit threshold for distribution
     pub minimum_threshold: Decimal,
     /// Hash used to protect rule updates
@@ -39,6 +41,8 @@ pub struct DistributionResult {
     pub tax_amount: Option<Decimal>,
     /// Amount allocated to reinvestment (optional if percentage is 0)
     pub reinvestment_amount: Option<Decimal>,
+    /// Amount allocated to insurance reserve (optional if percentage is 0)
+    pub insurance_amount: Option<Decimal>,
     /// Timestamp when distribution was executed
     pub distribution_date: NaiveDateTime,
     /// Transaction IDs created for this distribution
@@ -64,6 +68,8 @@ pub struct DistributionHistory {
     pub tax_amount: Option<Decimal>,
     /// Distributed reinvestment amount
     pub reinvestment_amount: Option<Decimal>,
+    /// Distributed insurance reserve amount
+    pub insurance_amount: Option<Decimal>,
     /// Row creation timestamp
     pub created_at: NaiveDateTime,
     /// Row update timestamp
@@ -108,6 +114,8 @@ pub struct DistributionExecutionPlan {
     pub tax_amount: Option<Decimal>,
     /// Amounts written to history (for audit/reporting).
     pub reinvestment_amount: Option<Decimal>,
+    /// Amounts written to history (for audit/reporting).
+    pub insurance_amount: Option<Decimal>,
 }
 
 /// Error types for distribution operations
@@ -168,6 +176,7 @@ impl DistributionRules {
         earnings_percent: Decimal,
         tax_percent: Decimal,
         reinvestment_percent: Decimal,
+        insurance_percent: Decimal,
         minimum_threshold: Decimal,
     ) -> Self {
         let now = Utc::now().naive_utc();
@@ -177,6 +186,7 @@ impl DistributionRules {
             earnings_percent,
             tax_percent,
             reinvestment_percent,
+            insurance_percent,
             minimum_threshold,
             configuration_password_hash: String::new(),
             created_at: now,
@@ -198,6 +208,7 @@ impl DistributionRules {
             Decimal::new(30, 2),  // 30%
             Decimal::new(25, 2),  // 25%
             Decimal::new(45, 2),  // 45%
+            Decimal::ZERO,        // 0%
             Decimal::new(500, 0), // $500 minimum
         )
     }
@@ -208,6 +219,7 @@ impl DistributionRules {
         if self.earnings_percent < Decimal::ZERO
             || self.tax_percent < Decimal::ZERO
             || self.reinvestment_percent < Decimal::ZERO
+            || self.insurance_percent < Decimal::ZERO
         {
             return Err(DistributionError::InvalidPercentage);
         }
@@ -216,6 +228,7 @@ impl DistributionRules {
         if self.earnings_percent > Decimal::ONE
             || self.tax_percent > Decimal::ONE
             || self.reinvestment_percent > Decimal::ONE
+            || self.insurance_percent > Decimal::ONE
         {
             return Err(DistributionError::InvalidPercentage);
         }
@@ -225,6 +238,7 @@ impl DistributionRules {
             .earnings_percent
             .checked_add(self.tax_percent)
             .and_then(|sum| sum.checked_add(self.reinvestment_percent))
+            .and_then(|sum| sum.checked_add(self.insurance_percent))
             .ok_or(DistributionError::InvalidPercentageSum)?;
         if total != Decimal::ONE {
             return Err(DistributionError::InvalidPercentageSum);
@@ -258,6 +272,9 @@ impl DistributionRules {
         let reinvestment_amount = profit
             .checked_mul(self.reinvestment_percent)
             .ok_or(DistributionError::InvalidPercentage)?;
+        let insurance_amount = profit
+            .checked_mul(self.insurance_percent)
+            .ok_or(DistributionError::InvalidPercentage)?;
 
         Ok(DistributionResult {
             source_account_id: self.account_id,
@@ -274,6 +291,11 @@ impl DistributionRules {
             },
             reinvestment_amount: if reinvestment_amount > Decimal::ZERO {
                 Some(reinvestment_amount)
+            } else {
+                None
+            },
+            insurance_amount: if insurance_amount > Decimal::ZERO {
+                Some(insurance_amount)
             } else {
                 None
             },
@@ -294,6 +316,7 @@ mod tests {
             Decimal::new(30, 2),  // 0.30
             Decimal::new(25, 2),  // 0.25
             Decimal::new(45, 2),  // 0.45
+            Decimal::ZERO,        // 0.00
             Decimal::new(500, 0), // $500 minimum
         );
 
@@ -307,6 +330,7 @@ mod tests {
             Decimal::new(30, 2), // 0.30
             Decimal::new(25, 2), // 0.25
             Decimal::new(50, 2), // 0.50 - sums to 105%
+            Decimal::ZERO,
             Decimal::new(500, 0),
         );
 
@@ -323,6 +347,7 @@ mod tests {
             Decimal::new(-10, 2), // -0.10 (negative)
             Decimal::new(55, 2),  // 0.55
             Decimal::new(45, 2),  // 0.45
+            Decimal::ZERO,
             Decimal::new(500, 0),
         );
 
@@ -336,6 +361,7 @@ mod tests {
             Decimal::new(150, 2), // 1.50 (150%)
             Decimal::new(25, 2),  // 0.25
             Decimal::new(25, 2),  // 0.25
+            Decimal::ZERO,
             Decimal::new(500, 0),
         );
 
@@ -349,6 +375,7 @@ mod tests {
             Decimal::new(30, 2),  // 0.30
             Decimal::new(25, 2),  // 0.25
             Decimal::new(45, 2),  // 0.45
+            Decimal::ZERO,        // 0.00
             Decimal::new(500, 0), // $500 minimum
         );
 
@@ -362,7 +389,29 @@ mod tests {
         assert_eq!(distribution.earnings_amount, Some(Decimal::new(600, 0))); // 30% of $2000
         assert_eq!(distribution.tax_amount, Some(Decimal::new(500, 0))); // 25% of $2000
         assert_eq!(distribution.reinvestment_amount, Some(Decimal::new(900, 0)));
+        assert_eq!(distribution.insurance_amount, None);
         // 45% of $2000
+    }
+
+    #[test]
+    fn test_calculate_distribution_with_insurance_allocation() {
+        let rules = DistributionRules::new(
+            Uuid::new_v4(),
+            Decimal::new(30, 2),
+            Decimal::new(25, 2),
+            Decimal::new(35, 2),
+            Decimal::new(10, 2),
+            Decimal::new(500, 0),
+        );
+
+        let distribution = rules
+            .calculate_distribution(Decimal::new(2000, 0))
+            .expect("insurance allocation should calculate");
+
+        assert_eq!(distribution.earnings_amount, Some(Decimal::new(600, 0)));
+        assert_eq!(distribution.tax_amount, Some(Decimal::new(500, 0)));
+        assert_eq!(distribution.reinvestment_amount, Some(Decimal::new(700, 0)));
+        assert_eq!(distribution.insurance_amount, Some(Decimal::new(200, 0)));
     }
 
     #[test]
@@ -373,6 +422,7 @@ mod tests {
             Decimal::ZERO,
             Decimal::new(25, 2),
             Decimal::new(75, 2),
+            Decimal::ZERO,
             Decimal::new(500, 0),
         );
 
@@ -387,6 +437,7 @@ mod tests {
                     distribution.earnings_amount,
                     distribution.tax_amount,
                     distribution.reinvestment_amount,
+                    distribution.insurance_amount,
                     distribution.transactions_created.is_empty(),
                 )
             });
@@ -399,6 +450,7 @@ mod tests {
                 None,
                 Some(Decimal::new(500, 0)),
                 Some(Decimal::new(1500, 0)),
+                None,
                 true,
             ))
         );
@@ -411,6 +463,7 @@ mod tests {
             Decimal::new(30, 2),
             Decimal::new(25, 2),
             Decimal::new(45, 2),
+            Decimal::ZERO,
             Decimal::new(500, 0), // $500 minimum
         );
 
@@ -427,6 +480,7 @@ mod tests {
             Decimal::new(30, 2),
             Decimal::new(25, 2),
             Decimal::new(45, 2),
+            Decimal::ZERO,
             Decimal::new(500, 0),
         );
 
@@ -443,6 +497,7 @@ mod tests {
             Decimal::new(30, 2),
             Decimal::new(25, 2),
             Decimal::new(45, 2),
+            Decimal::ZERO,
             Decimal::new(500, 0),
         );
 
@@ -462,7 +517,10 @@ mod tests {
         assert_eq!(rules.account_id, account_id);
 
         // Default percentages should sum to 100%
-        let total = rules.earnings_percent + rules.tax_percent + rules.reinvestment_percent;
+        let total = rules.earnings_percent
+            + rules.tax_percent
+            + rules.reinvestment_percent
+            + rules.insurance_percent;
         assert_eq!(total, Decimal::ONE);
     }
 


### PR DESCRIPTION
## Summary
- add insurance as a distribution target with model and SQLite persistence support
- allocate configured profit percentages into an insurance child account during distribution execution
- expose insurance configuration, history, and reserve status through the CLI

Closes #100

## Verification
- cargo clippy --workspace --all-targets --all-features -- -D warnings
- cargo test --locked --all-features --workspace
- cargo test --locked --no-default-features --workspace
- cargo fmt --all -- --check
- git diff --check