### PR TITLE
fix(ci): grant security audit check permissions

### DIFF
--- a/.github/workflows/rust.yaml
+++ b/.github/workflows/rust.yaml
@@ -11,6 +11,10 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+  checks: write
+
 env:
   CARGO_TERM_COLOR: always
   RUST_BACKTRACE: 1


### PR DESCRIPTION
## Summary
- grant the Rust CI workflow read-only contents access and check-run write access
- keep the permission scope minimal for the rustsec audit action

Closes #152

## Verification
- ruby -e "require 'yaml'; YAML.load_file('.github/workflows/rust.yaml'); puts 'yaml ok'"